### PR TITLE
feat(archives): preserve Deribit option mark/iv/index as OptionQuote frames

### DIFF
--- a/python/flox_py/archives/deribit.py
+++ b/python/flox_py/archives/deribit.py
@@ -22,10 +22,12 @@ is left as a follow-up — the simpler single-instrument convert covers
 backtest research that pins to a specific option contract or rolls
 through a known series sequentially.
 
-`mark_price`, `iv`, and `index_price` are not representable in the
-current floxlog ``TradeRecord`` schema. The importer drops them at
-read time; researchers needing those side channels should keep the
-source CSV alongside the tape and re-join in numpy when needed.
+For option instruments, the `mark_price`, `iv`, and `index_price`
+columns are preserved as OptionQuote frames alongside the trades and
+read back via ``DataReader.read_option_quotes_from``. `iv` is stored as
+the archive provides it (Deribit reports trade IV in percent), so the
+value round-trips the source and the consumer applies its own unit
+convention. Open interest is not in the trade archive and stays 0.
 """
 from __future__ import annotations
 
@@ -127,12 +129,16 @@ def _open_csv(path: Path) -> Tuple[io.TextIOBase, "object"]:
     return f, f
 
 
-def _iter_rows(path: Path) -> Iterator[Tuple[int, float, float, int, int]]:
-    """Yield ``(trade_id, price, qty, ts_ns, side)`` rows from a
-    Deribit archive CSV. Skips the leading header row.
+def _iter_rows(
+    path: Path,
+) -> Iterator[Tuple[int, float, float, int, int, float, float, float]]:
+    """Yield ``(trade_id, price, qty, ts_ns, side, mark, iv, index)`` rows from
+    a Deribit archive CSV. Skips the leading header row.
 
-    Deribit columns (post-2022): trade_id, timestamp_ms, instrument,
-    side, price, amount, mark_price, iv, index_price."""
+    Deribit columns (post-2022): trade_id, timestamp_ms, instrument, side,
+    price, amount, mark_price, iv, index_price. ``mark``/``index`` are prices;
+    ``iv`` is the implied volatility in percent (e.g. 65.5). Missing side
+    channels (older trade-only rows) yield NaN."""
     stream, ctx = _open_csv(path)
     try:
         reader = csv.reader(stream)
@@ -150,9 +156,19 @@ def _iter_rows(path: Path) -> Iterator[Tuple[int, float, float, int, int]]:
                 amount = float(row[5])
             except (ValueError, IndexError):
                 continue
+
+            def _opt(idx: int) -> float:
+                try:
+                    return float(row[idx]) if len(row) > idx and row[idx] != "" else float("nan")
+                except (ValueError, IndexError):
+                    return float("nan")
+
+            mark = _opt(6)
+            iv = _opt(7)
+            index = _opt(8)
             side = _SIDE_BUY if side_token == "buy" else _SIDE_SELL
             ts_ns = ts_ms * 1_000_000
-            yield (trade_id, price, amount, ts_ns, side)
+            yield (trade_id, price, amount, ts_ns, side, mark, iv, index)
     finally:
         try:
             ctx.close()
@@ -306,7 +322,7 @@ def trades_to_floxlog(
 
     last_id = _existing_max_trade_id(out_tape, symbol_id) if append else 0
 
-    rows: List[Tuple[int, float, float, int, int]] = []
+    rows: List[Tuple[int, float, float, int, int, float, float, float]] = []
     rows_read = 0
     rows_skipped = 0
     for r in _iter_rows(csv_path):
@@ -351,6 +367,26 @@ def trades_to_floxlog(
             prices=prices, quantities=qty,
             trade_ids=ids, symbol_ids=sym_ids, sides=sides,
         )
+        # For option instruments, preserve the mark/iv/index side channels as
+        # OptionQuote frames. iv is stored exactly as the Deribit archive
+        # provides it (Deribit reports trade IV in percent), so the tape value
+        # round-trips the source; a consumer applies its own unit convention.
+        # Open interest is not in the trade archive, so it stays 0. Rows
+        # missing every side channel (all NaN) are skipped.
+        if market == "option":
+            mark = np.fromiter((r[5] for r in rows), dtype=np.float64, count=n)
+            iv = np.fromiter((r[6] for r in rows), dtype=np.float64, count=n)
+            index = np.fromiter((r[7] for r in rows), dtype=np.float64, count=n)
+            valid = ~(np.isnan(mark) & np.isnan(iv) & np.isnan(index))
+            if valid.any():
+                writer.write_option_quotes(
+                    exchange_ts_ns=ts_ns[valid], recv_ts_ns=ts_ns[valid],
+                    mark_prices=np.nan_to_num(mark[valid]),
+                    index_prices=np.nan_to_num(index[valid]),
+                    ivs=np.nan_to_num(iv[valid]),
+                    open_interest=np.zeros(int(valid.sum()), dtype=np.float64),
+                    symbol_ids=sym_ids[valid],
+                )
     finally:
         writer.close()
 

--- a/python/tests/test_deribit_archive.py
+++ b/python/tests/test_deribit_archive.py
@@ -117,6 +117,35 @@ class DeribitOptionTests(unittest.TestCase):
         self.assertEqual(sym["name"], "BTC-29MAR24-50000-C")
         self.assertEqual(sym["base_asset"], "BTC")
 
+    def test_option_quotes_preserved(self) -> None:
+        # mark/iv/index from the option CSV are kept as OptionQuote frames
+        # instead of dropped, and read back via read_option_quotes_from.
+        g = self.tmp / "BTC-29MAR24-50000-C-2024-01-15.csv.gz"
+        _build_gz(g, _ROWS_OPTION)
+        deribit.trades_to_floxlog(
+            g, self.tape, symbol_id=7,
+            symbol_name="BTC-29MAR24-50000-C", market="option",
+        )
+        reader = flox_py.DataReader(str(self.tape))
+        quotes = reader.read_option_quotes_from(0)
+        self.assertEqual(quotes.size, 2)
+        # Source row 200: mark=0.0498, iv=0.55, index=42000.0
+        self.assertAlmostEqual(quotes["mark_price_raw"][0] / 1e8, 0.0498, places=6)
+        self.assertAlmostEqual(quotes["iv_raw"][0] / 1e8, 0.55, places=6)
+        self.assertAlmostEqual(quotes["index_price_raw"][0] / 1e8, 42_000.0, places=2)
+        self.assertEqual(int(quotes["symbol_id"][0]), 7)
+        # Trades are still written alongside the quotes.
+        self.assertEqual(reader.read_trades().size, 2)
+
+    def test_perpetual_emits_no_option_quotes(self) -> None:
+        g = self.tmp / "BTC-PERPETUAL-2024-01-15.csv.gz"
+        _build_gz(g, _ROWS_PERP)
+        deribit.trades_to_floxlog(
+            g, self.tape, symbol_id=7, symbol_name="BTC-PERPETUAL", market="perpetual",
+        )
+        reader = flox_py.DataReader(str(self.tape))
+        self.assertEqual(reader.read_option_quotes_from(0).size, 0)
+
     def test_protocol_compliance(self) -> None:
         self.assertIsInstance(deribit, ArchiveReader)
 


### PR DESCRIPTION
## Summary
The Deribit importer no longer drops mark_price, iv, and index_price for option instruments. _iter_rows now yields those columns, and convert() writes them as OptionQuote frames alongside the trades for the option market, readable via DataReader.read_option_quotes_from.

These side channels are the inputs the vol-surface and greeks work need. Until now the floxlog schema had nowhere to put them, so the importer discarded them at read time. #338, #339, and #340 gave them a tape representation and a Python read path; this connects the importer to it.

## Notes
iv is stored exactly as the archive provides it (Deribit reports trade IV in percent), so the value round-trips the source and the consumer applies its own unit convention. Open interest is not in the trade archive and stays 0. Perpetual and future imports emit no option quotes.

## Tests
test_deribit_archive.py: an option import preserves mark/iv/index and reads them back, trades are still written alongside the quotes, and a perpetual import emits no option quotes. 7 tests pass.

## MCP impact
None. This is an internal importer change with no new Python API surface, no C ABI export, and no doc page, so no bundled MCP data changes and no tools need updating.

W16-T014