### PR TITLE
NLevelOrderBook: add anchoring for consistent state

### DIFF
--- a/include/flox/book/nlevel_order_book.h
+++ b/include/flox/book/nlevel_order_book.h
@@ -12,10 +12,16 @@
 #include "flox/book/abstract_order_book.h"
 #include "flox/book/events/book_update_event.h"
 #include "flox/common.h"
+#include "flox/util/base/math.h"
 
 #include <array>
-#include <cstddef>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <limits>
 #include <optional>
+#include <type_traits>
 
 namespace flox
 {
@@ -26,143 +32,638 @@ class NLevelOrderBook : public IOrderBook
  public:
   static constexpr size_t MAX_LEVELS = MaxLevels;
 
-  explicit NLevelOrderBook(Price tickSize)
-      : _tickSize(tickSize),
-        _minBidIndex(MAX_LEVELS),
-        _maxBidIndex(0),
-        _minAskIndex(MAX_LEVELS),
-        _maxAskIndex(0)
+  explicit NLevelOrderBook(Price tickSize) noexcept
+      : _tickSize(tickSize)
   {
-    static_assert(MAX_LEVELS < std::numeric_limits<size_t>::max());
+    _tickSizeDiv = math::make_fastdiv64((uint64_t)_tickSize.raw(), 1);
+    clear();
   }
 
-  void applyBookUpdate(const BookUpdateEvent& event) override
+  [[nodiscard]] inline std::optional<size_t> bestAskIndex() const noexcept
   {
-    const auto& update = event.update;
-
-    if (update.type == BookUpdateType::SNAPSHOT)
+    if (_bestAskIdx < MAX_LEVELS)
     {
-      _bids.fill({});
-      _asks.fill({});
-      _minBidIndex = MAX_LEVELS;
-      _maxBidIndex = 0;
-      _minAskIndex = MAX_LEVELS;
-      _maxAskIndex = 0;
+      return _bestAskIdx;
     }
 
-    for (const auto& [price, qty] : update.bids)
-    {
-      const size_t i = priceToIndex(price);
-      if (i >= MAX_LEVELS)
-      {
-        continue;
-      }
-
-      _bids[i] = qty;
-      if (qty.isZero())
-      {
-        continue;
-      }
-
-      _minBidIndex = std::min(_minBidIndex, i);
-      _maxBidIndex = std::max(_maxBidIndex, i);
-    }
-
-    for (const auto& [price, qty] : update.asks)
-    {
-      const size_t i = priceToIndex(price);
-      if (i >= MAX_LEVELS)
-      {
-        continue;
-      }
-
-      _asks[i] = qty;
-      if (qty.isZero())
-      {
-        continue;
-      }
-
-      _minAskIndex = std::min(_minAskIndex, i);
-      _maxAskIndex = std::max(_maxAskIndex, i);
-    }
-  }
-
-  std::optional<Price> bestBid() const override
-  {
-    if (_minBidIndex >= MAX_LEVELS)
+    if (_minAsk >= MAX_LEVELS)
     {
       return std::nullopt;
     }
 
-    for (size_t i = _maxBidIndex + 1; i-- > _minBidIndex;)
-    {
-      if (!_bids[i].isZero())
-      {
-        return indexToPrice(i);
-      }
-    }
-    return std::nullopt;
-  }
-
-  std::optional<Price> bestAsk() const override
-  {
-    if (_minAskIndex >= MAX_LEVELS)
-    {
-      return std::nullopt;
-    }
-
-    for (size_t i = _minAskIndex; i <= _maxAskIndex && i < MAX_LEVELS; ++i)
+    for (size_t i = _minAsk; i <= _maxAsk && i < MAX_LEVELS; ++i)
     {
       if (!_asks[i].isZero())
       {
-        return indexToPrice(i);
+        return i;
       }
     }
     return std::nullopt;
   }
 
-  Quantity bidAtPrice(Price price) const override
+  [[nodiscard]] inline std::optional<size_t> bestBidIndex() const noexcept
   {
-    const size_t i = priceToIndex(price);
+    if (_bestBidIdx < MAX_LEVELS)
+    {
+      return _bestBidIdx;
+    }
+
+    if (_minBid >= MAX_LEVELS)
+    {
+      return std::nullopt;
+    }
+
+    for (size_t i = _maxBid + 1; i-- > _minBid;)
+    {
+      if (!_bids[i].isZero())
+      {
+        return i;
+      }
+
+      if (i == 0)
+      {
+        break;
+      }
+    }
+    return std::nullopt;
+  }
+
+  void dump(std::ostream& os, size_t levels,
+            int pricePrec = 4, int qtyPrec = 3, bool ansi = false) const
+  {
+    if (levels == 0)
+    {
+      return;
+    }
+
+    if (levels > 512)
+    {
+      levels = 512;
+    }
+
+    auto aBest = bestAsk();
+    auto bBest = bestBid();
+
+    const double ts = _tickSize.toDouble();
+    os.setf(std::ios::fixed);
+    os << "tick=" << std::setprecision(pricePrec) << ts
+       << "  baseIndex=" << _baseIndex;
+
+    if (aBest && bBest)
+    {
+      const double ba = aBest->toDouble(), bb = bBest->toDouble();
+      os << "  spread=" << std::setprecision(pricePrec) << (ba - bb)
+         << "  mid=" << std::setprecision(pricePrec) << ((ba + bb) * 0.5);
+    }
+    os << "\n";
+
+    struct Row
+    {
+      double px{0}, qty{0};
+      bool have{false};
+    };
+
+    std::array<Row, 512> asks{}, bids{};
+    size_t na = 0, nb = 0;
+
+    if (auto aIdxOpt = bestAskIndex())
+    {
+      for (size_t i = *aIdxOpt; i <= _maxAsk && i < MAX_LEVELS && na < levels; ++i)
+      {
+        if (_asks[i].isZero())
+        {
+          continue;
+        }
+
+        asks[na].have = true;
+        asks[na].px = indexToPrice(i).toDouble();
+        asks[na].qty = _asks[i].toDouble();
+        ++na;
+      }
+    }
+
+    if (auto bIdxOpt = bestBidIndex())
+    {
+      for (size_t i = *bIdxOpt + 1; i-- > _minBid && nb < levels;)
+      {
+        if (_bids[i].isZero())
+        {
+          if (i == 0)
+          {
+            break;
+          }
+          continue;
+        }
+
+        bids[nb].have = true;
+        bids[nb].px = indexToPrice(i).toDouble();
+        bids[nb].qty = _bids[i].toDouble();
+        ++nb;
+
+        if (i == 0)
+        {
+          break;
+        }
+      }
+    }
+
+    auto num_len = [](double v, int prec) -> int
+    {
+      char buf[64];
+      auto r = std::to_chars(buf, buf + sizeof(buf), v, std::chars_format::fixed, prec);
+      return int(r.ptr - buf);
+    };
+
+    auto print_num = [](std::ostream& o, double v, int prec, int width)
+    {
+      char buf[64];
+      auto r = std::to_chars(buf, buf + sizeof(buf), v, std::chars_format::fixed, prec);
+      int len = int(r.ptr - buf);
+      for (int i = 0; i < width - len; ++i)
+      {
+        o.put(' ');
+      }
+      o.write(buf, len);
+    };
+
+    auto print_dash = [](std::ostream& o, int width)
+    {
+      for (int i = 0; i < width - 1; ++i)
+      {
+        o.put(' ');
+      }
+      o.put('-');
+    };
+
+    int wQty = 7;
+    int wPx = 6;
+
+    for (size_t i = 0; i < na; ++i)
+    {
+      wQty = std::max(wQty, num_len(asks[i].qty, qtyPrec));
+      wPx = std::max(wPx, num_len(asks[i].px, pricePrec));
+    }
+
+    for (size_t i = 0; i < nb; ++i)
+    {
+      wQty = std::max(wQty, num_len(bids[i].qty, qtyPrec));
+      wPx = std::max(wPx, num_len(bids[i].px, pricePrec));
+    }
+
+    const char* RED = ansi ? "\033[31m" : "";
+    const char* GRN = ansi ? "\033[32m" : "";
+    const char* DIM = ansi ? "\033[2m" : "";
+    const char* RST = ansi ? "\033[0m" : "";
+
+    os << "  " << std::setw(wQty) << "ASK_QTY"
+       << "  " << std::setw(wPx) << "ASK_PX"
+       << "  " << DIM << "│" << RST << "  "
+       << std::setw(wPx) << "BID_PX"
+       << "  " << std::setw(wQty) << "BID_QTY"
+       << "\n";
+
+    const size_t rows = std::max(na, nb);
+
+    for (size_t r = 0; r < rows; ++r)
+    {
+      os << "  ";
+      if (r < na && asks[r].have)
+      {
+        os << RED;
+        print_num(os, asks[r].qty, qtyPrec, wQty);
+        os << RST;
+      }
+      else
+      {
+        print_dash(os, wQty);
+      }
+
+      os << "  ";
+      if (r < na && asks[r].have)
+      {
+        os << RED;
+        print_num(os, asks[r].px, pricePrec, wPx);
+        os << RST;
+      }
+      else
+      {
+        print_dash(os, wPx);
+      }
+
+      os << "  " << DIM << "│" << RST << "  ";
+
+      if (r < nb && bids[r].have)
+      {
+        os << GRN;
+        print_num(os, bids[r].px, pricePrec, wPx);
+        os << RST;
+      }
+      else
+      {
+        print_dash(os, wPx);
+      }
+
+      os << "  ";
+      if (r < nb && bids[r].have)
+      {
+        os << GRN;
+        print_num(os, bids[r].qty, qtyPrec, wQty);
+        os << RST;
+      }
+      else
+      {
+        print_dash(os, wQty);
+      }
+
+      os << "\n";
+    }
+  }
+
+  void applyBookUpdate(const BookUpdateEvent& ev) override
+  {
+    const auto& up = ev.update;
+
+    if (up.type == BookUpdateType::SNAPSHOT)
+    {
+      int64_t minIdx = std::numeric_limits<int64_t>::max();
+      int64_t maxIdx = std::numeric_limits<int64_t>::min();
+
+      auto acc = [&](const auto& vec)
+      {
+        for (const auto& [p, _] : vec)
+        {
+          const int64_t t = ticks(p);
+          if (t < minIdx)
+          {
+            minIdx = t;
+          }
+          if (t > maxIdx)
+          {
+            maxIdx = t;
+          }
+        }
+      };
+
+      acc(up.bids);
+      acc(up.asks);
+
+      if (minIdx == std::numeric_limits<int64_t>::max())
+      {
+        clear();
+      }
+      else
+      {
+        reanchor(minIdx, maxIdx);
+      }
+
+      _bids.fill({});
+      _asks.fill({});
+      _minBid = _minAsk = MAX_LEVELS;
+      _maxBid = _maxAsk = 0;
+      _bestBidIdx = _bestAskIdx = MAX_LEVELS;
+      _bestBidTick = _bestAskTick = -1;
+    }
+
+    for (const auto& [p, q] : up.bids)
+    {
+      const size_t i = localIndex(p);
+      if (i >= MAX_LEVELS)
+      {
+        continue;
+      }
+
+      const bool had = !_bids[i].isZero();
+      if (_bids[i].raw() == q.raw())
+      {
+        continue;
+      }
+
+      _bids[i] = q;
+
+      if (!q.isZero())
+      {
+        if (i < _minBid)
+        {
+          _minBid = i;
+        }
+        if (i > _maxBid)
+        {
+          _maxBid = i;
+        }
+        if (_bestBidIdx >= MAX_LEVELS || i > _bestBidIdx)
+        {
+          _bestBidIdx = i;
+          _bestBidTick = _baseIndex + static_cast<int64_t>(i);
+        }
+      }
+      else if (had)
+      {
+        if (i == _bestBidIdx)
+        {
+          _bestBidIdx = prevNonZeroBid(i);
+          _bestBidTick = (_bestBidIdx < MAX_LEVELS)
+                             ? (_baseIndex + static_cast<int64_t>(_bestBidIdx))
+                             : -1;
+        }
+        if (i == _minBid)
+        {
+          _minBid = nextNonZeroBid(_minBid);
+        }
+        if (i == _maxBid)
+        {
+          _maxBid = prevNonZeroBid(_maxBid);
+        }
+      }
+    }
+
+    for (const auto& [p, q] : up.asks)
+    {
+      const size_t i = localIndex(p);
+      if (i >= MAX_LEVELS)
+      {
+        continue;
+      }
+
+      const bool had = !_asks[i].isZero();
+      if (_asks[i].raw() == q.raw())
+      {
+        continue;
+      }
+
+      _asks[i] = q;
+
+      if (!q.isZero())
+      {
+        if (i < _minAsk)
+        {
+          _minAsk = i;
+        }
+        if (i > _maxAsk)
+        {
+          _maxAsk = i;
+        }
+        if (_bestAskIdx >= MAX_LEVELS || i < _bestAskIdx)
+        {
+          _bestAskIdx = i;
+          _bestAskTick = _baseIndex + static_cast<int64_t>(i);
+        }
+      }
+      else if (had)
+      {
+        if (i == _bestAskIdx)
+        {
+          _bestAskIdx = nextNonZeroAsk(i);
+          _bestAskTick = (_bestAskIdx < MAX_LEVELS)
+                             ? (_baseIndex + static_cast<int64_t>(_bestAskIdx))
+                             : -1;
+        }
+        if (i == _minAsk)
+        {
+          _minAsk = nextNonZeroAsk(_minAsk);
+        }
+        if (i == _maxAsk)
+        {
+          _maxAsk = prevNonZeroAsk(_maxAsk);
+        }
+      }
+    }
+  }
+
+  [[nodiscard]] inline std::optional<Price> bestBid() const override
+  {
+    const int64_t t = _bestBidTick;
+    if (t < 0)
+    {
+      return std::nullopt;
+    }
+    return std::optional<Price>{Price::fromRaw(_tickSize.raw() * t)};
+  }
+
+  [[nodiscard]] inline std::optional<Price> bestAsk() const override
+  {
+    const int64_t t = _bestAskTick;
+    if (t < 0)
+    {
+      return std::nullopt;
+    }
+    return std::optional<Price>{Price::fromRaw(_tickSize.raw() * t)};
+  }
+
+  [[nodiscard]] inline Quantity bidAtPrice(Price p) const override
+  {
+    const size_t i = localIndex(p);
     return i < MAX_LEVELS ? _bids[i] : Quantity{};
   }
 
-  Quantity askAtPrice(Price price) const override
+  [[nodiscard]] inline Quantity askAtPrice(Price p) const override
   {
-    const size_t i = priceToIndex(price);
+    const size_t i = localIndex(p);
     return i < MAX_LEVELS ? _asks[i] : Quantity{};
   }
 
-  void clear()
+  [[nodiscard]] inline std::pair<double, double> consumeAsks(double needQtyBase) const noexcept
+  {
+    if (_bestAskIdx >= MAX_LEVELS)
+    {
+      return {0.0, 0.0};
+    }
+
+    double rem = needQtyBase;
+    double notional = 0.0;
+
+    const double ts = _tickSize.toDouble();
+    size_t i = _bestAskIdx;
+    const size_t hi = _maxAsk;
+
+    double px = ts * static_cast<double>(_baseIndex + static_cast<int64_t>(i));
+
+    for (; i <= hi && rem > math::EPS_QTY; ++i, px += ts)
+    {
+      const double q = _asks[i].toDouble();
+      if (q <= 0.0)
+      {
+        continue;
+      }
+
+      const double take = q < rem ? q : rem;
+      notional += take * px;
+      rem -= take;
+    }
+
+    return {needQtyBase - rem, notional};
+  }
+
+  [[nodiscard]] inline std::pair<double, double> consumeBids(double needQtyBase) const noexcept
+  {
+    if (_bestBidIdx >= MAX_LEVELS)
+    {
+      return {0.0, 0.0};
+    }
+
+    double rem = needQtyBase;
+    double notional = 0.0;
+
+    const double ts = _tickSize.toDouble();
+    size_t i = _bestBidIdx;
+    const size_t lo = _minBid;
+
+    double px = ts * static_cast<double>(_baseIndex + static_cast<int64_t>(i));
+
+    for (;;)
+    {
+      if (rem <= math::EPS_QTY)
+      {
+        break;
+      }
+
+      const double q = _bids[i].toDouble();
+      if (q > 0.0)
+      {
+        const double take = q < rem ? q : rem;
+        notional += take * px;
+        rem -= take;
+      }
+
+      if (i == lo)
+      {
+        break;
+      }
+      --i;
+      px -= ts;
+    }
+
+    return {needQtyBase - rem, notional};
+  }
+
+  [[nodiscard]] inline Price tickSize() const noexcept { return _tickSize; }
+
+  void clear() noexcept
   {
     _bids.fill({});
     _asks.fill({});
-    _minBidIndex = MAX_LEVELS;
-    _maxBidIndex = 0;
-    _minAskIndex = MAX_LEVELS;
-    _maxAskIndex = 0;
+    _minBid = _minAsk = MAX_LEVELS;
+    _maxBid = _maxAsk = 0;
+    _baseIndex = 0;
+    _bestBidIdx = _bestAskIdx = MAX_LEVELS;
+    _bestBidTick = _bestAskTick = -1;
   }
 
  private:
-  size_t priceToIndex(Price price) const
+  [[nodiscard]] inline int64_t ticks(Price p) const noexcept
   {
-    return static_cast<size_t>((price / _tickSize.raw()).raw());
+    const int64_t pr = p.raw();
+    return math::sdiv_round_nearest(pr, _tickSizeDiv);
   }
 
-  Price indexToPrice(size_t index) const
+  [[nodiscard]] inline Price indexToPrice(size_t i) const noexcept
   {
-    return _tickSize * static_cast<int64_t>(index);
+    const int64_t ts = _tickSize.raw();
+    const int64_t tick = _baseIndex + static_cast<int64_t>(i);
+    return Price::fromRaw(ts * tick);
   }
 
+  [[nodiscard]] inline size_t localIndex(Price p) const noexcept
+  {
+    const int64_t t = ticks(p) - _baseIndex;
+    return (static_cast<uint64_t>(t) < static_cast<uint64_t>(MAX_LEVELS))
+               ? static_cast<size_t>(t)
+               : MAX_LEVELS;
+  }
+
+  void reanchor(int64_t minIdx, int64_t maxIdx) noexcept
+  {
+    constexpr int64_t HYST = 8;
+    const int64_t span = maxIdx - minIdx + 1;
+    const int64_t curLo = _baseIndex;
+    const int64_t curHi = _baseIndex + static_cast<int64_t>(MAX_LEVELS) - 1;
+
+    if (curLo + HYST <= minIdx && maxIdx <= curHi - HYST)
+    {
+      return;
+    }
+
+    if (span >= static_cast<int64_t>(MAX_LEVELS))
+    {
+      _baseIndex = minIdx;
+    }
+    else
+    {
+      const int64_t mid = (minIdx + maxIdx) / 2;
+      _baseIndex = mid - static_cast<int64_t>(MAX_LEVELS / 2);
+    }
+  }
+
+  [[nodiscard]] inline size_t nextNonZeroAsk(size_t from) const noexcept
+  {
+    for (size_t i = from; i < MAX_LEVELS; ++i)
+    {
+      if (!_asks[i].isZero())
+      {
+        return i;
+      }
+    }
+    return MAX_LEVELS;
+  }
+
+  [[nodiscard]] inline size_t prevNonZeroAsk(size_t from) const noexcept
+  {
+    for (size_t i = from + 1; i-- > 0;)
+    {
+      if (!_asks[i].isZero())
+      {
+        return i;
+      }
+
+      if (i == 0)
+      {
+        break;
+      }
+    }
+    return MAX_LEVELS;
+  }
+
+  [[nodiscard]] inline size_t nextNonZeroBid(size_t from) const noexcept
+  {
+    for (size_t i = from; i < MAX_LEVELS; ++i)
+    {
+      if (!_bids[i].isZero())
+      {
+        return i;
+      }
+    }
+    return MAX_LEVELS;
+  }
+
+  [[nodiscard]] inline size_t prevNonZeroBid(size_t from) const noexcept
+  {
+    for (size_t i = from + 1; i-- > 0;)
+    {
+      if (!_bids[i].isZero())
+      {
+        return i;
+      }
+
+      if (i == 0)
+      {
+        break;
+      }
+    }
+    return MAX_LEVELS;
+  }
+
+ private:
   Price _tickSize;
+  math::FastDiv64 _tickSizeDiv;
 
-  std::array<Quantity, MAX_LEVELS> _bids{};
-  std::array<Quantity, MAX_LEVELS> _asks{};
+  int64_t _baseIndex{0};
 
-  size_t _minBidIndex;
-  size_t _maxBidIndex;
-  size_t _minAskIndex;
-  size_t _maxAskIndex;
+  alignas(64) std::array<Quantity, MAX_LEVELS> _bids{};
+  alignas(64) std::array<Quantity, MAX_LEVELS> _asks{};
+
+  size_t _minBid{MAX_LEVELS}, _maxBid{0}, _minAsk{MAX_LEVELS}, _maxAsk{0};
+
+  size_t _bestBidIdx{MAX_LEVELS}, _bestAskIdx{MAX_LEVELS};
+  int64_t _bestBidTick{-1}, _bestAskTick{-1};
 };
 
 }  // namespace flox

--- a/include/flox/util/base/decimal.h
+++ b/include/flox/util/base/decimal.h
@@ -24,6 +24,8 @@ class Decimal
   static constexpr int Scale = Scale_;
   static constexpr int64_t TickSize = TickSize_;
 
+  static_assert(Scale > 0, "Decimal requires Scale > 0 for arithmetic");
+
   constexpr Decimal() : _raw(0) {}
   explicit constexpr Decimal(int64_t raw) : _raw(raw) {}
 
@@ -62,6 +64,27 @@ class Decimal
   constexpr Decimal operator*(int64_t x) const { return Decimal(_raw * x); }
   constexpr Decimal operator/(int64_t x) const { return Decimal(_raw / x); }
 
+  constexpr Decimal operator*(const Decimal& other) const
+  {
+#if defined(__SIZEOF_INT128__)
+    using i128 = __int128_t;
+    return Decimal(static_cast<int64_t>((i128)_raw * (i128)other._raw / (i128)Scale));
+#else
+    return Decimal((_raw / Scale) * other._raw + (_raw % Scale) * other._raw / Scale);
+#endif
+  }
+  constexpr Decimal operator/(const Decimal& other) const
+  {
+    assert(other.isZero() != 0 && "Division by zero");
+
+#if defined(__SIZEOF_INT128__)
+    using i128 = __int128_t;
+    return Decimal(static_cast<int64_t>(((i128)_raw * (i128)Scale) / (i128)other._raw));
+#else
+    return Decimal((_raw * Scale) / other._raw);
+#endif
+  }
+
   constexpr friend Decimal operator*(int64_t x, Decimal d) { return Decimal(x * d._raw); }
 
   constexpr Decimal& operator+=(const Decimal& other)
@@ -73,6 +96,18 @@ class Decimal
   constexpr Decimal& operator-=(const Decimal& other)
   {
     _raw -= other._raw;
+    return *this;
+  }
+
+  constexpr Decimal& operator*=(const Decimal& other)
+  {
+    *this = *this * other;
+    return *this;
+  }
+
+  constexpr Decimal& operator/=(const Decimal& other)
+  {
+    *this = *this / other;
     return *this;
   }
 

--- a/include/flox/util/base/math.h
+++ b/include/flox/util/base/math.h
@@ -1,0 +1,70 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#if !defined(__SIZEOF_INT128__)
+#error "__uint128_t not supported on current compiler/target"
+#endif
+
+namespace flox::math
+{
+inline constexpr double EPS_DOUBLE = 1e-12;
+
+inline constexpr double EPS_PRICE = 1e-9;
+inline constexpr double EPS_QTY = 1e-12;
+
+struct FastDiv64
+{
+  uint64_t d;  // divisor (must be > 0)
+  uint64_t m;  // magic (high 64 bits of reciprocal)
+  unsigned k;  // extra shift (0 or 1 is enough for 64-bit)
+};
+
+// Build reciprocal: m = ceil( 2^(64+k) / d )
+static inline FastDiv64 make_fastdiv64(uint64_t d, unsigned k = 1)
+{
+  __uint128_t one = (__uint128_t)1;
+  __uint128_t M = ((one << (64 + k)) + d - 1) / d;  // ceil
+  FastDiv64 fd;
+  fd.d = d;
+  fd.m = (uint64_t)M;
+  fd.k = k;
+  return fd;
+}
+
+// Unsigned floor(n / d) using magic; exact with one correction.
+static inline uint64_t udiv_fast(uint64_t n, const FastDiv64& fd)
+{
+  __uint128_t prod = (__uint128_t)n * fd.m;
+  uint64_t q = (uint64_t)(prod >> (64 + fd.k));
+  uint64_t r = n - q * fd.d;
+
+  if (r >= fd.d)
+  {
+    ++q;
+  }
+
+  return q;
+}
+
+// Signed division with rounding to nearest: q = round(n / d)
+static inline int64_t sdiv_round_nearest(int64_t n, const FastDiv64& fd)
+{
+  const int64_t half = (int64_t)(fd.d >> 1);
+  int64_t nadj = (n >= 0) ? (n + half) : (n - half);
+  uint64_t u = (uint64_t)nadj;
+  uint64_t q = udiv_fast(u, fd);
+
+  return (int64_t)q;
+}
+
+}  // namespace flox::math

--- a/tests/test_nlevel_order_book.cpp
+++ b/tests/test_nlevel_order_book.cpp
@@ -90,3 +90,103 @@ TEST_F(NLevelOrderBookTest, HandlesEmptyBook)
   EXPECT_EQ(book.bidAtPrice(Price::fromDouble(123.0)), Quantity::fromDouble(0.0));
   EXPECT_EQ(book.askAtPrice(Price::fromDouble(123.0)), Quantity::fromDouble(0.0));
 }
+
+static inline void ExpectPairNear(const std::pair<double, double>& got,
+                                  double expFilled, double expNotional,
+                                  double eps = 1e-9)
+{
+  EXPECT_NEAR(got.first, expFilled, eps);
+  EXPECT_NEAR(got.second, expNotional, eps);
+}
+
+TEST_F(NLevelOrderBookTest, ConsumeAsks_Basic)
+{
+  auto up = makeSnapshot(
+      {},
+      {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)},
+       {Price::fromDouble(100.1), Quantity::fromDouble(2.0)},
+       {Price::fromDouble(100.2), Quantity::fromDouble(3.0)}});
+
+  book.applyBookUpdate(*up);
+
+  ExpectPairNear(book.consumeAsks(0.0), 0.0, 0.0);
+  ExpectPairNear(book.consumeAsks(1.0), 1.0, 100.0);
+  ExpectPairNear(book.consumeAsks(2.5), 2.5, 250.15);
+  ExpectPairNear(book.consumeAsks(10.0), 6.0, 600.8);
+}
+
+TEST_F(NLevelOrderBookTest, ConsumeBids_Basic)
+{
+  auto up = makeSnapshot(
+      {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)},
+       {Price::fromDouble(99.9), Quantity::fromDouble(2.0)},
+       {Price::fromDouble(99.8), Quantity::fromDouble(3.0)}},
+      {});
+
+  book.applyBookUpdate(*up);
+
+  ExpectPairNear(book.consumeBids(2.5), 2.5, 249.85);
+  ExpectPairNear(book.consumeBids(10.0), 6.0, 599.2);
+}
+
+TEST_F(NLevelOrderBookTest, ConsumeAsks_WithHoles)
+{
+  auto up = makeSnapshot(
+      {},
+      {{Price::fromDouble(100.0), Quantity::fromDouble(0.0)},
+       {Price::fromDouble(100.1), Quantity::fromDouble(2.0)},
+       {Price::fromDouble(100.2), Quantity::fromDouble(0.0)},
+       {Price::fromDouble(100.3), Quantity::fromDouble(3.0)}});
+
+  book.applyBookUpdate(*up);
+
+  ExpectPairNear(book.consumeAsks(2.0), 2.0, 200.2);
+  ExpectPairNear(book.consumeAsks(4.0), 4.0, 400.8);
+  ExpectPairNear(book.consumeAsks(10.0), 5.0, 501.1);
+}
+
+TEST_F(NLevelOrderBookTest, ConsumeBids_WithHoles)
+{
+  auto up = makeSnapshot(
+      {{Price::fromDouble(100.0), Quantity::fromDouble(0.0)},
+       {Price::fromDouble(99.9), Quantity::fromDouble(2.0)},
+       {Price::fromDouble(99.8), Quantity::fromDouble(0.0)},
+       {Price::fromDouble(99.7), Quantity::fromDouble(3.0)}},
+      {});
+
+  book.applyBookUpdate(*up);
+
+  ExpectPairNear(book.consumeBids(3.0), 3.0, 299.5);
+  ExpectPairNear(book.consumeBids(10.0), 5.0, 498.9);
+}
+
+TEST_F(NLevelOrderBookTest, Consume_EmptyBook)
+{
+  auto up = makeSnapshot({}, {});
+  book.applyBookUpdate(*up);
+
+  ExpectPairNear(book.consumeAsks(5.0), 0.0, 0.0);
+  ExpectPairNear(book.consumeBids(5.0), 0.0, 0.0);
+}
+
+TEST_F(NLevelOrderBookTest, Consume_IsConstDoesNotMutate)
+{
+  auto up = makeSnapshot(
+      {{Price::fromDouble(100.0), Quantity::fromDouble(1.0)},
+       {Price::fromDouble(99.9), Quantity::fromDouble(2.0)}},
+      {{Price::fromDouble(100.1), Quantity::fromDouble(2.0)},
+       {Price::fromDouble(100.2), Quantity::fromDouble(3.0)}});
+
+  book.applyBookUpdate(*up);
+
+  auto r1 = book.consumeAsks(3.5);
+  auto r2 = book.consumeAsks(3.5);
+  ExpectPairNear(r1, r2.first, r2.second);
+
+  auto b1 = book.consumeBids(2.25);
+  auto b2 = book.consumeBids(2.25);
+  ExpectPairNear(b1, b2.first, b2.second);
+
+  EXPECT_EQ(book.bestAsk(), Price::fromDouble(100.1));
+  EXPECT_EQ(book.bestBid(), Price::fromDouble(100.0));
+}


### PR DESCRIPTION
Introduce anchoring (baseIndex) for bids and asks in NLevelOrderBook. 
Snapshots now reset anchors and updates apply relative to them, ensuring stable and consistent order book state. 
Additionally, switch tick computations to optimized FastDiv64 (reciprocal, round-to-nearest) to reduce division cost and jitter. 
Also adds minor decimal helpers (EPS, mul/div).