### PR TITLE
feat(archives): Deribit option chain loading and querying

### DIFF
--- a/python/flox_py/archives/deribit.py
+++ b/python/flox_py/archives/deribit.py
@@ -45,7 +45,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Sequence, Tuple, Union
 
 from . import _cache
 
@@ -503,8 +503,118 @@ def range_to_floxlog(
     return agg
 
 
+# ─── Option chain loading ────────────────────────────────────────────────────
+
+def parse_option_instrument(name: str) -> Tuple[str, date, float, str]:
+    """Parse a Deribit option instrument id into (underlying, expiry, strike,
+    option_type). ``BTC-29MAR24-50000-C`` -> ("BTC", date(2024,3,29), 50000.0,
+    "C"). option_type is "C" (call) or "P" (put). Raises ValueError on a
+    non-option id (perp/future have a different shape)."""
+    parts = name.split("-")
+    if len(parts) != 4:
+        raise ValueError(f"not an option instrument: {name!r}")
+    underlying, expiry_s, strike_s, opt = parts
+    opt = opt.upper()
+    if opt not in ("C", "P"):
+        raise ValueError(f"unknown option type {opt!r} in {name!r}")
+    # Deribit expiry is DDMMMYY, e.g. 29MAR24. strptime wants title-case month.
+    expiry = datetime.strptime(expiry_s.title(), "%d%b%y").date()
+    return underlying, expiry, float(strike_s), opt
+
+
+@dataclass(frozen=True)
+class OptionContract:
+    instrument: str
+    underlying: str
+    expiry: date
+    strike: float
+    option_type: str  # "C" or "P"
+    tape: Path
+
+
+class OptionChain:
+    """A queryable set of option contracts, each backed by its own floxlog tape.
+    Filter by expiry / strike / type, take an as-of-date slice (contracts not
+    yet expired), and walk expiries for series rolls."""
+
+    def __init__(self, contracts: Sequence[OptionContract]) -> None:
+        self._contracts: List[OptionContract] = list(contracts)
+
+    def __len__(self) -> int:
+        return len(self._contracts)
+
+    def __iter__(self) -> Iterator[OptionContract]:
+        return iter(self._contracts)
+
+    def expiries(self) -> List[date]:
+        return sorted({c.expiry for c in self._contracts})
+
+    def strikes(self, expiry: Optional[date] = None) -> List[float]:
+        pool = self._contracts if expiry is None else [c for c in self._contracts
+                                                       if c.expiry == expiry]
+        return sorted({c.strike for c in pool})
+
+    def query(self, expiry: Optional[date] = None, strike: Optional[float] = None,
+              option_type: Optional[str] = None) -> List[OptionContract]:
+        opt = option_type.upper() if option_type else None
+        return [c for c in self._contracts
+                if (expiry is None or c.expiry == expiry)
+                and (strike is None or c.strike == strike)
+                and (opt is None or c.option_type == opt)]
+
+    def get(self, expiry: date, strike: float, option_type: str) -> Optional[OptionContract]:
+        hits = self.query(expiry=expiry, strike=strike, option_type=option_type)
+        return hits[0] if hits else None
+
+    def as_of(self, on: DateLike) -> "OptionChain":
+        """Contracts live on ``on`` (expiry on or after that date)."""
+        d = _coerce_day(on)
+        return OptionChain([c for c in self._contracts if c.expiry >= d])
+
+    def next_expiry_after(self, on: DateLike) -> Optional[date]:
+        """First expiry strictly after ``on`` — the contract a series rolls into."""
+        d = _coerce_day(on)
+        later = [e for e in self.expiries() if e > d]
+        return later[0] if later else None
+
+
+def load_option_chain(
+    instruments: Sequence[str],
+    day: DateLike,
+    out_root: Union[str, Path],
+    *,
+    mirror: Union[str, Path],
+    exchange_id: int = 0,
+    compression: str = "none",
+) -> OptionChain:
+    """Convert each option instrument's archive for ``day`` into its own tape
+    under ``out_root/<instrument>`` and return an OptionChain over them. CSVs are
+    read from ``mirror`` (Deribit layout) and downloaded there if absent. Each
+    instrument gets a distinct symbol_id (its index + 1)."""
+    day = _coerce_day(day)
+    out_root = Path(out_root).expanduser()
+    mirror = Path(mirror).expanduser()
+    contracts: List[OptionContract] = []
+    for i, inst in enumerate(instruments):
+        underlying, expiry, strike, opt = parse_option_instrument(inst)
+        csv_path = _mirror_path(mirror, inst, "option", day)
+        if not csv_path.exists():
+            _download(_archive_url(inst, "option", day), csv_path)
+        tape = out_root / inst
+        trades_to_floxlog(
+            csv_path, tape, symbol_id=i + 1, symbol_name=inst, market="option",
+            exchange_id=exchange_id, compression=compression,
+        )
+        contracts.append(OptionContract(inst, underlying, expiry, strike, opt, tape))
+    return OptionChain(contracts)
+
+
 __all__ = [
     "ConvertStats",
     "trades_to_floxlog",
     "range_to_floxlog",
+    "parse_option_instrument",
+    "OptionContract",
+    "OptionChain",
+    "load_option_chain",
 ]

--- a/python/tests/test_option_chain.py
+++ b/python/tests/test_option_chain.py
@@ -1,0 +1,113 @@
+"""
+python/tests/test_option_chain.py — Deribit option chain loading and querying.
+
+Builds a synthetic mirror of a few option instruments (no network), loads them
+into a chain, and exercises parse / query / as-of / roll.
+
+Run from repo root:
+    PYTHONPATH=build/python python3 python/tests/test_option_chain.py
+or against an installed module:
+    python3 python/tests/test_option_chain.py
+"""
+
+import sys
+import os
+import gzip
+import tempfile
+import shutil
+import unittest
+from datetime import date
+from pathlib import Path
+
+build_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'build', 'python')
+if os.path.isdir(build_dir):
+    sys.path.insert(0, os.path.abspath(build_dir))
+
+from flox_py.archives import deribit
+
+_CSV_HEADER = ("trade_id,timestamp_ms,instrument,side,price,amount,"
+               "mark_price,iv,index_price\n")
+
+# (instrument, [rows])
+_INSTRUMENTS = {
+    "BTC-29MAR24-50000-C": [
+        (200, 1_700_000_000_000, "BTC-29MAR24-50000-C", "buy", 0.05, 10.0, 0.0498, 0.55, 42_000.0),
+        (201, 1_700_000_001_000, "BTC-29MAR24-50000-C", "sell", 0.051, 5.0, 0.0511, 0.56, 42_010.0),
+    ],
+    "BTC-29MAR24-50000-P": [
+        (300, 1_700_000_000_500, "BTC-29MAR24-50000-P", "buy", 0.04, 8.0, 0.0399, 0.60, 42_005.0),
+    ],
+    "BTC-26APR24-55000-C": [
+        (400, 1_700_000_002_000, "BTC-26APR24-55000-C", "buy", 0.03, 3.0, 0.0301, 0.62, 42_020.0),
+    ],
+}
+_DAY = "2024-01-15"
+
+
+def _build_mirror(root: Path) -> None:
+    for inst, rows in _INSTRUMENTS.items():
+        d = root / "option" / inst
+        d.mkdir(parents=True, exist_ok=True)
+        with gzip.open(d / f"{inst}-{_DAY}.csv.gz", "wt") as f:
+            f.write(_CSV_HEADER)
+            for r in rows:
+                f.write(",".join(str(x) for x in r) + "\n")
+
+
+class OptionChainTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="opt-chain-"))
+        self.mirror = self.tmp / "mirror"
+        self.out = self.tmp / "tapes"
+        _build_mirror(self.mirror)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_parse_instrument(self):
+        u, e, k, o = deribit.parse_option_instrument("BTC-29MAR24-50000-C")
+        self.assertEqual(u, "BTC")
+        self.assertEqual(e, date(2024, 3, 29))
+        self.assertEqual(k, 50000.0)
+        self.assertEqual(o, "C")
+        with self.assertRaises(ValueError):
+            deribit.parse_option_instrument("BTC-PERPETUAL")
+
+    def test_load_and_query(self):
+        chain = deribit.load_option_chain(
+            list(_INSTRUMENTS), _DAY, self.out, mirror=self.mirror,
+        )
+        self.assertEqual(len(chain), 3)
+        self.assertEqual(chain.expiries(), [date(2024, 3, 29), date(2024, 4, 26)])
+        self.assertEqual(chain.strikes(date(2024, 3, 29)), [50000.0])
+
+        # Query by expiry/type.
+        mar_calls = chain.query(expiry=date(2024, 3, 29), option_type="C")
+        self.assertEqual(len(mar_calls), 1)
+        self.assertEqual(mar_calls[0].instrument, "BTC-29MAR24-50000-C")
+
+        # get() resolves a single contract and its tape is readable.
+        import flox_py
+        c = chain.get(date(2024, 3, 29), 50000.0, "P")
+        self.assertIsNotNone(c)
+        quotes = flox_py.DataReader(str(c.tape)).read_option_quotes_from(0)
+        self.assertEqual(quotes.size, 1)
+        self.assertAlmostEqual(quotes["iv_raw"][0] / 1e8, 0.60, places=6)
+
+    def test_as_of_and_roll(self):
+        chain = deribit.load_option_chain(
+            list(_INSTRUMENTS), _DAY, self.out, mirror=self.mirror,
+        )
+        # Both expiries live before March.
+        self.assertEqual(len(chain.as_of("2024-01-15")), 3)
+        # After the March expiry only the April contract remains live.
+        live_after_mar = chain.as_of("2024-03-30")
+        self.assertEqual(len(live_after_mar), 1)
+        self.assertEqual(live_after_mar.expiries(), [date(2024, 4, 26)])
+        # Roll: the expiry a March position rolls into is April.
+        self.assertEqual(chain.next_expiry_after("2024-03-29"), date(2024, 4, 26))
+        self.assertIsNone(chain.next_expiry_after("2024-04-26"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds load_option_chain, which converts each option instrument's archive for a date into its own tape and returns an OptionChain over them. parse_option_instrument decodes a Deribit option id (BTC-29MAR24-50000-C into underlying, expiry, strike, type). OptionChain filters by expiry, strike, and type, takes an as-of-date slice of live contracts, and reports the next expiry for series rolls.

Importers convert one instrument per call, but options research works on a whole chain: skew across strikes at one expiry, term structure across expiries, and rolling a position from one expiry into the next. This gives that a single queryable entry point on top of the per-instrument importer.

## Tests
python/tests/test_option_chain.py: 3 tests over a synthetic three-instrument mirror with no network — instrument parsing, load plus query by expiry/strike/type with a tape read-back, and the as-of slice plus roll detection.

## MCP impact
None. These are pure-Python archive helpers with no pybind surface, no C ABI export, and no doc page, so no bundled MCP data changes and no tools need updating.

W16-T015