### PR TITLE
feat(replay): OptionQuote event type + OptionQuoteRecord

### DIFF
--- a/include/flox/replay/binary_format_v1.h
+++ b/include/flox/replay/binary_format_v1.h
@@ -23,8 +23,17 @@ enum class EventType : uint8_t
 {
   Trade = 1,
   BookSnapshot = 2,
-  BookDelta = 3
+  BookDelta = 3,
+  // Option side-channel: mark price, implied vol, index price, open interest.
+  // Additive — readers that predate this type skip the frame via FrameHeader.size
+  // (see MmapSegmentReader::next unknown-type branch), so old tapes/readers are
+  // unaffected and no format-version bump is needed.
+  OptionQuote = 4
 };
+
+// Fixed-point scale for implied volatility stored in OptionQuoteRecord.iv_raw.
+// 0.65 (65 vol points) -> 65000000. Matches the 1e8 convention used elsewhere.
+inline constexpr int64_t kIvScale = 100000000;
 
 namespace SegmentFlags
 {
@@ -93,6 +102,25 @@ struct alignas(8) TradeRecord
   uint16_t exchange_id{0};
 };
 static_assert(sizeof(TradeRecord) == 48, "TradeRecord must be 48 bytes");
+
+// Option side-channel quote. price_raw / index_price_raw use the same
+// PRICE_SCALE as TradeRecord; iv_raw uses kIvScale; open_interest_raw uses the
+// venue's contract/quantity scale (QUANTITY_SCALE). Fields are independent of
+// any trade — emitted whenever the venue publishes a mark/IV snapshot.
+struct alignas(8) OptionQuoteRecord
+{
+  int64_t exchange_ts_ns{0};
+  int64_t recv_ts_ns{0};
+  int64_t mark_price_raw{0};
+  int64_t index_price_raw{0};
+  int64_t iv_raw{0};
+  int64_t open_interest_raw{0};
+  uint32_t symbol_id{0};
+  uint8_t instrument{0};
+  uint8_t _pad{0};
+  uint16_t exchange_id{0};
+};
+static_assert(sizeof(OptionQuoteRecord) == 56, "OptionQuoteRecord must be 56 bytes");
 
 struct alignas(8) BookLevel
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ add_flox_test(test_adf)
 add_flox_test(test_autocorrelation)
 add_flox_test(test_black_scholes)
 add_flox_test(test_greeks)
+add_flox_test(test_option_quote_record)
 
 if(FLOX_BUILD_CAPI)
   add_flox_test(test_capi_registry)

--- a/tests/test_option_quote_record.cpp
+++ b/tests/test_option_quote_record.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+#include "flox/replay/binary_format_v1.h"
+
+using namespace flox::replay;
+
+TEST(OptionQuoteRecord, SizeAndAlignment)
+{
+  static_assert(sizeof(OptionQuoteRecord) == 56);
+  static_assert(alignof(OptionQuoteRecord) == 8);
+  EXPECT_EQ(sizeof(OptionQuoteRecord) % 8, 0u);
+}
+
+TEST(OptionQuoteRecord, EventTypeValue)
+{
+  EXPECT_EQ(static_cast<uint8_t>(EventType::OptionQuote), 4);
+}
+
+TEST(OptionQuoteRecord, IvScaleRoundTrip)
+{
+  const double iv = 0.6532;
+  const int64_t raw = static_cast<int64_t>(iv * kIvScale);
+  const double back = static_cast<double>(raw) / kIvScale;
+  EXPECT_NEAR(back, iv, 1.0 / kIvScale);
+}
+
+// Mirror the reader's unknown-frame skip logic (MmapSegmentReader::next) on a
+// hand-built buffer: an OptionQuote frame followed by a Trade frame. A consumer
+// that only understands Trade must skip the OptionQuote via FrameHeader.size and
+// still land on the Trade. This validates the additive/backward-compatible
+// design before the real writer/reader path is wired (W16.T012).
+TEST(OptionQuoteRecord, UnknownFrameSkippedByTradeOnlyConsumer)
+{
+  std::vector<std::byte> buf;
+  auto append = [&](const void* p, size_t n)
+  {
+    const auto* b = static_cast<const std::byte*>(p);
+    buf.insert(buf.end(), b, b + n);
+  };
+
+  // Frame 1: OptionQuote
+  OptionQuoteRecord oq{};
+  oq.exchange_ts_ns = 1000;
+  oq.iv_raw = static_cast<int64_t>(0.5 * kIvScale);
+  oq.symbol_id = 7;
+  FrameHeader fh1{};
+  fh1.size = sizeof(OptionQuoteRecord);
+  fh1.type = static_cast<uint8_t>(EventType::OptionQuote);
+  append(&fh1, sizeof(fh1));
+  append(&oq, sizeof(oq));
+
+  // Frame 2: Trade
+  TradeRecord tr{};
+  tr.exchange_ts_ns = 2000;
+  tr.price_raw = 12345;
+  tr.symbol_id = 7;
+  FrameHeader fh2{};
+  fh2.size = sizeof(TradeRecord);
+  fh2.type = static_cast<uint8_t>(EventType::Trade);
+  append(&fh2, sizeof(fh2));
+  append(&tr, sizeof(tr));
+
+  // Walk frames as a Trade-only consumer.
+  size_t pos = 0;
+  bool foundTrade = false;
+  while (pos + sizeof(FrameHeader) <= buf.size())
+  {
+    FrameHeader hdr;
+    std::memcpy(&hdr, buf.data() + pos, sizeof(FrameHeader));
+    const size_t frameSize = sizeof(FrameHeader) + hdr.size;
+    ASSERT_LE(pos + frameSize, buf.size());
+    if (hdr.type == static_cast<uint8_t>(EventType::Trade))
+    {
+      TradeRecord got;
+      std::memcpy(&got, buf.data() + pos + sizeof(FrameHeader), sizeof(TradeRecord));
+      EXPECT_EQ(got.exchange_ts_ns, 2000);
+      EXPECT_EQ(got.price_raw, 12345);
+      foundTrade = true;
+    }
+    // Unknown types (OptionQuote here) fall through and advance by frameSize.
+    pos += frameSize;
+  }
+  EXPECT_TRUE(foundTrade);
+}


### PR DESCRIPTION
## Summary
Adds EventType::OptionQuote (value 4) and a fixed 56-byte OptionQuoteRecord to the binary tape format. The record carries the option side-channel data a venue publishes alongside trades: mark price, implied vol, index price, and open interest. iv_raw uses a kIvScale of 1e8.

The Deribit importer currently drops mark_price, iv, and index_price because the floxlog schema had nowhere to put them. This record gives them a home, so a later importer change can preserve them and the vol-surface work has real implied vol to build on.

## Compatibility
Additive. Readers that predate the type skip the frame through FrameHeader.size (the unknown-type branch in MmapSegmentReader::next), so existing tapes and readers are unaffected and the format version does not bump. The 81 existing binary-log tests still pass.

## Tests
tests/test_option_quote_record.cpp: 4 gtest cases covering size and alignment, the event-type value, an iv-scale round-trip, and a trade-only consumer skipping an OptionQuote frame via FrameHeader.size.

## MCP impact
None. This is an internal binary-format addition with no Python surface, no C ABI export, and no doc page, so no bundled MCP data changes and no tools need updating.

W16-T011