### PR TITLE
feat(engine): SymbolInfo contract spec — multiplier, settlement, exercise

### DIFF
--- a/include/flox/common.h
+++ b/include/flox/common.h
@@ -35,6 +35,18 @@ enum class OptionType
   PUT
 };
 
+enum class SettlementType
+{
+  Cash,
+  Physical
+};
+
+enum class ExerciseStyle
+{
+  European,
+  American
+};
+
 enum class OrderType : uint8_t
 {
   LIMIT = 0,

--- a/include/flox/engine/symbol_registry.h
+++ b/include/flox/engine/symbol_registry.h
@@ -39,6 +39,14 @@ struct SymbolInfo
   std::optional<Price> strike;
   std::optional<TimePoint> expiry;
   std::optional<OptionType> optionType;
+
+  // Contract spec. Defaults preserve spot/perp behavior: a 1.0 multiplier, cash
+  // settlement, European exercise. Options override these per the venue
+  // (US equity 100x, physical-settled American; crypto 1x, cash, European).
+  double contractMultiplier{1.0};
+  SettlementType settlementType{SettlementType::Cash};
+  ExerciseStyle exerciseStyle{ExerciseStyle::European};
+  std::optional<std::string> settlementCcy;
 };
 
 class SymbolRegistry : public ISubsystem

--- a/src/engine/symbol_registry.cpp
+++ b/src/engine/symbol_registry.cpp
@@ -11,6 +11,7 @@
 #include "flox/util/performance/profile.h"
 
 #include <cstdio>
+#include <cstring>
 #include <optional>
 #include <span>
 
@@ -371,6 +372,16 @@ bool SymbolRegistry::saveToFile(const std::filesystem::path& path) const
       std::fprintf(f, ", \"option_type\": %d", static_cast<int>(*sym.optionType));
     }
 
+    std::fprintf(f,
+                 ", \"contract_multiplier\": %.10g, \"settlement_type\": %d, "
+                 "\"exercise_style\": %d",
+                 sym.contractMultiplier, static_cast<int>(sym.settlementType),
+                 static_cast<int>(sym.exerciseStyle));
+    if (sym.settlementCcy.has_value())
+    {
+      std::fprintf(f, ", \"settlement_ccy\": \"%s\"", sym.settlementCcy->c_str());
+    }
+
     std::fprintf(f, "}%s\n", (++count < _symbols.size()) ? "," : "");
   }
 
@@ -480,6 +491,33 @@ bool SymbolRegistry::loadFromFile(const std::filesystem::path& path)
       info.optionType = static_cast<OptionType>(std::stoi(content.substr(opt_start)));
     }
 
+    // Contract spec (older files omit these; defaults already on `info`).
+    size_t mult_start = content.find("\"contract_multiplier\":", pos);
+    if (mult_start != std::string::npos && mult_start < entry_end)
+    {
+      info.contractMultiplier = std::stod(content.substr(mult_start + 22));
+    }
+    size_t settle_start = content.find("\"settlement_type\":", pos);
+    if (settle_start != std::string::npos && settle_start < entry_end)
+    {
+      info.settlementType = static_cast<SettlementType>(std::stoi(content.substr(settle_start + 18)));
+    }
+    size_t ex_start = content.find("\"exercise_style\":", pos);
+    if (ex_start != std::string::npos && ex_start < entry_end)
+    {
+      info.exerciseStyle = static_cast<ExerciseStyle>(std::stoi(content.substr(ex_start + 17)));
+    }
+    size_t ccy_start = content.find("\"settlement_ccy\": \"", pos);
+    if (ccy_start != std::string::npos && ccy_start < entry_end)
+    {
+      ccy_start += 19;
+      size_t ccy_end = content.find('"', ccy_start);
+      if (ccy_end != std::string::npos)
+      {
+        info.settlementCcy = content.substr(ccy_start, ccy_end - ccy_start);
+      }
+    }
+
     // Add to registry
     std::string key = info.exchange + ":" + info.symbol;
     _map[key] = info.id;
@@ -512,7 +550,9 @@ bool SymbolRegistry::loadFromFile(const std::filesystem::path& path)
 //   [1 byte] option_type (if flag set)
 
 static constexpr uint32_t kSymbolRegistryMagic = 0x47455253;  // "SREG"
-static constexpr uint32_t kSymbolRegistryVersion = 2;
+// v3 adds the contract spec (multiplier / settlement_type / exercise_style /
+// settlement_ccy). v2 files load with defaults for those.
+static constexpr uint32_t kSymbolRegistryVersion = 3;
 
 std::vector<std::byte> SymbolRegistry::serialize() const
 {
@@ -543,6 +583,16 @@ std::vector<std::byte> SymbolRegistry::serialize() const
     for (int i = 0; i < 8; ++i)
     {
       result.push_back(static_cast<std::byte>((v >> (i * 8)) & 0xFF));
+    }
+  };
+
+  auto write_f64 = [&result](double d)
+  {
+    int64_t bits;
+    std::memcpy(&bits, &d, sizeof(bits));
+    for (int i = 0; i < 8; ++i)
+    {
+      result.push_back(static_cast<std::byte>((bits >> (i * 8)) & 0xFF));
     }
   };
 
@@ -582,6 +632,10 @@ std::vector<std::byte> SymbolRegistry::serialize() const
     {
       flags |= 0x04;
     }
+    if (sym.settlementCcy.has_value())
+    {
+      flags |= 0x08;
+    }
     write_u8(flags);
 
     if (sym.strike.has_value())
@@ -598,6 +652,15 @@ std::vector<std::byte> SymbolRegistry::serialize() const
     if (sym.optionType.has_value())
     {
       write_u8(static_cast<uint8_t>(*sym.optionType));
+    }
+
+    // v3 contract spec.
+    write_f64(sym.contractMultiplier);
+    write_u8(static_cast<uint8_t>(sym.settlementType));
+    write_u8(static_cast<uint8_t>(sym.exerciseStyle));
+    if (sym.settlementCcy.has_value())
+    {
+      write_string(*sym.settlementCcy);
     }
   }
 
@@ -661,6 +724,14 @@ bool SymbolRegistry::deserialize(std::span<const std::byte> data)
     return v;
   };
 
+  auto read_f64 = [&read_i64]() -> double
+  {
+    int64_t bits = read_i64();
+    double d;
+    std::memcpy(&d, &bits, sizeof(d));
+    return d;
+  };
+
   auto read_string = [&data, &pos, &read_u16]() -> std::string
   {
     uint16_t len = read_u16();
@@ -685,7 +756,7 @@ bool SymbolRegistry::deserialize(std::span<const std::byte> data)
   }
 
   uint32_t version = read_u32();
-  if (version != 1 && version != 2)
+  if (version != 1 && version != 2 && version != 3)
   {
     return false;
   }
@@ -723,6 +794,17 @@ bool SymbolRegistry::deserialize(std::span<const std::byte> data)
     if (flags & 0x04)
     {
       info.optionType = static_cast<OptionType>(read_u8());
+    }
+
+    if (version >= 3)
+    {
+      info.contractMultiplier = read_f64();
+      info.settlementType = static_cast<SettlementType>(read_u8());
+      info.exerciseStyle = static_cast<ExerciseStyle>(read_u8());
+      if (flags & 0x08)
+      {
+        info.settlementCcy = read_string();
+      }
     }
 
     std::string key = info.exchange + ":" + info.symbol;

--- a/tests/test_symbol_registry.cpp
+++ b/tests/test_symbol_registry.cpp
@@ -145,6 +145,72 @@ TEST(SymbolRegistryTest, RegisterOptionAndFutureSymbols)
   EXPECT_EQ(futOptInfo->type, InstrumentType::Future);
 }
 
+TEST(SymbolRegistryTest, ContractSpecDefaultsAndRoundTrip)
+{
+  SymbolRegistry registry;
+
+  // Plain perp (registered with a bare SymbolInfo) keeps the defaults.
+  SymbolInfo perpInfo;
+  perpInfo.exchange = "bybit";
+  perpInfo.symbol = "BTCUSDT";
+  perpInfo.type = InstrumentType::Future;
+  auto perpId = registry.registerSymbol(perpInfo);
+  auto perp = registry.getSymbolInfo(perpId);
+  ASSERT_TRUE(perp.has_value());
+  EXPECT_DOUBLE_EQ(perp->contractMultiplier, 1.0);
+  EXPECT_EQ(perp->settlementType, SettlementType::Cash);
+  EXPECT_EQ(perp->exerciseStyle, ExerciseStyle::European);
+  EXPECT_FALSE(perp->settlementCcy.has_value());
+
+  // Equity option overrides the spec.
+  SymbolInfo opt;
+  opt.exchange = "cboe";
+  opt.symbol = "SPY-20240920-450-C";
+  opt.type = InstrumentType::Option;
+  opt.strike = Price::fromDouble(450.0);
+  opt.optionType = OptionType::CALL;
+  opt.contractMultiplier = 100.0;
+  opt.settlementType = SettlementType::Physical;
+  opt.exerciseStyle = ExerciseStyle::American;
+  opt.settlementCcy = "USD";
+  auto optId = registry.registerSymbol(opt);
+
+  auto got = registry.getSymbolInfo(optId);
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->contractMultiplier, 100.0);
+  EXPECT_EQ(got->settlementType, SettlementType::Physical);
+  EXPECT_EQ(got->exerciseStyle, ExerciseStyle::American);
+  ASSERT_TRUE(got->settlementCcy.has_value());
+  EXPECT_EQ(*got->settlementCcy, "USD");
+
+  // Binary serialize / deserialize preserves the spec.
+  auto bytes = registry.serialize();
+  SymbolRegistry restored;
+  ASSERT_TRUE(restored.deserialize(bytes));
+  auto rOpt = restored.getSymbolInfo(optId);
+  ASSERT_TRUE(rOpt.has_value());
+  EXPECT_DOUBLE_EQ(rOpt->contractMultiplier, 100.0);
+  EXPECT_EQ(rOpt->settlementType, SettlementType::Physical);
+  EXPECT_EQ(rOpt->exerciseStyle, ExerciseStyle::American);
+  ASSERT_TRUE(rOpt->settlementCcy.has_value());
+  EXPECT_EQ(*rOpt->settlementCcy, "USD");
+
+  // JSON file save / load preserves the spec.
+  auto path = std::filesystem::temp_directory_path() / "test_contract_spec.json";
+  std::filesystem::remove(path);
+  ASSERT_TRUE(registry.saveToFile(path));
+  SymbolRegistry fromFile;
+  ASSERT_TRUE(fromFile.loadFromFile(path));
+  auto fOpt = fromFile.getSymbolInfo(optId);
+  ASSERT_TRUE(fOpt.has_value());
+  EXPECT_DOUBLE_EQ(fOpt->contractMultiplier, 100.0);
+  EXPECT_EQ(fOpt->settlementType, SettlementType::Physical);
+  EXPECT_EQ(fOpt->exerciseStyle, ExerciseStyle::American);
+  ASSERT_TRUE(fOpt->settlementCcy.has_value());
+  EXPECT_EQ(*fOpt->settlementCcy, "USD");
+  std::filesystem::remove(path);
+}
+
 TEST(SymbolRegistryTest, SaveAndLoadFromFile)
 {
   std::filesystem::path tempPath = std::filesystem::temp_directory_path() / "test_registry.json";


### PR DESCRIPTION
## Summary
Adds the instrument-spec fields option execution and settlement need: contractMultiplier (default 1.0), settlementType (Cash/Physical), exerciseStyle (European/American), and an optional settlementCcy on SymbolInfo, plus the two enums next to OptionType in common.h. Both the JSON and binary registry serializers persist them — the binary format is bumped to v3, and v2 files load with defaults.

SymbolInfo already carries strike/expiry/optionType but nothing describing how a contract is sized, settled, or exercised. The premium and multiplier accounting (W16-T017), expiry settlement (W16-T018), and exercise/assignment (W16-T019) all read these. Defaults keep every spot/perp/future symbol behaving exactly as before.

This is the first of four subtasks decomposed from option execution and settlement.

## Tests
test_symbol_registry.cpp: defaults on a plain symbol, an equity option overriding all four fields, and round-trips through both binary serialize/deserialize and JSON saveToFile/loadFromFile. Regression: test_account and test_backtest stay green.

## MCP impact
None. This is a C++ data-model change with no Python surface (the new fields are not exposed in pybind, consistent with the existing strike/expiry/optionType fields), no C ABI export, and no doc page. sync_mcp_data --check passes, so no bundled data changes.

W16-T016