### PR TITLE
feat(backtest): American option exercise + assignment mechanics

### DIFF
--- a/include/flox/backtest/option_exercise_engine.h
+++ b/include/flox/backtest/option_exercise_engine.h
@@ -1,0 +1,123 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include "flox/common.h"
+#include "flox/engine/symbol_registry.h"
+#include "flox/position/position_group.h"
+#include "flox/pricing/american.h"
+
+#include <cstdint>
+
+// Exercise and assignment for American options. The expiry engine
+// (option_settlement_engine.h) handles European-style cash settlement at expiry;
+// this handles the early-exercise right an American option carries before then.
+//
+// Exercising delivers the underlying at the strike and closes the option leg:
+//   - Long call  -> buy underlying at strike   (open underlying long)
+//   - Long put   -> sell underlying at strike  (open underlying short)
+// Assignment is the mirror, forced on a short when the counterparty exercises:
+//   - Short call -> sell underlying at strike  (open underlying short)
+//   - Short put  -> buy underlying at strike   (open underlying long)
+//
+// The option leg closes at zero: its premium is already its entry cost, so the
+// long realizes -premium and the short keeps +premium, while the option's
+// intrinsic value transfers into the underlying position's strike cost basis (no
+// double counting). European options have no early-exercise right, so exercise()
+// refuses them.
+
+namespace flox
+{
+
+class OptionExerciseEngine
+{
+ public:
+  explicit OptionExerciseEngine(const SymbolRegistry& registry) : _registry(registry) {}
+
+  struct ExerciseResult
+  {
+    bool exercised{false};
+    PositionId underlyingPositionId{0};  // valid only when exercised
+  };
+
+  // Exercise (long) or assign (short) the option at optionPid, delivering into
+  // underlyingSymbol at the strike. Refuses European options, non-options, and
+  // already-closed positions (exercised=false). The delivered quantity is the
+  // option quantity scaled by its contract multiplier (1 option = multiplier
+  // units of underlying).
+  ExerciseResult exercise(PositionGroupTracker& positions, PositionId optionPid,
+                          SymbolId underlyingSymbol)
+  {
+    const IndividualPosition* pos = positions.getPosition(optionPid);
+    if (!pos || pos->closed)
+    {
+      return {};
+    }
+    auto info = _registry.getSymbolInfo(pos->symbol);
+    if (!info || info->type != InstrumentType::Option || !info->strike.has_value() ||
+        !info->optionType.has_value())
+    {
+      return {};
+    }
+    if (info->exerciseStyle != ExerciseStyle::American)
+    {
+      return {};  // European: no early-exercise right
+    }
+
+    const bool isLong = pos->side == Side::BUY;
+    const OptionType ot = *info->optionType;
+    // Long call / short put -> underlying long; long put / short call -> short.
+    const bool underlyingLong = (ot == OptionType::CALL) == isLong;
+    const Side underlyingSide = underlyingLong ? Side::BUY : Side::SELL;
+
+    const double strike = info->strike->toDouble();
+    // Deliver per the instrument's contract multiplier (1 option = multiplier
+    // units of underlying) — the authoritative spec, not the position's copy.
+    const double units = pos->quantity.toDouble() * info->contractMultiplier;
+
+    positions.closePosition(optionPid, Price::fromDouble(0.0));
+    const PositionId uid = positions.openPosition(
+        kSyntheticOrderBase + _exerciseSeq++, underlyingSymbol, underlyingSide,
+        Price::fromDouble(strike), Quantity::fromDouble(units), /*contractMultiplier=*/1.0);
+
+    return {true, uid};
+  }
+
+  // True when early exercise of a long American option held at `spot` is optimal
+  // — spot at or beyond the Barone-Adesi-Whaley critical boundary. European
+  // options and zero-time / zero-vol inputs return false.
+  bool isEarlyExerciseOptimal(SymbolId optionSymbol, double spot, double t, double rate,
+                              double carry, double vol) const
+  {
+    auto info = _registry.getSymbolInfo(optionSymbol);
+    if (!info || info->type != InstrumentType::Option || !info->strike.has_value() ||
+        !info->optionType.has_value() || info->exerciseStyle != ExerciseStyle::American)
+    {
+      return false;
+    }
+    if (t <= 0.0 || vol <= 0.0)
+    {
+      return false;
+    }
+    const double strike = info->strike->toDouble();
+    const double crit = pricing::bawCriticalPrice(*info->optionType, strike, t, rate, carry, vol);
+    return (*info->optionType == OptionType::CALL) ? spot >= crit : spot <= crit;
+  }
+
+ private:
+  // Synthetic order ids for exercise-generated underlying positions, parked high
+  // to avoid colliding with the caller's real order id space.
+  static constexpr OrderId kSyntheticOrderBase = OrderId{1} << 60;
+
+  const SymbolRegistry& _registry;
+  uint64_t _exerciseSeq{0};
+};
+
+}  // namespace flox

--- a/include/flox/pricing/american.h
+++ b/include/flox/pricing/american.h
@@ -211,6 +211,19 @@ inline double bawPrice(OptionType type, double spot, double strike, double t, do
   return euro + a1 * std::pow(spot / sk, q1);
 }
 
+// The critical underlying price at which early exercise of an American option
+// becomes optimal: a call is exercised at or above it, a put at or below it.
+// Drives an auto-exercise rule in a backtest's settlement loop.
+inline double bawCriticalPrice(OptionType type, double strike, double t, double rate, double carry,
+                               double vol) noexcept
+{
+  if (strike <= 0.0 || t <= 0.0 || vol <= 0.0)
+  {
+    return strike;
+  }
+  return detail::bawCriticalPrice(type, strike, t, rate, carry, vol);
+}
+
 // Engine dispatch by exercise style: European routes to closed-form
 // Black-Scholes, American to Barone-Adesi-Whaley. Transparent to the caller —
 // pass the SymbolInfo's exerciseStyle and get the right model.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ if(FLOX_ENABLE_BACKTEST)
   add_flox_test(test_w15_reproducibility)
   add_flox_test(test_w15_calibration)
   add_flox_test(test_option_settlement)
+  add_flox_test(test_option_exercise)
 endif()
 
 add_flox_test(test_indicators)

--- a/tests/test_option_exercise.cpp
+++ b/tests/test_option_exercise.cpp
@@ -1,0 +1,202 @@
+#include <gtest/gtest.h>
+
+#include "flox/backtest/option_exercise_engine.h"
+#include "flox/engine/symbol_registry.h"
+#include "flox/position/position_group.h"
+
+#include <string>
+
+using namespace flox;
+
+namespace
+{
+int g_optSeq = 0;
+
+SymbolId registerOption(SymbolRegistry& reg, OptionType type, double strike,
+                        ExerciseStyle style, int mult = 1)
+{
+  SymbolInfo info;
+  info.exchange = "cme";
+  info.symbol = "OPT-" + std::to_string(g_optSeq++);  // unique per registration
+  info.type = InstrumentType::Option;
+  info.strike = Price::fromDouble(strike);
+  info.optionType = type;
+  info.exerciseStyle = style;
+  info.contractMultiplier = static_cast<double>(mult);
+  return reg.registerSymbol(info);
+}
+
+SymbolId registerUnderlying(SymbolRegistry& reg)
+{
+  SymbolInfo info;
+  info.exchange = "cme";
+  info.symbol = "UND";
+  info.type = InstrumentType::Spot;
+  return reg.registerSymbol(info);
+}
+}  // namespace
+
+// Exercising a long American call buys the underlying at the strike and closes
+// the option leg.
+TEST(OptionExerciseTest, LongCallExerciseOpensUnderlyingLong)
+{
+  SymbolRegistry reg;
+  const SymbolId opt = registerOption(reg, OptionType::CALL, 100.0, ExerciseStyle::American);
+  const SymbolId und = registerUnderlying(reg);
+
+  PositionGroupTracker positions;
+  const PositionId optPid =
+      positions.openPosition(1, opt, Side::BUY, Price::fromDouble(5.0), Quantity::fromDouble(2.0));
+
+  OptionExerciseEngine engine(reg);
+  const auto res = engine.exercise(positions, optPid, und);
+
+  ASSERT_TRUE(res.exercised);
+  EXPECT_TRUE(positions.getPosition(optPid)->closed);
+  const IndividualPosition* u = positions.getPosition(res.underlyingPositionId);
+  ASSERT_NE(u, nullptr);
+  EXPECT_EQ(u->side, Side::BUY);
+  EXPECT_NEAR(u->entryPrice.toDouble(), 100.0, 1e-9);
+  EXPECT_NEAR(u->quantity.toDouble(), 2.0, 1e-9);
+}
+
+// A long put exercises into a short underlying position (sell at strike).
+TEST(OptionExerciseTest, LongPutExerciseOpensUnderlyingShort)
+{
+  SymbolRegistry reg;
+  const SymbolId opt = registerOption(reg, OptionType::PUT, 100.0, ExerciseStyle::American);
+  const SymbolId und = registerUnderlying(reg);
+
+  PositionGroupTracker positions;
+  const PositionId optPid =
+      positions.openPosition(1, opt, Side::BUY, Price::fromDouble(5.0), Quantity::fromDouble(3.0));
+
+  OptionExerciseEngine engine(reg);
+  const auto res = engine.exercise(positions, optPid, und);
+
+  ASSERT_TRUE(res.exercised);
+  const IndividualPosition* u = positions.getPosition(res.underlyingPositionId);
+  ASSERT_NE(u, nullptr);
+  EXPECT_EQ(u->side, Side::SELL);
+  EXPECT_NEAR(u->quantity.toDouble(), 3.0, 1e-9);
+}
+
+// Assignment on a short call forces a short underlying delivery (sell at strike),
+// the mirror of a long call's exercise.
+TEST(OptionExerciseTest, ShortCallAssignmentOpensUnderlyingShort)
+{
+  SymbolRegistry reg;
+  const SymbolId opt = registerOption(reg, OptionType::CALL, 100.0, ExerciseStyle::American);
+  const SymbolId und = registerUnderlying(reg);
+
+  PositionGroupTracker positions;
+  // Short call: sold for premium 5.
+  const PositionId optPid =
+      positions.openPosition(1, opt, Side::SELL, Price::fromDouble(5.0), Quantity::fromDouble(2.0));
+
+  OptionExerciseEngine engine(reg);
+  const auto res = engine.exercise(positions, optPid, und);
+
+  ASSERT_TRUE(res.exercised);
+  const IndividualPosition* u = positions.getPosition(res.underlyingPositionId);
+  ASSERT_NE(u, nullptr);
+  EXPECT_EQ(u->side, Side::SELL);
+  // Short keeps the premium when the option closes at zero: (0 - 5) on a SELL = +10.
+  EXPECT_NEAR(positions.realizedPnl(opt).toDouble(), 10.0, 1e-9);
+}
+
+// Short put assignment forces a long underlying delivery (buy at strike).
+TEST(OptionExerciseTest, ShortPutAssignmentOpensUnderlyingLong)
+{
+  SymbolRegistry reg;
+  const SymbolId opt = registerOption(reg, OptionType::PUT, 100.0, ExerciseStyle::American);
+  const SymbolId und = registerUnderlying(reg);
+
+  PositionGroupTracker positions;
+  const PositionId optPid =
+      positions.openPosition(1, opt, Side::SELL, Price::fromDouble(5.0), Quantity::fromDouble(1.0));
+
+  OptionExerciseEngine engine(reg);
+  const auto res = engine.exercise(positions, optPid, und);
+
+  ASSERT_TRUE(res.exercised);
+  EXPECT_EQ(positions.getPosition(res.underlyingPositionId)->side, Side::BUY);
+}
+
+// European options carry no early-exercise right: exercise refuses them and the
+// option position stays open.
+TEST(OptionExerciseTest, EuropeanRejected)
+{
+  SymbolRegistry reg;
+  const SymbolId opt = registerOption(reg, OptionType::CALL, 100.0, ExerciseStyle::European);
+  const SymbolId und = registerUnderlying(reg);
+
+  PositionGroupTracker positions;
+  const PositionId optPid =
+      positions.openPosition(1, opt, Side::BUY, Price::fromDouble(5.0), Quantity::fromDouble(2.0));
+
+  OptionExerciseEngine engine(reg);
+  const auto res = engine.exercise(positions, optPid, und);
+
+  EXPECT_FALSE(res.exercised);
+  EXPECT_FALSE(positions.getPosition(optPid)->closed);
+  EXPECT_EQ(positions.openPositionCount(), 1u);
+}
+
+// The contract multiplier scales the delivered underlying quantity: one
+// 100-multiplier option delivers 100 underlying units per contract.
+TEST(OptionExerciseTest, MultiplierScalesDeliveredUnits)
+{
+  SymbolRegistry reg;
+  const SymbolId opt = registerOption(reg, OptionType::CALL, 100.0, ExerciseStyle::American, 100);
+  const SymbolId und = registerUnderlying(reg);
+
+  PositionGroupTracker positions;
+  const PositionId optPid =
+      positions.openPosition(1, opt, Side::BUY, Price::fromDouble(5.0), Quantity::fromDouble(2.0));
+
+  OptionExerciseEngine engine(reg);
+  const auto res = engine.exercise(positions, optPid, und);
+
+  ASSERT_TRUE(res.exercised);
+  EXPECT_NEAR(positions.getPosition(res.underlyingPositionId)->quantity.toDouble(), 200.0, 1e-6);
+}
+
+// Exercise then mark the underlying to spot: total realized PnL is
+// intrinsic - premium, with no double counting of the intrinsic.
+TEST(OptionExerciseTest, EndToEndPnlIsIntrinsicMinusPremium)
+{
+  SymbolRegistry reg;
+  const SymbolId opt = registerOption(reg, OptionType::CALL, 100.0, ExerciseStyle::American);
+  const SymbolId und = registerUnderlying(reg);
+
+  PositionGroupTracker positions;
+  const PositionId optPid =
+      positions.openPosition(1, opt, Side::BUY, Price::fromDouble(5.0), Quantity::fromDouble(2.0));
+
+  OptionExerciseEngine engine(reg);
+  const auto res = engine.exercise(positions, optPid, und);
+  ASSERT_TRUE(res.exercised);
+
+  // Underlying now worth 120: close it to realize the delivery gain.
+  positions.closePosition(res.underlyingPositionId, Price::fromDouble(120.0));
+
+  // (intrinsic 20 - premium 5) * 2 contracts = 30.
+  EXPECT_NEAR(positions.totalRealizedPnl().toDouble(), 30.0, 1e-9);
+}
+
+// The BAW boundary check flags a deep-ITM American put for early exercise while
+// leaving an out-of-the-money one alone; European always returns false.
+TEST(OptionExerciseTest, EarlyExerciseBoundary)
+{
+  SymbolRegistry reg;
+  const SymbolId amerPut = registerOption(reg, OptionType::PUT, 100.0, ExerciseStyle::American);
+  const SymbolId euroPut = registerOption(reg, OptionType::PUT, 100.0, ExerciseStyle::European);
+
+  OptionExerciseEngine engine(reg);
+  const double t = 0.5, r = 0.10, b = 0.0, vol = 0.25;
+
+  EXPECT_TRUE(engine.isEarlyExerciseOptimal(amerPut, /*spot=*/40.0, t, r, b, vol));    // deep ITM
+  EXPECT_FALSE(engine.isEarlyExerciseOptimal(amerPut, /*spot=*/110.0, t, r, b, vol));  // OTM
+  EXPECT_FALSE(engine.isEarlyExerciseOptimal(euroPut, /*spot=*/40.0, t, r, b, vol));   // European
+}


### PR DESCRIPTION
## Summary
- The expiry engine settles European options at expiry; this adds the early-exercise right an American option carries before then.
- OptionExerciseEngine::exercise delivers the underlying at the strike and closes the option leg. Long call -> buy underlying; long put -> sell; short call assignment -> sell; short put assignment -> buy. Delivered quantity scales by the instrument's contract multiplier. The option closes at zero so its intrinsic transfers into the underlying's strike cost basis (no double counting); the long realizes -premium, the short keeps +premium.
- European options are refused (no early-exercise right).
- isEarlyExerciseOptimal flags a long American option at or beyond the Barone-Adesi-Whaley critical boundary, exposed from american.h as bawCriticalPrice, for an auto-exercise rule in a settlement loop.

## Test plan
- [x] All four exercise/assignment quadrants open the correct underlying side
- [x] European option exercise refused; position stays open
- [x] Contract multiplier scales delivered underlying quantity
- [x] Early-exercise boundary: deep-ITM American flagged, OTM and European not
- [x] End-to-end PnL equals intrinsic minus premium (no double counting)
- [x] format + test-gating consistent (backtest-gated, matches settlement engine)

W16-T019