### PR TITLE
Fix compilation

### DIFF
--- a/include/flox/aggregator/candle_aggregator_component.h
+++ b/include/flox/aggregator/candle_aggregator_component.h
@@ -64,9 +64,8 @@ struct CandleAggregatorTrait
     requires concepts::CandleAggregator<T>
   static constexpr VTable makeVTable()
   {
-    static constexpr auto mds = MarketDataSubscriberTrait::makeVTable<T>();
-    static constexpr auto ss = SubsystemTrait::makeVTable<T>();
-
+    static auto mds = MarketDataSubscriberTrait::makeVTable<T>();
+    static auto ss = SubsystemTrait::makeVTable<T>();
     return {
         .mds = &mds,
         .subsystem = &ss,

--- a/include/flox/engine/market_data_subscriber_component.h
+++ b/include/flox/engine/market_data_subscriber_component.h
@@ -13,7 +13,6 @@
 
 #include "flox/engine/subscriber_component.h"
 #include "flox/util/base/ref.h"
-#include "flox/util/meta/meta.h"
 
 namespace flox
 {
@@ -63,7 +62,7 @@ struct MarketDataSubscriberTrait
     requires concepts::MarketDataSubscriber<T>
   static constexpr VTable makeVTable()
   {
-    static constexpr auto sub = SubscriberTrait::makeVTable<T>();
+    static auto sub = SubscriberTrait::makeVTable<T>();
     return {
         .subscriber = &sub,
         .onBookUpdate = meta::wrap<&T::onBookUpdate>(),

--- a/include/flox/execution/order_execution_listener_component.h
+++ b/include/flox/execution/order_execution_listener_component.h
@@ -76,8 +76,8 @@ struct OrderExecutionListenerTrait
     requires concepts::OrderExecutionListener<T>
   static constexpr VTable makeVTable()
   {
-    static constexpr auto sub = SubscriberTrait::makeVTable<T>();
-    static constexpr auto sys = SubsystemTrait::makeVTable<T>();
+    static auto sub = SubscriberTrait::makeVTable<T>();
+    static auto sys = SubsystemTrait::makeVTable<T>();
 
     return {
         .subscriber = &sub,

--- a/include/flox/position/position_manager_component.h
+++ b/include/flox/position/position_manager_component.h
@@ -58,7 +58,7 @@ struct PositionManagerTrait
     requires concepts::PositionManager<T>
   static constexpr VTable makeVTable()
   {
-    static constexpr auto oel = OrderExecutionListenerTrait::makeVTable<T>();
+    static auto oel = OrderExecutionListenerTrait::makeVTable<T>();
     return {
         .oel = &oel,
         .getPosition = meta::wrap<&T::getPosition>(),

--- a/include/flox/strategy/strategy_component.h
+++ b/include/flox/strategy/strategy_component.h
@@ -52,8 +52,8 @@ struct StrategyTrait
     requires concepts::Strategy<T>
   static constexpr VTable makeVTable()
   {
-    static constexpr auto subsystem = SubsystemTrait::makeVTable<T>();
-    static constexpr auto mds = MarketDataSubscriberTrait::makeVTable<T>();
+    static auto subsystem = SubsystemTrait::makeVTable<T>();
+    static auto mds = MarketDataSubscriberTrait::makeVTable<T>();
     return {
         .subsystem = &subsystem,
         .mds = &mds,


### PR DESCRIPTION
In my system this repository does not compile:

```
❯ make -j$(nproc)
[  1%] Building CXX object CMakeFiles/flox.dir/src/engine/engine.cpp.o
[  3%] Building CXX object CMakeFiles/flox.dir/src/aggregator/candle_aggregator.cpp.o
[  5%] Building CXX object CMakeFiles/flox_sync.dir/src/aggregator/candle_aggregator.cpp.o
[  6%] Building CXX object CMakeFiles/flox_sync.dir/src/engine/engine.cpp.o
[  8%] Linking CXX static library libflox_sync.a
[ 10%] Built target flox_sync
[ 13%] Building CXX object tests/CMakeFiles/test_sync_order_execution_bus.dir/test_sync_order_execution_bus.cpp.o
[ 13%] Building CXX object tests/CMakeFiles/test_sync_market_data_bus.dir/test_sync_market_data_bus.cpp.o
[ 15%] Building CXX object tests/CMakeFiles/test_sync_candle_aggregator.dir/test_sync_candle_aggregator.cpp.o
[ 16%] Linking CXX static library libflox.a
[ 18%] Built target flox
[ 20%] Building CXX object benchmarks/CMakeFiles/nlevel_order_book_benchmark.dir/nlevel_order_book_benchmark.cpp.o
[ 22%] Building CXX object benchmarks/CMakeFiles/candle_aggregator_benchmark.dir/candle_aggregator_benchmark.cpp.o
[ 23%] Building CXX object tests/CMakeFiles/test_candle_aggregator.dir/test_candle_aggregator.cpp.o
[ 25%] Building CXX object tests/CMakeFiles/test_market_data_bus.dir/test_market_data_bus.cpp.o
[ 27%] Linking CXX executable test_symbol_registry
[ 28%] Built target test_symbol_registry
[ 30%] Building CXX object tests/CMakeFiles/test_connection_factory.dir/test_connection_factory.cpp.o
In file included from /home/ggomes/Documents/flox/tests/test_sync_candle_aggregator.cpp:17:
/home/ggomes/Documents/flox/include/flox/strategy/strategy_component.h: In instantiation of ‘static constexpr flox::traits::StrategyTrait::VTable flox::traits::StrategyTrait::makeVTable() [with T = {anonymous}::TestStrategy]’:
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:81:63:   required from ‘static DerivedT flox::RefBase<DerivedT, TraitT>::from(Impl*) [with Impl = {anonymous}::TestStrategy; DerivedT = flox::StrategyRef; TraitT = flox::traits::StrategyTrai
t]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:109:25:   required from ‘static RefType flox::PoolAllocator<Trait, N>::create(Args&& ...) [with RefType = flox::StrategyRef; ImplType = {anonymous}::TestStrategy; Args = {std::vector<flox::C
andle, std::allocator<flox::Candle> >&}; Trait = flox::traits::StrategyTrait; long unsigned int N = 8]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:98:44:   required from ‘auto flox::make(Args&& ...) [with T = {anonymous}::TestStrategy; Args = {std::vector<Candle, std::allocator<Candle> >&}]’
/home/ggomes/Documents/flox/tests/test_sync_candle_aggregator.cpp:87:34:   required from here
/home/ggomes/Documents/flox/include/flox/strategy/strategy_component.h:56:73: error: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = {anonymous}::TestStrategy]’ call
ed in a constant expression
   56 |     static constexpr auto mds = MarketDataSubscriberTrait::makeVTable<T>();
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/ggomes/Documents/flox/include/flox/aggregator/events/candle_event.h:14,
                 from /home/ggomes/Documents/flox/include/flox/aggregator/bus/candle_bus.h:12,
                 from /home/ggomes/Documents/flox/tests/test_sync_candle_aggregator.cpp:10:
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:64:27: note: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = {anonymous}::TestStra
tegy]’ is not usable as a ‘constexpr’ function because:
   64 |   static constexpr VTable makeVTable()
      |                           ^~~~~~~~~~
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:66:27: error: ‘sub’ defined ‘static’ in ‘constexpr’ context
   66 |     static constexpr auto sub = SubscriberTrait::makeVTable<T>();
      |                           ^~~
In file included from /home/ggomes/Documents/flox/include/flox/aggregator/candle_aggregator.h:13,
                 from /home/ggomes/Documents/flox/tests/test_sync_candle_aggregator.cpp:11:
/home/ggomes/Documents/flox/include/flox/aggregator/candle_aggregator_component.h: In instantiation of ‘static constexpr flox::traits::CandleAggregatorTrait::VTable flox::traits::CandleAggregatorTrait::makeVTable() [with T = flox::CandleAggregator
]’:
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:81:63:   required from ‘static DerivedT flox::RefBase<DerivedT, TraitT>::from(Impl*) [with Impl = flox::CandleAggregator; DerivedT = flox::CandleAggregatorRef; TraitT = flox::traits::CandleA
ggregatorTrait]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:109:25:   required from ‘static RefType flox::PoolAllocator<Trait, N>::create(Args&& ...) [with RefType = flox::CandleAggregatorRef; ImplType = flox::CandleAggregator; Args = {const std::chr
ono::duration<long int, std::ratio<1, 1> >&, flox::EventBusRef<flox::CandleEvent, flox::SPSCQueue<std::pair<flox::CandleEvent, flox::TickBarrier*>, 4096> >&}; Trait = flox::traits::CandleAggregatorTrait; long unsigned int N = 8]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:98:44:   required from ‘auto flox::make(Args&& ...) [with T = CandleAggregator; Args = {const std::chrono::duration<long int, std::ratio<1, 1> >&, EventBusRef<CandleEvent, SPSCQueue<std::pai
r<CandleEvent, TickBarrier*>, 4096> >&}]’
/home/ggomes/Documents/flox/tests/test_sync_candle_aggregator.cpp:89:43:   required from here
/home/ggomes/Documents/flox/include/flox/aggregator/candle_aggregator_component.h:67:73: error: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = flox::CandleAggregato
r]’ called in a constant expression
   67 |     static constexpr auto mds = MarketDataSubscriberTrait::makeVTable<T>();
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:64:27: note: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = flox::CandleAggregato
r]’ is not usable as a ‘constexpr’ function because:
   64 |   static constexpr VTable makeVTable()
      |                           ^~~~~~~~~~
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:66:27: error: ‘sub’ defined ‘static’ in ‘constexpr’ context
   66 |     static constexpr auto sub = SubscriberTrait::makeVTable<T>();
      |                           ^~~
make[2]: *** [tests/CMakeFiles/test_sync_candle_aggregator.dir/build.make:79: tests/CMakeFiles/test_sync_candle_aggregator.dir/test_sync_candle_aggregator.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:989: tests/CMakeFiles/test_sync_candle_aggregator.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 32%] Linking CXX executable test_sync_order_execution_bus
[ 32%] Built target test_sync_order_execution_bus
In file included from /home/ggomes/Documents/flox/include/flox/aggregator/candle_aggregator.h:13,
                 from /home/ggomes/Documents/flox/tests/test_candle_aggregator.cpp:11:
/home/ggomes/Documents/flox/include/flox/aggregator/candle_aggregator_component.h: In instantiation of ‘static constexpr flox::traits::CandleAggregatorTrait::VTable flox::traits::CandleAggregatorTrait::makeVTable() [with T = flox::CandleAggregator
]’:
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:81:63:   required from ‘static DerivedT flox::RefBase<DerivedT, TraitT>::from(Impl*) [with Impl = flox::CandleAggregator; DerivedT = flox::CandleAggregatorRef; TraitT = flox::traits::CandleA
ggregatorTrait]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:109:25:   required from ‘static RefType flox::PoolAllocator<Trait, N>::create(Args&& ...) [with RefType = flox::CandleAggregatorRef; ImplType = flox::CandleAggregator; Args = {const std::chr
ono::duration<long int, std::ratio<1, 1> >&, flox::EventBusRef<flox::CandleEvent, flox::SPSCQueue<flox::CandleEvent, 4096> >&}; Trait = flox::traits::CandleAggregatorTrait; long unsigned int N = 8]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:98:44:   required from ‘auto flox::make(Args&& ...) [with T = CandleAggregator; Args = {const std::chrono::duration<long int, std::ratio<1, 1> >&, EventBusRef<CandleEvent, SPSCQueue<CandleEv
ent, 4096> >&}]’
/home/ggomes/Documents/flox/tests/test_candle_aggregator.cpp:90:43:   required from here
/home/ggomes/Documents/flox/include/flox/aggregator/candle_aggregator_component.h:67:73: error: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = flox::CandleAggregato
r]’ called in a constant expression
   67 |     static constexpr auto mds = MarketDataSubscriberTrait::makeVTable<T>();
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /home/ggomes/Documents/flox/include/flox/aggregator/events/candle_event.h:14,
                 from /home/ggomes/Documents/flox/include/flox/aggregator/bus/candle_bus.h:12,
                 from /home/ggomes/Documents/flox/tests/test_candle_aggregator.cpp:10:
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:64:27: note: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = flox::CandleAggregato
r]’ is not usable as a ‘constexpr’ function because:
   64 |   static constexpr VTable makeVTable()
      |                           ^~~~~~~~~~
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:66:27: error: ‘sub’ defined ‘static’ in ‘constexpr’ context
   66 |     static constexpr auto sub = SubscriberTrait::makeVTable<T>();
      |                           ^~~
In file included from /home/ggomes/Documents/flox/tests/test_candle_aggregator.cpp:17:
/home/ggomes/Documents/flox/include/flox/strategy/strategy_component.h: In instantiation of ‘static constexpr flox::traits::StrategyTrait::VTable flox::traits::StrategyTrait::makeVTable() [with T = {anonymous}::TestStrategy]’:
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:81:63:   required from ‘static DerivedT flox::RefBase<DerivedT, TraitT>::from(Impl*) [with Impl = {anonymous}::TestStrategy; DerivedT = flox::StrategyRef; TraitT = flox::traits::StrategyTrai
t]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:109:25:   required from ‘static RefType flox::PoolAllocator<Trait, N>::create(Args&& ...) [with RefType = flox::StrategyRef; ImplType = {anonymous}::TestStrategy; Args = {int, std::vector<fl
ox::Candle, std::allocator<flox::Candle> >&}; Trait = flox::traits::StrategyTrait; long unsigned int N = 8]’
/home/ggomes/Documents/flox/include/flox/util/base/ref.h:98:44:   required from ‘auto flox::make(Args&& ...) [with T = {anonymous}::TestStrategy; Args = {int, std::vector<Candle, std::allocator<Candle> >&}]’
/home/ggomes/Documents/flox/tests/test_candle_aggregator.cpp:91:34:   required from here
/home/ggomes/Documents/flox/include/flox/strategy/strategy_component.h:56:73: error: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = {anonymous}::TestStrategy]’ call
ed in a constant expression
   56 |     static constexpr auto mds = MarketDataSubscriberTrait::makeVTable<T>();
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:64:27: note: ‘static constexpr flox::traits::MarketDataSubscriberTrait::VTable flox::traits::MarketDataSubscriberTrait::makeVTable() [with T = {anonymous}::TestStra
tegy]’ is not usable as a ‘constexpr’ function because:
   64 |   static constexpr VTable makeVTable()
      |                           ^~~~~~~~~~
/home/ggomes/Documents/flox/include/flox/engine/market_data_subscriber_component.h:66:27: error: ‘sub’ defined ‘static’ in ‘constexpr’ context
   66 |     static constexpr auto sub = SubscriberTrait::makeVTable<T>();
      |                           ^~~
[ 33%] Linking CXX executable test_sync_market_data_bus
[ 35%] Linking CXX executable nlevel_order_book_benchmark
make[2]: *** [tests/CMakeFiles/test_candle_aggregator.dir/build.make:79: tests/CMakeFiles/test_candle_aggregator.dir/test_candle_aggregator.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:381: tests/CMakeFiles/test_candle_aggregator.dir/all] Error 2
[ 35%] Built target test_sync_market_data_bus
[ 37%] Linking CXX executable candle_aggregator_benchmark
[ 37%] Built target nlevel_order_book_benchmark
[ 38%] Linking CXX executable test_market_data_bus
[ 40%] Linking CXX executable test_connection_factory
[ 40%] Built target candle_aggregator_benchmark
[ 40%] Built target test_connection_factory
[ 40%] Built target test_market_data_bus
make: *** [Makefile:146: all] Error 2
```

this commit fixes that by removing the `constexpr` keyword from the places where the error comes from.