### PR TITLE
feat(replay): write and read OptionQuote frames

### DIFF
--- a/include/flox/replay/abstract_event_reader.h
+++ b/include/flox/replay/abstract_event_reader.h
@@ -106,10 +106,7 @@ struct ReaderFilter
 
   bool passes(const ReplayEvent& event) const
   {
-    uint32_t symbol_id = (event.type == EventType::Trade)
-                             ? event.trade.symbol_id
-                             : event.book_header.symbol_id;
-    return passes(event.timestamp_ns, symbol_id);
+    return passes(event.timestamp_ns, event.symbolId());
   }
 };
 

--- a/include/flox/replay/readers/binary_log_reader.h
+++ b/include/flox/replay/readers/binary_log_reader.h
@@ -168,6 +168,23 @@ struct ReplayEvent
   BookRecordHeader book_header{};
   std::vector<BookLevel> bids;
   std::vector<BookLevel> asks;
+
+  OptionQuoteRecord option_quote{};
+
+  // Symbol id for the active record, whichever event type this is. Keeps
+  // symbol filtering correct as new record types are added.
+  uint32_t symbolId() const
+  {
+    switch (type)
+    {
+      case EventType::Trade:
+        return trade.symbol_id;
+      case EventType::OptionQuote:
+        return option_quote.symbol_id;
+      default:
+        return book_header.symbol_id;
+    }
+  }
 };
 
 struct SegmentInfo

--- a/include/flox/replay/writers/binary_log_writer.h
+++ b/include/flox/replay/writers/binary_log_writer.h
@@ -55,6 +55,7 @@ struct WriterStats
   uint64_t segments_created{0};
   uint64_t trades_written{0};
   uint64_t book_updates_written{0};
+  uint64_t option_quotes_written{0};
   uint64_t blocks_written{0};
   uint64_t uncompressed_bytes{0};
   uint64_t compressed_bytes{0};
@@ -72,6 +73,7 @@ class BinaryLogWriter
   BinaryLogWriter& operator=(BinaryLogWriter&&) noexcept;
 
   bool writeTrade(const TradeRecord& trade);
+  bool writeOptionQuote(const OptionQuoteRecord& quote);
   bool writeBook(const BookRecordHeader& header, std::span<const BookLevel> bids,
                  std::span<const BookLevel> asks);
 

--- a/src/replay/binary_log_reader.cpp
+++ b/src/replay/binary_log_reader.cpp
@@ -58,6 +58,12 @@ int64_t firstTimestampInBlock(const std::vector<std::byte>& data)
       std::memcpy(&bh, data.data() + offset, sizeof(BookRecordHeader));
       ts = bh.exchange_ts_ns;
     }
+    else if (type == EventType::OptionQuote && frame.size >= sizeof(OptionQuoteRecord))
+    {
+      OptionQuoteRecord oq;
+      std::memcpy(&oq, data.data() + offset, sizeof(OptionQuoteRecord));
+      ts = oq.exchange_ts_ns;
+    }
     if (ts > 0)
     {
       return ts;
@@ -97,6 +103,12 @@ int64_t lastTimestampInBlock(const std::vector<std::byte>& data)
       BookRecordHeader bh;
       std::memcpy(&bh, data.data() + offset, sizeof(BookRecordHeader));
       ts = bh.exchange_ts_ns;
+    }
+    else if (type == EventType::OptionQuote && frame.size >= sizeof(OptionQuoteRecord))
+    {
+      OptionQuoteRecord oq;
+      std::memcpy(&oq, data.data() + offset, sizeof(OptionQuoteRecord));
+      ts = oq.exchange_ts_ns;
     }
     if (ts > 0)
     {
@@ -709,8 +721,7 @@ bool BinaryLogReader::passesFilter(const ReplayEvent& event) const
   // Symbol filter
   if (!_config.symbols.empty())
   {
-    uint32_t symbol_id = (event.type == EventType::Trade) ? event.trade.symbol_id
-                                                          : event.book_header.symbol_id;
+    uint32_t symbol_id = event.symbolId();
     if (_config.symbols.find(symbol_id) == _config.symbols.end())
     {
       return false;
@@ -1615,8 +1626,7 @@ DatasetSummary BinaryLogReader::inspectWithSymbols(const std::filesystem::path& 
 
   reader.forEach([&summary](const ReplayEvent& event)
                  {
-    uint32_t symbol_id = (event.type == EventType::Trade) ? event.trade.symbol_id
-                                                          : event.book_header.symbol_id;
+    uint32_t symbol_id = event.symbolId();
     summary.symbols.insert(symbol_id);
     return true; });
 
@@ -1685,8 +1695,7 @@ std::set<uint32_t> BinaryLogReader::availableSymbols()
 
   forEach([&symbols](const ReplayEvent& event)
           {
-    uint32_t symbol_id = (event.type == EventType::Trade) ? event.trade.symbol_id
-                                                          : event.book_header.symbol_id;
+    uint32_t symbol_id = event.symbolId();
     symbols.insert(symbol_id);
     return true; });
 
@@ -1943,6 +1952,18 @@ bool BinaryLogIterator::parseFrame(EventType type, const std::byte* data, size_t
     }
     std::memcpy(&out.trade, data, sizeof(TradeRecord));
     out.timestamp_ns = out.trade.exchange_ts_ns;
+    out.bids.clear();
+    out.asks.clear();
+    return true;
+  }
+  else if (type == EventType::OptionQuote)
+  {
+    if (size < sizeof(OptionQuoteRecord))
+    {
+      return false;
+    }
+    std::memcpy(&out.option_quote, data, sizeof(OptionQuoteRecord));
+    out.timestamp_ns = out.option_quote.exchange_ts_ns;
     out.bids.clear();
     out.asks.clear();
     return true;

--- a/src/replay/binary_log_writer.cpp
+++ b/src/replay/binary_log_writer.cpp
@@ -443,6 +443,76 @@ bool BinaryLogWriter::writeTrade(const TradeRecord& trade)
   return ok;
 }
 
+bool BinaryLogWriter::writeOptionQuote(const OptionQuoteRecord& quote)
+{
+  std::lock_guard lock(_mutex);
+
+  if (!ensureOpen())
+  {
+    return false;
+  }
+
+  bool ok;
+  if (isCompressed())
+  {
+    ok = writeFrameToBlock(EventType::OptionQuote, &quote, sizeof(quote), quote.exchange_ts_ns);
+  }
+  else
+  {
+    const size_t frame_size = sizeof(FrameHeader) + sizeof(quote);
+    if (!maybeRotate(frame_size))
+    {
+      return false;
+    }
+
+    uint64_t frame_offset = _segment_bytes;
+
+    FrameHeader header{};
+    header.size = static_cast<uint32_t>(sizeof(quote));
+    header.crc32 = Crc32::compute(&quote, sizeof(quote));
+    header.type = static_cast<uint8_t>(EventType::OptionQuote);
+    header.rec_version = 1;
+
+    if (std::fwrite(&header, sizeof(header), 1, _file) != 1)
+    {
+      return false;
+    }
+    if (std::fwrite(&quote, sizeof(quote), 1, _file) != 1)
+    {
+      return false;
+    }
+
+    _segment_bytes += frame_size;
+    _stats.bytes_written += frame_size;
+    ++_stats.events_written;
+
+    if (_segment_header.first_event_ns == 0)
+    {
+      _segment_header.first_event_ns = quote.exchange_ts_ns;
+    }
+    _segment_header.last_event_ns = quote.exchange_ts_ns;
+    ++_segment_header.event_count;
+
+    if (_config.create_index)
+    {
+      if (_index_entries.empty() || _events_since_last_index >= _config.index_interval)
+      {
+        _index_entries.push_back(
+            IndexEntry{.timestamp_ns = quote.exchange_ts_ns, .file_offset = frame_offset});
+        _events_since_last_index = 0;
+      }
+      ++_events_since_last_index;
+    }
+    ok = true;
+  }
+
+  if (ok)
+  {
+    ++_stats.option_quotes_written;
+  }
+  return ok;
+}
+
 bool BinaryLogWriter::writeBook(const BookRecordHeader& hdr, std::span<const BookLevel> bids,
                                 std::span<const BookLevel> asks)
 {

--- a/src/replay/mmap_reader.cpp
+++ b/src/replay/mmap_reader.cpp
@@ -331,6 +331,15 @@ bool MmapSegmentReader::next(ReplayEvent& out)
     std::memcpy(&out.trade, payload, sizeof(TradeRecord));
     out.timestamp_ns = out.trade.exchange_ts_ns;
   }
+  else if (frame->type == static_cast<uint8_t>(EventType::OptionQuote))
+  {
+    if (frame->size < sizeof(OptionQuoteRecord))
+    {
+      return false;
+    }
+    std::memcpy(&out.option_quote, payload, sizeof(OptionQuoteRecord));
+    out.timestamp_ns = out.option_quote.exchange_ts_ns;
+  }
   else if (frame->type == static_cast<uint8_t>(EventType::BookSnapshot) ||
            frame->type == static_cast<uint8_t>(EventType::BookDelta))
   {
@@ -536,8 +545,7 @@ uint64_t MmapReader::forEach(EventCallback callback)
 
     while (reader->next(event))
     {
-      uint32_t symbol_id = (event.type == EventType::Trade) ? event.trade.symbol_id
-                                                            : event.book_header.symbol_id;
+      uint32_t symbol_id = event.symbolId();
 
       if (!passesFilter(event.timestamp_ns, symbol_id))
       {
@@ -590,8 +598,7 @@ uint64_t MmapReader::forEachFrom(int64_t start_ts_ns, EventCallback callback)
         continue;
       }
 
-      uint32_t symbol_id = (event.type == EventType::Trade) ? event.trade.symbol_id
-                                                            : event.book_header.symbol_id;
+      uint32_t symbol_id = event.symbolId();
 
       if (!passesFilter(event.timestamp_ns, symbol_id))
       {

--- a/src/replay/parallel_reader.cpp
+++ b/src/replay/parallel_reader.cpp
@@ -127,8 +127,7 @@ std::unique_ptr<SegmentBuffer> ParallelReader::readSegment(const SegmentInfo& se
     // Apply symbol filter
     if (!_config.symbols.empty())
     {
-      uint32_t symbol_id = (event.type == EventType::Trade) ? event.trade.symbol_id
-                                                            : event.book_header.symbol_id;
+      uint32_t symbol_id = event.symbolId();
       if (_config.symbols.find(symbol_id) == _config.symbols.end())
       {
         continue;
@@ -196,7 +195,7 @@ bool ParallelReader::passesFilter(const ReplayEvent& event) const
   if (!_config.symbols.empty())
   {
     uint32_t symbol_id =
-        (event.type == EventType::Trade) ? event.trade.symbol_id : event.book_header.symbol_id;
+        event.symbolId();
     if (_config.symbols.find(symbol_id) == _config.symbols.end())
     {
       return false;

--- a/src/replay/segment_ops.cpp
+++ b/src/replay/segment_ops.cpp
@@ -289,7 +289,7 @@ SplitResult SegmentOps::split(const std::filesystem::path& input_path, const Spl
     while (iter.next(event))
     {
       uint32_t symbol_id =
-          (event.type == EventType::Trade) ? event.trade.symbol_id : event.book_header.symbol_id;
+          event.symbolId();
       auto* writer = getOrCreateWriter(symbol_id);
 
       if (event.type == EventType::Trade)
@@ -531,7 +531,7 @@ ExportResult SegmentOps::exportDirectory(const std::filesystem::path& input_dir,
       if (!config.symbols.empty())
       {
         uint32_t sym =
-            (event.type == EventType::Trade) ? event.trade.symbol_id : event.book_header.symbol_id;
+            event.symbolId();
         if (config.symbols.find(sym) == config.symbols.end())
         {
           continue;
@@ -616,7 +616,7 @@ ExportResult SegmentOps::exportData(const std::filesystem::path& input_path,
       if (!config.symbols.empty())
       {
         uint32_t sym =
-            (event.type == EventType::Trade) ? event.trade.symbol_id : event.book_header.symbol_id;
+            event.symbolId();
         if (config.symbols.find(sym) == config.symbols.end())
         {
           return false;
@@ -691,7 +691,7 @@ ExportResult SegmentOps::exportData(const std::filesystem::path& input_path,
     if (!config.symbols.empty())
     {
       uint32_t sym =
-          (event.type == EventType::Trade) ? event.trade.symbol_id : event.book_header.symbol_id;
+          event.symbolId();
       if (config.symbols.find(sym) == config.symbols.end())
       {
         continue;
@@ -883,7 +883,7 @@ uint64_t SegmentOps::extractSymbols(const std::filesystem::path& input_path,
   auto predicate = [&symbols](const ReplayEvent& event)
   {
     uint32_t sym =
-        (event.type == EventType::Trade) ? event.trade.symbol_id : event.book_header.symbol_id;
+        event.symbolId();
     return symbols.find(sym) != symbols.end();
   };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,6 +126,7 @@ add_flox_test(test_autocorrelation)
 add_flox_test(test_black_scholes)
 add_flox_test(test_greeks)
 add_flox_test(test_option_quote_record)
+add_flox_test(test_option_quote_io)
 
 if(FLOX_BUILD_CAPI)
   add_flox_test(test_capi_registry)

--- a/tests/test_option_quote_io.cpp
+++ b/tests/test_option_quote_io.cpp
@@ -1,0 +1,144 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "flox/common.h"
+#include "flox/replay/readers/binary_log_reader.h"
+#include "flox/replay/writers/binary_log_writer.h"
+
+using namespace flox::replay;
+
+namespace
+{
+OptionQuoteRecord makeQuote(int i, uint32_t sym = 7)
+{
+  OptionQuoteRecord q{};
+  q.exchange_ts_ns = 1'000'000'000LL + i * 1'000'000LL;
+  q.recv_ts_ns = q.exchange_ts_ns + 100;
+  q.mark_price_raw = (3000LL + i) * 100000000LL;
+  q.index_price_raw = (3001LL + i) * 100000000LL;
+  q.iv_raw = static_cast<int64_t>((0.5 + i * 0.001) * kIvScale);
+  q.open_interest_raw = (1000LL + i) * 100000000LL;
+  q.symbol_id = sym;
+  q.instrument = static_cast<uint8_t>(flox::InstrumentType::Option);
+  return q;
+}
+}  // namespace
+
+class OptionQuoteIoTest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    _dir = std::filesystem::temp_directory_path() / "flox_test_option_quote_io";
+    std::filesystem::remove_all(_dir);
+    std::filesystem::create_directories(_dir);
+  }
+  void TearDown() override { std::filesystem::remove_all(_dir); }
+  std::filesystem::path _dir;
+};
+
+TEST_F(OptionQuoteIoTest, WriteAndReadUncompressed)
+{
+  {
+    WriterConfig config{.output_dir = _dir};
+    BinaryLogWriter writer(config);
+    for (int i = 0; i < 100; ++i)
+    {
+      EXPECT_TRUE(writer.writeOptionQuote(makeQuote(i)));
+    }
+    writer.close();
+    EXPECT_EQ(writer.stats().option_quotes_written, 100u);
+  }
+
+  ReaderConfig config{.data_dir = _dir};
+  BinaryLogReader reader(config);
+  int count = 0;
+  reader.forEach(
+      [&](const ReplayEvent& event)
+      {
+        EXPECT_EQ(event.type, EventType::OptionQuote);
+        const auto expected = makeQuote(count);
+        EXPECT_EQ(event.option_quote.exchange_ts_ns, expected.exchange_ts_ns);
+        EXPECT_EQ(event.option_quote.mark_price_raw, expected.mark_price_raw);
+        EXPECT_EQ(event.option_quote.iv_raw, expected.iv_raw);
+        EXPECT_EQ(event.option_quote.open_interest_raw, expected.open_interest_raw);
+        EXPECT_EQ(event.option_quote.symbol_id, 7u);
+        EXPECT_EQ(event.symbolId(), 7u);  // helper resolves option-quote symbol
+        ++count;
+        return true;
+      });
+  EXPECT_EQ(count, 100);
+}
+
+TEST_F(OptionQuoteIoTest, InterleavedTradesAndQuotesInTimestampOrder)
+{
+  {
+    WriterConfig config{.output_dir = _dir};
+    BinaryLogWriter writer(config);
+    for (int i = 0; i < 50; ++i)
+    {
+      TradeRecord t{};
+      t.exchange_ts_ns = 1'000'000'000LL + (2 * i) * 1'000'000LL;
+      t.price_raw = 100LL * 100000000LL;
+      t.symbol_id = 7;
+      EXPECT_TRUE(writer.writeTrade(t));
+
+      auto q = makeQuote(0);
+      q.exchange_ts_ns = 1'000'000'000LL + (2 * i + 1) * 1'000'000LL;
+      EXPECT_TRUE(writer.writeOptionQuote(q));
+    }
+    writer.close();
+  }
+
+  ReaderConfig config{.data_dir = _dir};
+  BinaryLogReader reader(config);
+  int trades = 0, quotes = 0;
+  int64_t last_ts = 0;
+  reader.forEach(
+      [&](const ReplayEvent& event)
+      {
+        EXPECT_GE(event.timestamp_ns, last_ts);  // non-decreasing
+        last_ts = event.timestamp_ns;
+        if (event.type == EventType::Trade)
+        {
+          ++trades;
+        }
+        else if (event.type == EventType::OptionQuote)
+        {
+          ++quotes;
+        }
+        return true;
+      });
+  EXPECT_EQ(trades, 50);
+  EXPECT_EQ(quotes, 50);
+}
+
+TEST_F(OptionQuoteIoTest, CompressedRoundTrip)
+{
+  {
+    WriterConfig config{.output_dir = _dir, .compression = CompressionType::LZ4};
+    BinaryLogWriter writer(config);
+    for (int i = 0; i < 100; ++i)
+    {
+      EXPECT_TRUE(writer.writeOptionQuote(makeQuote(i)));
+    }
+    writer.close();
+    EXPECT_EQ(writer.stats().option_quotes_written, 100u);
+  }
+
+  ReaderConfig config{.data_dir = _dir};
+  BinaryLogReader reader(config);
+  int count = 0;
+  reader.forEach(
+      [&](const ReplayEvent& event)
+      {
+        EXPECT_EQ(event.type, EventType::OptionQuote);
+        const auto expected = makeQuote(count);
+        EXPECT_EQ(event.option_quote.iv_raw, expected.iv_raw);
+        EXPECT_EQ(event.option_quote.mark_price_raw, expected.mark_price_raw);
+        ++count;
+        return true;
+      });
+  EXPECT_EQ(count, 100);
+}


### PR DESCRIPTION
## Summary
Wires the OptionQuoteRecord added in #338 through the writer and reader. BinaryLogWriter.writeOptionQuote serializes the frame on both the uncompressed and LZ4 block paths, mirroring writeTrade. ReplayEvent gains an option_quote field, and every reader (the mmap reader, the binary-log iterator, and the block timestamp scan) parses EventType::OptionQuote.

It also adds ReplayEvent::symbolId(), which returns the correct symbol field for the event type. The symbol-filter sites across the readers and segment_ops moved from a Trade-or-book ternary to this helper, so an option quote now filters by its own symbol instead of misreading the record bytes as a book header.

#338 defined the record but nothing could emit or replay it. This makes option quotes a first-class tape event, which the Deribit implied-vol importer (W16-T014) and the pybind read path (W16-T013) build on.

## Tests
tests/test_option_quote_io.cpp: a 100-quote uncompressed round-trip, interleaved trades and quotes read back in timestamp order, and an LZ4 compressed round-trip. Regression: test_binary_log (81) and test_replay_connector (7) still pass, and the replay-equivalence gate is green.

## MCP impact
None. This is an internal writer/reader change with no Python surface, no C ABI export, and no doc page, so no bundled MCP data changes and no tools need updating.

W16-T012