### PR TITLE
chore(packages): refresh PyPI + npm descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 ## FLOX
 
-FLOX is a modular framework for building trading systems with polyglot strategy bindings and AI-friendly developer tools.
-Strategies run on one C++ core in Python, Node.js, Codon, or embedded JavaScript. Same strategy code goes from backtest to live without a rewrite step.
+FLOX is an AI-native framework for building trading systems.
+
+Strategies, backtests, paper trading, and live execution sit behind one toolkit. AI agents discover the surface and drive it end-to-end through an MCP control plane. One strategy class runs backtest, paper, and live. Bindings for Python, Node.js, Codon, embedded JavaScript, and a stable C API.
 
 Documentation is available at [flox-foundation.github.io/flox](https://flox-foundation.github.io/flox)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,11 @@
 # FLOX
 
-**High-performance trading framework with bindings for Python, Node.js, Codon, and C++.**
+**AI-native framework for building trading systems.**
+
+Strategies, backtests, paper trading, and live execution sit
+behind one toolkit. AI agents discover the surface and drive it
+end-to-end through an MCP control plane. One strategy class
+runs backtest, paper, and live.
 
 [![GitHub](https://img.shields.io/badge/GitHub-FLOX--Foundation%2Fflox-blue?logo=github)](https://github.com/FLOX-Foundation/flox)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/FLOX-Foundation/flox/blob/main/LICENSE)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -15,7 +15,12 @@ This file concatenates the curated documentation set listed in `llms.txt`. Each 
 
 # FLOX
 
-**High-performance trading framework with bindings for Python, Node.js, Codon, and C++.**
+**AI-native framework for building trading systems.**
+
+Strategies, backtests, paper trading, and live execution sit
+behind one toolkit. AI agents discover the surface and drive it
+end-to-end through an MCP control plane. One strategy class
+runs backtest, paper, and live.
 
 [![GitHub](https://img.shields.io/badge/GitHub-FLOX--Foundation%2Fflox-blue?logo=github)](https://github.com/FLOX-Foundation/flox)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/FLOX-Foundation/flox/blob/main/LICENSE)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: FLOX
-site_description: High-performance trading framework with Python, Node.js, Codon, and C++ bindings
+site_description: AI-native framework for building trading systems.
 site_url: https://flox-foundation.github.io/flox/
 repo_url: https://github.com/FLOX-Foundation/flox
 repo_name: FLOX-Foundation/flox

--- a/node/README.md
+++ b/node/README.md
@@ -1,6 +1,8 @@
 # @flox-foundation/flox
 
-Node.js bindings for [FLOX](https://github.com/FLOX-Foundation/flox), a modular framework for building trading systems with polyglot strategy bindings and AI-friendly developer tools. Same strategy code goes from backtest to live without a rewrite step.
+Node.js bindings for [FLOX](https://github.com/FLOX-Foundation/flox) — an AI-native framework for building trading systems.
+
+AI agents discover the surface and drive it end-to-end through an MCP control plane. One strategy class runs backtest, paper, and live.
 
 Prebuilt binaries included for Linux x64, macOS arm64, Windows x64.
 

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flox-foundation/flox",
   "version": "0.6.1",
-  "description": "Node.js bindings for FLOX, a framework for building trading systems",
+  "description": "AI-native framework for building trading systems.",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
@@ -16,11 +16,31 @@
   },
   "keywords": [
     "trading",
-    "strategy",
     "backtest",
-    "flox"
+    "crypto",
+    "perpetual",
+    "cross-margin",
+    "liquidation",
+    "funding",
+    "paper-trading",
+    "live-trading",
+    "ccxt",
+    "venue-realistic",
+    "execution",
+    "market-making",
+    "mcp",
+    "ai-agent",
+    "indicators",
+    "technical-analysis",
+    "walk-forward",
+    "reproducibility",
+    "FLOX"
   ],
   "license": "MIT",
+  "homepage": "https://flox-foundation.github.io/flox/",
+  "bugs": {
+    "url": "https://github.com/FLOX-Foundation/flox/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/FLOX-Foundation/flox.git"

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,8 @@
 # flox-py
 
-Python bindings for [FLOX](https://github.com/FLOX-Foundation/flox), a modular framework for building trading systems with polyglot strategy bindings and AI-friendly developer tools. Same strategy code goes from backtest to live without a rewrite step.
+Python bindings for [FLOX](https://github.com/FLOX-Foundation/flox) — an AI-native framework for building trading systems.
+
+AI agents discover the surface and drive it end-to-end through an MCP control plane. One strategy class runs backtest, paper, and live.
 
 ## Install
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,21 +6,63 @@ build-backend = "scikit_build_core.build"
 name = "flox-py"
 version = "0.6.1"
 authors = [{name = "FLOX Foundation"}]
-description = "Python bindings for the Flox indicator library"
+description = "AI-native framework for building trading systems."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 dependencies = ["numpy"]
-keywords = ["trading", "backtest", "indicators", "technical-analysis"]
+keywords = [
+    "trading",
+    "backtest",
+    "crypto",
+    "perpetual",
+    "cross-margin",
+    "liquidation",
+    "funding",
+    "paper-trading",
+    "live-trading",
+    "ccxt",
+    "venue-realistic",
+    "execution",
+    "market-making",
+    "mcp",
+    "ai-agent",
+    "indicators",
+    "technical-analysis",
+    "walk-forward",
+    "monte-carlo",
+    "reproducibility",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Financial and Insurance Industry",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Topic :: Office/Business :: Financial :: Investment",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
 ]
 
+[project.optional-dependencies]
+ccxt = ["ccxt[pro]>=4.0"]
+mlflow = ["mlflow>=2.0"]
+mcp = ["mcp>=1.0"]
+
 [project.urls]
+Homepage = "https://flox-foundation.github.io/flox/"
+Documentation = "https://flox-foundation.github.io/flox/"
 Repository = "https://github.com/FLOX-Foundation/flox"
+Issues = "https://github.com/FLOX-Foundation/flox/issues"
+Changelog = "https://github.com/FLOX-Foundation/flox/releases"
 
 [project.scripts]
 flox = "flox_py.cli:main"


### PR DESCRIPTION
## Summary

Both package descriptions still claimed FLOX was an \"indicator library\" / \"framework for building trading systems\" — both predate the W15 round 4 + 5 backtest physics, the venue-realistic stack, paper / live trading via ccxt, and the AI-native MCP control plane.

- New description naming the actual surface
- Expanded keyword set (crypto, perpetual, cross-margin, liquidation, funding, paper-trading, live-trading, ccxt, venue-realistic, execution, market-making, mcp, ai-agent)
- PyPI: extra classifiers (Python 3.10/11/12, OSes, topic taxonomy), optional-dependencies for `ccxt`/`mlflow`/`mcp`, project URLs
- npm: homepage + bugs URLs

Versions left at 0.6.1 — release-prep PR, not a release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)