### PR TITLE
docs(mkdocs): register W15 how-to pages in nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,16 @@ nav:
           - Heatmap rendering: how-to/heatmap.md
           - Realistic Backtest Fills: how-to/backtest-realistic-fills.md
           - Native iceberg orders: how-to/iceberg-orders.md
+          - Realistic backtest in one call: how-to/realistic-backtest.md
+          - Cross-margin accounts: how-to/cross-margin.md
+          - Liquidation and ADL: how-to/liquidation-and-adl.md
+          - Perpetual funding: how-to/perpetual-funding.md
+          - Order TIF flags: how-to/order-tif-flags.md
+          - Self-match prevention: how-to/self-match-prevention.md
+          - Matching modes: how-to/matching-modes.md
+          - Rate limits: how-to/rate-limits.md
+          - Venue downtime: how-to/venue-downtime.md
+          - Calibrate live queue: how-to/calibrate-live-queue.md
           - Record and replay market data: how-to/tape-record.md
           - Merge multiple tapes on read: how-to/multi-tape.md
           - Import Binance public archives: how-to/import-binance-archive.md


### PR DESCRIPTION
## Summary

10 W15 how-to pages existed in docs/how-to/ but were never linked in mkdocs.yml nav — they only surfaced via search or direct URL. Pure nav addition; no content changes.

Pages registered:
- realistic-backtest.md (T052 venue factory canonical guide)
- cross-margin.md (T037 Account state)
- liquidation-and-adl.md (T036/T032 engine)
- perpetual-funding.md (T031/T047)
- order-tif-flags.md (T028)
- self-match-prevention.md (T025/T044)
- matching-modes.md (T024/T043 pro-rata variants)
- rate-limits.md (T022/T049)
- venue-downtime.md (T023/T046)
- calibrate-live-queue.md (T033/T048)

## Test plan

- [x] mkdocs build clean (no warnings/errors)
- [x] All 10 referenced files exist on disk

W15-T062

🤖 Generated with [Claude Code](https://claude.com/claude-code)