### PR TITLE
fix(mcp): lookup_symbol finds polyglot classes via class->group index

### DIFF
--- a/mcp/flox_mcp/tools/lookup.py
+++ b/mcp/flox_mcp/tools/lookup.py
@@ -89,6 +89,21 @@ def _node_local_name_for(group: str, manifest: dict) -> Tuple[List[str], List[st
     return list(nd.get("classes") or []), list(nd.get("functions") or [])
 
 
+def _class_to_group_index(manifest: dict, binding_key: str) -> Dict[str, str]:
+    """Build a `class_name → group_name` index from the manifest's
+    per-group binding metadata. Used to find a polyglot class
+    (Account, VenueStack, LiquidationEngine, ...) when the IR has
+    no matching C-ABI symbol with that spelling."""
+    out: Dict[str, str] = {}
+    for group_name, grp in (manifest.get("groups") or {}).items():
+        binding = (grp or {}).get(binding_key) or {}
+        for cls in binding.get("classes") or []:
+            out[cls] = group_name
+        for fn in binding.get("functions") or []:
+            out.setdefault(fn, group_name)
+    return out
+
+
 # ── lookup_symbol ─────────────────────────────────────────────────────
 
 
@@ -130,6 +145,13 @@ def _resolve_python(name: str, manifest: dict, ir_match: Optional[dict]) -> Opti
             return {"name": c, "kind": "class", "from_group": ir_match["group"]}
         for f in fns:
             return {"name": f, "kind": "function", "from_group": ir_match["group"]}
+    # Fallback: scan the inverted class→group index. Catches polyglot
+    # classes like Account / VenueStack / LiquidationEngine that
+    # have no C-ABI symbol by that spelling.
+    py_idx = _class_to_group_index(manifest, _PYBIND_KEY)
+    if name in py_idx:
+        return {"name": name, "kind": "class",
+                "from_group": py_idx[name]}
     return None
 
 
@@ -143,6 +165,10 @@ def _resolve_node(name: str, manifest: dict, ir_match: Optional[dict]) -> Option
             return {"name": c, "kind": "class", "from_group": ir_match["group"]}
         for f in fns:
             return {"name": f, "kind": "function", "from_group": ir_match["group"]}
+    napi_idx = _class_to_group_index(manifest, _NAPI_KEY)
+    if name in napi_idx:
+        return {"name": name, "kind": "class",
+                "from_group": napi_idx[name]}
     return None
 
 

--- a/mcp/tests/test_polyglot_tools.py
+++ b/mcp/tests/test_polyglot_tools.py
@@ -95,6 +95,35 @@ def test_lookup_symbol_attaches_gotcha_when_resolved():
     assert "subscribed" in out.lower()
 
 
+@pytest.mark.parametrize(
+    "klass",
+    [
+        "Account",
+        "VenueStack",
+        "LiquidationEngine",
+        "FeeSchedule",
+        "FundingSchedule",
+        "RateLimitPolicy",
+        "VenueAvailability",
+        "SimulatedExecutor",
+    ],
+)
+def test_lookup_symbol_finds_polyglot_classes(klass: str):
+    """W15-T063: polyglot classes (Account, VenueStack, LiquidationEngine,
+    ...) have no C-ABI symbol with that exact spelling. The resolver
+    must consult the inverted class->group index from
+    binding_manifest.json so an AI agent searching for the class name
+    actually finds it."""
+    out = lookup.lookup_symbol(klass)
+    assert "no match" not in out.lower(), (
+        f"polyglot class {klass!r} unresolved; lookup_symbol returned:\n{out}"
+    )
+    assert "python" in out
+    # napi should also list it (every polyglot class registered in
+    # T037/T052 lives in both pybind11 and napi manifests).
+    assert "node" in out
+
+
 # ── list_bindings ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Critical fix for AI-agent discoverability. Before this patch, `lookup_symbol(\"Account\")`, `lookup_symbol(\"VenueStack\")`, `lookup_symbol(\"LiquidationEngine\")`, and every other polyglot class added in W15 returned \"no match\" — because the resolver only matched against the IR snapshot (C ABI functions / structs / enums / typedefs), and these high-level classes have no C ABI symbol with that exact spelling.

`binding_manifest.json` already records every polyglot class under `groups.<group>.{pybind11,napi}.classes`. The resolver just wasn't consulting that index when the IR lookup missed.

This patch adds an inverted class->group index for pybind11 and napi, and falls back to it when `ir_match` is None. AI agents asking \"does flox.Account exist?\" via MCP now get a hit pointing at the python + node class entries.

Discovered while preparing the round-5 \"AI + scaffold + MCP → realistic backtest\" workflow — the MCP discovery layer was silently broken for every W15 high-level class.

## Test plan

- [x] mcp/tests/test_polyglot_tools.py: 8 new parametrised regression cases (Account, VenueStack, LiquidationEngine, FeeSchedule, FundingSchedule, RateLimitPolicy, VenueAvailability, SimulatedExecutor) — all pass
- [x] Existing 47 polyglot tests still pass (55 total in suite)
- [x] Manual verification: lookup_symbol(\"Account\") now returns python + node class table

W15-T063

🤖 Generated with [Claude Code](https://claude.com/claude-code)