### PR TITLE
ci(tests): static audit of test gating vs gated header includes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         python3 scripts/check_binding_parity.py
     - name: Verify error codes have docs and pages aren't stale
       run: python3 scripts/check_error_codes.py
+    - name: Verify test gating against backtest / capi headers
+      run: python3 scripts/check_test_gating.py
     - name: Verify Python API index is in sync with .pyi
       run: python3 scripts/gen_api_index.py --check
     - name: Verify doc snippets follow the --8<-- include pattern

--- a/docs/contributors/test-gating.md
+++ b/docs/contributors/test-gating.md
@@ -1,0 +1,64 @@
+# Test gating
+
+The build matrix has a `tests-only` configuration that builds with
+`FLOX_BUILD_TESTS=ON` but no other flags. If a test exec depends on
+backtest-only sources (`flox/backtest/...`) or C API symbols
+(`flox/capi/...`) without sitting under the matching CMake gating
+block, the linker fails on that config — the test cpp compiles fine
+but cannot find the symbols it needs.
+
+`scripts/check_test_gating.py` runs in CI (verify-docs-current) and
+fails any PR whose test additions slip through this gate.
+
+## The rule
+
+| Header prefix       | Required CMake flag      |
+|---------------------|--------------------------|
+| `flox/backtest/...` | `FLOX_ENABLE_BACKTEST`   |
+| `flox/capi/...`     | `FLOX_BUILD_CAPI`        |
+
+Implications: `FLOX_BUILD_CAPI` implies `FLOX_ENABLE_BACKTEST`,
+`FLOX_BUILD_CODON` and `FLOX_BUILD_QUICKJS` both imply
+`FLOX_BUILD_CAPI`. The checker walks these so a test under
+`if(FLOX_BUILD_QUICKJS)` is treated as having `FLOX_BUILD_CAPI` and
+`FLOX_ENABLE_BACKTEST` active.
+
+## What to do when the gate fails
+
+The error tells you which flag is missing for which test. Move
+`add_flox_test(test_name)` into the matching `if(...)` block in
+`tests/CMakeLists.txt`. Example fix from W15-T020:
+
+```cmake
+# Wrong — test_live_queue_position needs FLOX_ENABLE_BACKTEST.
+add_flox_test(test_live_queue_position)
+
+# Right — inside the backtest gate.
+if(FLOX_ENABLE_BACKTEST)
+  ...
+  add_flox_test(test_live_queue_position)
+endif()
+```
+
+## Running locally
+
+```
+python3 scripts/check_test_gating.py
+```
+
+The script prints a coverage map of every test target with its
+declared CMake gating and its needed-from-includes set. A clean run
+ends with `OK — N test targets, gating consistent.`
+
+## Scope
+
+- Direct `#include` lines only. Transitive includes through engine
+  headers are not chased — false negatives are possible if a public
+  engine header internally pulls in a backtest header, but those
+  cases also show up as link failures during `tests-only` CI and
+  bubble up the same way.
+- No auto-fix. The check surfaces the gap; the PR author moves the
+  test into the right block.
+- The `FLAG_IMPLIES` map at the top of the script mirrors the
+  hard-prereq guards in the root `CMakeLists.txt`. Keep them in
+  sync when adding a new flag dependency.

--- a/scripts/check_test_gating.py
+++ b/scripts/check_test_gating.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Audit tests/*.cpp against their CMake gating blocks.
+
+Reads `tests/CMakeLists.txt`, determines which test targets live under
+which `if(FLAG)` block, then scans the corresponding source file for
+includes from gated header prefixes. Fails the check when a test
+includes a gated header but lives outside the matching block.
+
+Examples of gated headers:
+- `flox/backtest/...`   → requires FLOX_ENABLE_BACKTEST
+- `flox/capi/...`       → requires FLOX_BUILD_CAPI
+
+The check is conservative — only direct `#include` lines are inspected,
+so transitive includes through engine headers are not chased. T020
+caught one case (`test_live_queue_position`); this script automates the
+audit for every future PR.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CMAKE_PATH = REPO_ROOT / "tests" / "CMakeLists.txt"
+TESTS_DIR = REPO_ROOT / "tests"
+
+# header prefix → required cmake flag
+GATED_PREFIXES: dict[str, str] = {
+    "flox/backtest/": "FLOX_ENABLE_BACKTEST",
+    "flox/capi/": "FLOX_BUILD_CAPI",
+}
+
+# Hard-prereq implications expressed in CMakeLists.txt. When a flag
+# is active, every flag it implies is also guaranteed active. Mirrors
+# the message(FATAL_ERROR ...) guards at config time.
+FLAG_IMPLIES: dict[str, set[str]] = {
+    "FLOX_BUILD_CAPI": {"FLOX_ENABLE_BACKTEST"},
+    "FLOX_BUILD_CODON": {"FLOX_BUILD_CAPI", "FLOX_ENABLE_BACKTEST"},
+    "FLOX_BUILD_QUICKJS": {"FLOX_BUILD_CAPI", "FLOX_ENABLE_BACKTEST"},
+}
+
+
+def expand_flags(flags: list[str]) -> set[str]:
+    """Resolve transitive flag implications."""
+    out: set[str] = set(flags)
+    changed = True
+    while changed:
+        changed = False
+        for f in list(out):
+            for implied in FLAG_IMPLIES.get(f, set()):
+                if implied not in out:
+                    out.add(implied)
+                    changed = True
+    return out
+
+ADD_TEST_RE = re.compile(r"^\s*add_flox_test\(\s*([A-Za-z0-9_]+)\s*\)")
+# Track every if(...) so the depth stays balanced. Non-flag forms
+# (if(TARGET ...), if(NOT ...), etc.) get a sentinel that contributes
+# no flag but still occupies a stack slot.
+IF_ANY_RE = re.compile(r"^\s*if\s*\(")
+IF_FLAG_RE = re.compile(r"^\s*if\(\s*([A-Za-z0-9_]+)\s*\)")
+ENDIF_RE = re.compile(r"^\s*endif\s*\(")
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s*[<"]([^>"]+)[>"]')
+
+_SENTINEL = "<non-flag>"
+
+
+def parse_cmake_gating(cmake_text: str) -> dict[str, list[str]]:
+    """Return {test_target: [flags…]} based on nested if() blocks."""
+    targets: dict[str, list[str]] = {}
+    flag_stack: list[str] = []
+    for raw in cmake_text.splitlines():
+        line = raw.split("#", 1)[0]
+        if IF_ANY_RE.match(line):
+            m = IF_FLAG_RE.match(line)
+            flag_stack.append(m.group(1) if m else _SENTINEL)
+            continue
+        if ENDIF_RE.match(line):
+            if flag_stack:
+                flag_stack.pop()
+            continue
+        if (m := ADD_TEST_RE.match(line)):
+            targets[m.group(1)] = [f for f in flag_stack if f != _SENTINEL]
+    return targets
+
+
+def scan_includes(cpp_path: Path) -> set[str]:
+    out: set[str] = set()
+    try:
+        with cpp_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                m = INCLUDE_RE.match(line)
+                if m:
+                    out.add(m.group(1))
+    except FileNotFoundError:
+        pass
+    return out
+
+
+def required_flags_for_includes(includes: set[str]) -> set[str]:
+    needed: set[str] = set()
+    for inc in includes:
+        for prefix, flag in GATED_PREFIXES.items():
+            if inc.startswith(prefix):
+                needed.add(flag)
+    return needed
+
+
+def main() -> int:
+    if not CMAKE_PATH.exists():
+        print(f"::error::{CMAKE_PATH} not found", file=sys.stderr)
+        return 2
+
+    targets = parse_cmake_gating(CMAKE_PATH.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    coverage_lines: list[str] = []
+
+    for target, current_flags in sorted(targets.items()):
+        cpp = TESTS_DIR / f"{target}.cpp"
+        includes = scan_includes(cpp)
+        needed = required_flags_for_includes(includes)
+        effective = expand_flags(current_flags)
+        missing = needed - effective
+        coverage_lines.append(
+            f"  {target:<45} gating=[{', '.join(current_flags) or '-'}]  needs=[{', '.join(sorted(needed)) or '-'}]"
+        )
+        if missing:
+            failures.append(
+                f"::error::{target} ({cpp.name}) includes a gated header but "
+                f"lives outside [{', '.join(sorted(missing))}] — move it inside "
+                f"the matching if(...) block in {CMAKE_PATH.relative_to(REPO_ROOT)}."
+            )
+
+    print("Test gating coverage:")
+    for line in coverage_lines:
+        print(line)
+    print()
+
+    if failures:
+        for f in failures:
+            print(f, file=sys.stderr)
+        return 1
+    print(f"OK — {len(targets)} test targets, gating consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,8 +70,6 @@ add_flox_test(test_multi_symbol_strategy)
 
 add_flox_test(test_order_group_replace)
 
-add_flox_test(test_rate_limit_policy)
-
 add_flox_test(test_position_aggregator)
 
 # CEX coordination tests
@@ -103,6 +101,7 @@ if(FLOX_ENABLE_BACKTEST)
   add_flox_test(test_extended_tif)
   add_flox_test(test_hidden_order_attribution)
   add_flox_test(test_funding_schedule)
+  add_flox_test(test_rate_limit_policy)
 endif()
 
 add_flox_test(test_indicators)


### PR DESCRIPTION
T020 caught one case of a test exec (test_live_queue_position) that linked against backtest-only sources without sitting under FLOX_ENABLE_BACKTEST. T022 silently introduced another (test_rate_limit_policy) that this audit catches.

scripts/check_test_gating.py walks tests/CMakeLists.txt, builds a target-to-cmake-flags map that respects nested if() blocks (and the non-flag forms like if(TARGET ...) which previously broke a naive stack-based parser), then scans direct #include lines in each test cpp for gated header prefixes:

flox/backtest/... requires FLOX_ENABLE_BACKTEST.
flox/capi/... requires FLOX_BUILD_CAPI.

The script resolves CMake's hard-prereq implications (CAPI implies BACKTEST; QUICKJS and CODON both imply CAPI), so a test under if(FLOX_BUILD_QUICKJS) is correctly treated as having CAPI and BACKTEST active without false positives.

Running on the current tree surfaced exactly one real gap: test_rate_limit_policy from #279 lived at the top level but includes flox/backtest/rate_limit_policy.h. Fix: moved into the FLOX_ENABLE_BACKTEST block alongside test_live_queue_position, test_funding_schedule, and the other backtest-coupled tests.

Wired into verify-docs-current CI alongside check_dts_exports, check_binding_parity, check_doc_snippets. Coverage map prints every test target with its declared CMake gating and the includes-derived needed set. A clean run ends with `OK — N test targets, gating consistent.`

Contributor docs at docs/contributors/test-gating.md explain the rule and the fix recipe.

Scope notes: direct #include lines only — transitive includes through engine headers are not chased (false negatives possible but those surface as link failures during tests-only CI). No auto-fix — the check surfaces the gap and the PR author moves the test into the right block.

W15-T035