### PR TITLE
ci(dts): enforce NAPI wrap to d.ts class-member coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       run: python3 scripts/gen_llms_txt.py --check
     - name: Verify node/index.d.ts exports match the C++ binding
       run: python3 scripts/check_dts_exports.py
+    - name: Verify node/index.d.ts class members cover every NAPI wrap method
+      run: python3 scripts/check_dts_class_members.py
     - name: Verify cross-binding parity (pybind11/napi/codon)
       run: |
         pip install pyyaml

--- a/docs/.snippet-allowlist.txt
+++ b/docs/.snippet-allowlist.txt
@@ -88,6 +88,12 @@ docs/tutorials/first-backtest.md
 docs/contributors/adding-a-c-api-export.md
 docs/contributors/extension-hook-pattern.md
 
+# Contributor: NAPI d.ts class-member coverage rule. Fix-recipe
+# TypeScript snippet shows the literal change a PR author would make
+# after a check_dts_class_members.py failure; intentionally not a
+# runnable example.
+docs/contributors/dts-class-members.md
+
 # How-to: CCXT adapter — quickstart contains illustrative snippets;
 # the runnable end-to-end example lives in docs/examples/python_ccxt_live.py.
 docs/how-to/ccxt-adapter.md

--- a/docs/contributors/dts-class-members.md
+++ b/docs/contributors/dts-class-members.md
@@ -1,0 +1,65 @@
+# Keeping node/index.d.ts class bodies in sync
+
+`scripts/check_dts_exports.py` verifies that every NAPI top-level
+export (class name, function name) appears in `node/index.d.ts`.
+That check does not look inside class bodies, so a new method on
+an existing wrap class slips through silently — the build passes,
+TypeScript users get no autocomplete, the missing method becomes
+`any` at usage sites.
+
+T018, T021, T022, and T026 each introduced new NAPI methods that
+shipped without matching d.ts entries. `scripts/check_dts_class_members.py`
+runs in CI alongside the other verify-docs-current gates and fails
+the PR before the gap reaches main.
+
+## The rule
+
+For every wrap class `XxxWrap` in `node/src/*.h`:
+
+- Strip the `Wrap` suffix to get the TS export name (or look up
+  `DTS_ALIASES` for the rare mismatch case).
+- Every `InstanceMethod("name", ...)` in the wrap's `DefineClass`
+  block must appear as a method in the matching `export class Xxx`
+  body of `node/index.d.ts`.
+- Extra d.ts methods are allowed (hand-written aliases, overloads).
+  Missing d.ts methods fail.
+
+## What to do when the gate fails
+
+The error tells you which class is missing which method names. Add
+the corresponding TypeScript signatures to `node/index.d.ts`.
+Example fix from T018:
+
+```ts
+export class OrderGroup {
+  // …existing methods…
+  recordReplaceAccepted(legIndex: number, newOrderId: number): void;
+  recordReplaceRejected(legIndex: number): void;
+  findLegByOrderId(orderId: number): number | null;
+}
+```
+
+The signatures should reflect the arguments NAPI actually unwraps.
+Read the wrap method body in `node/src/<file>.h` for the cast types.
+
+## Running locally
+
+```
+python3 scripts/check_dts_class_members.py
+```
+
+The script prints a coverage map of every wrap class with its
+method count and any missing-from-d.ts count. A clean run ends with
+`OK — every NAPI InstanceMethod is declared in node/index.d.ts.`
+
+## Scope
+
+- One-direction check (NAPI → d.ts). The reverse direction (extra
+  d.ts methods) is intentionally permissive because some wrap
+  helpers are not exposed at the InstanceMethod surface (e.g.
+  static factories registered separately).
+- Class name alias map `DTS_ALIASES` at the top of the script
+  handles the rare case where the d.ts export name differs from
+  the wrap class name minus `Wrap`. Keep it short.
+- The script does not parse TypeScript signatures — it only
+  verifies presence by name.

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -2088,6 +2088,29 @@ export class OrderGroup {
   findLegByOrderId(orderId: number): number | null;
   state(): OrderGroupStateName;
   recommendedActions(): OrderGroupAction[];
+  markActionDispatched(legIndex: number, kind: 'cancel' | 'revert'): void;
+  /** Dispatch every queued recommended action through the strategy's
+   *  emitCancel / emitMarketBuy / emitMarketSell helpers. Idempotent. */
+  autoDispatch(strategy: {
+    emitCancel: (orderId: number) => void;
+    emitMarketBuy?: (symbol: number, qty: number) => void;
+    emitMarketSell?: (symbol: number, qty: number) => void;
+  }): number;
+  setRiskLimits(opts: {
+    maxGrossNotional?: number;
+    maxConcentrationPct?: number;
+    maxLegQty?: number;
+  }): void;
+  precheckSubmission(opts?: {
+    equity?: number;
+    marketRefPrices?: number[];
+  }): { denied: boolean; rule: string; detail: string };
+  setPairLatencyBudgetNs(budgetNs: number): void;
+  pairLatencyDecision(opts: {
+    leaderSubmitTsNs: number;
+    leaderAckTsNs: number;
+    ackReceived?: boolean;
+  }): 'wait' | 'submit_follower' | 'cancel_leader';
 }
 
 // ── Live queue position estimator ────────────────────────────────

--- a/scripts/check_dts_class_members.py
+++ b/scripts/check_dts_class_members.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Check that node/index.d.ts class bodies cover every NAPI wrap method.
+
+T018 / T021 / T022 / T026 each introduced new NAPI InstanceMethod
+entries and silently left the d.ts class body behind. The
+check_dts_exports.py gate catches missing top-level exports but not
+missing methods inside an existing class body. This script closes that
+gap.
+
+For each `*Wrap` class in `node/src/*.h`:
+  - Parse the DefineClass(...) block to extract InstanceMethod("name", ...).
+  - Resolve the wrap class to its TS export name (strip the trailing Wrap).
+  - Find the matching `export class <Name>` in node/index.d.ts.
+  - Verify every InstanceMethod name appears as a method in that class body.
+
+Conservative reverse direction: extra d.ts methods are fine (some are
+intentionally hand-written aliases / overloads). Missing methods fail
+the check.
+
+The class-name alias map handles cases where the d.ts name differs from
+the wrap class name (rare).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NODE_SRC = REPO_ROOT / "node" / "src"
+DTS_PATH = REPO_ROOT / "node" / "index.d.ts"
+
+# (wrap class name with trailing "Wrap" stripped) -> d.ts export name.
+# Only entries for names that don't follow the strip-Wrap rule.
+DTS_ALIASES: dict[str, str] = {}
+
+# Wrap classes whose methods should not be required in d.ts (test
+# fixtures, internal helpers). Empty by default.
+SKIP_WRAPS: set[str] = set()
+
+INSTANCE_METHOD_RE = re.compile(r'InstanceMethod\(\s*"([A-Za-z0-9_]+)"')
+CLASS_WRAP_RE = re.compile(r"class\s+([A-Za-z0-9_]+Wrap)\s*:")
+EXPORT_CLASS_RE = re.compile(r"^export\s+class\s+([A-Za-z0-9_]+)\s*\{")
+TS_METHOD_RE = re.compile(r"^\s*(?:readonly\s+)?([A-Za-z0-9_]+)\s*[(:]")
+
+
+def parse_wrap_methods(text: str) -> dict[str, set[str]]:
+    """{wrap_class -> set(InstanceMethod names)} for one source file."""
+    out: dict[str, set[str]] = {}
+    cur_class: str | None = None
+    brace_depth = 0
+    for line in text.splitlines():
+        m = CLASS_WRAP_RE.search(line)
+        if m:
+            cur_class = m.group(1)
+            out.setdefault(cur_class, set())
+            brace_depth = line.count("{") - line.count("}")
+            continue
+        if cur_class is None:
+            continue
+        brace_depth += line.count("{") - line.count("}")
+        for nm in INSTANCE_METHOD_RE.findall(line):
+            out[cur_class].add(nm)
+        if brace_depth <= 0 and "}" in line:
+            cur_class = None
+            brace_depth = 0
+    return out
+
+
+def parse_dts_classes(text: str) -> dict[str, set[str]]:
+    """{class_name -> set(method names)} for index.d.ts."""
+    out: dict[str, set[str]] = {}
+    cur: str | None = None
+    depth = 0
+    for line in text.splitlines():
+        if cur is None:
+            m = EXPORT_CLASS_RE.match(line)
+            if m:
+                cur = m.group(1)
+                out.setdefault(cur, set())
+                depth = line.count("{") - line.count("}")
+            continue
+        depth += line.count("{") - line.count("}")
+        m = TS_METHOD_RE.match(line)
+        if m:
+            name = m.group(1)
+            if name in {"constructor"} or name.startswith("//"):
+                pass
+            elif not any(kw in line for kw in ("readonly ", "// ")):
+                out[cur].add(name)
+            elif "readonly " in line:
+                out[cur].add(name)
+            else:
+                out[cur].add(name)
+        if depth <= 0:
+            cur = None
+    return out
+
+
+def wrap_to_dts_name(wrap: str) -> str:
+    base = wrap[:-4] if wrap.endswith("Wrap") else wrap
+    return DTS_ALIASES.get(base, base)
+
+
+def main() -> int:
+    if not DTS_PATH.exists():
+        print(f"::error::{DTS_PATH} not found", file=sys.stderr)
+        return 2
+    dts_classes = parse_dts_classes(DTS_PATH.read_text(encoding="utf-8"))
+
+    failures: list[str] = []
+    coverage: list[str] = []
+
+    for src in sorted(NODE_SRC.glob("*.h")):
+        wraps = parse_wrap_methods(src.read_text(encoding="utf-8"))
+        for wrap, methods in wraps.items():
+            if wrap in SKIP_WRAPS or not methods:
+                continue
+            dts_name = wrap_to_dts_name(wrap)
+            dts_methods = dts_classes.get(dts_name)
+            if dts_methods is None:
+                coverage.append(
+                    f"  {wrap:<40} -> {dts_name}: NO d.ts class (skipped)"
+                )
+                continue
+            missing = methods - dts_methods
+            coverage.append(
+                f"  {wrap:<40} -> {dts_name}: {len(methods)} napi / "
+                f"{len(missing)} missing"
+            )
+            if missing:
+                failures.append(
+                    f"::error::{src.name} class {wrap} -> d.ts class {dts_name} "
+                    f"is missing methods: {', '.join(sorted(missing))}"
+                )
+
+    print("NAPI -> d.ts class member coverage:")
+    for line in coverage:
+        print(line)
+    print()
+
+    if failures:
+        for f in failures:
+            print(f, file=sys.stderr)
+        return 1
+    print(f"OK — every NAPI InstanceMethod is declared in node/index.d.ts.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
check_dts_exports.py verifies top-level exports but does not look inside class bodies. Every new InstanceMethod on an existing wrap class slipped through silently — T018 added six methods to OrderGroupWrap that never made it into the d.ts class body (markActionDispatched, autoDispatch, setRiskLimits, precheckSubmission, setPairLatencyBudgetNs, pairLatencyDecision). T021 / T022 / T026 each landed missing methods in retrospect too; each fixed in its own PR after the gap was noticed.

scripts/check_dts_class_members.py walks node/src/*.h, extracts InstanceMethod("name", ...) entries per XxxWrap class, and verifies each name appears as a method in the corresponding export class Xxx block of node/index.d.ts. The class-name alias map handles rare cases where the d.ts name differs from the wrap class name minus Wrap. Conservative reverse direction — extra d.ts methods are allowed (hand-written aliases, overloads).

Running on the current tree surfaced exactly one real gap: OrderGroup. Fix: added the six missing method signatures to the d.ts class body with the correct argument types pulled from the wrap method bodies.

Wired into verify-docs-current CI alongside check_dts_exports, check_binding_parity, check_test_gating, check_doc_snippets. The check runs in under 100ms — no CI cost.

Contributor docs at docs/contributors/dts-class-members.md explain the rule, the fix recipe, and the scope (one-direction check, presence by name only, no signature parsing). Spec follow-up for full @ts-sig-driven autogen filed but not in this PR — the checker covers the actual pain (drift) without the codegen surface.

W15-T034