### PR TITLE
feat(backtest): realistic illiquid-option fill model

### DIFF
--- a/include/flox/backtest/option_fill_model.h
+++ b/include/flox/backtest/option_fill_model.h
@@ -1,0 +1,153 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include "flox/common.h"
+
+#include <cstddef>
+#include <vector>
+
+// Realistic fills for illiquid options. Backtesting option strategies on the
+// mid (or worse, the close) manufactures alpha that evaporates live: real fills
+// cross part of a wide, sparse bid-ask spread. This models that honestly.
+//
+//   - A market order does not fill at the mid. It crosses a fraction of the
+//     half-spread toward the touch (single-leg ~0.75 of the way; ORATS).
+//   - Multi-leg spreads fill atomically with LESS slippage per leg — a package
+//     gets price improvement, down to ~0.56 for a four-leg spread (ORATS). So
+//     slippage is non-linear in the number of legs.
+//   - A missing or locked/crossed quote does NOT produce a fake fill: the order
+//     is reported unfilled, and the caller applies its no-quote policy.
+//   - Market makers widen near the close, so a backtest can widen the quote to
+//     model the last minutes rather than trusting the closing print.
+
+namespace flox
+{
+
+struct OptionBBO
+{
+  double bid{0.0};
+  double ask{0.0};
+
+  // A usable two-sided quote: positive bid and an ask strictly above it. A
+  // zero/absent side or a locked/crossed market (ask <= bid) is not usable.
+  bool valid() const { return bid > 0.0 && ask > bid; }
+  double mid() const { return 0.5 * (bid + ask); }
+  double halfSpread() const { return 0.5 * (ask - bid); }
+  double width() const { return ask - bid; }
+};
+
+// What a caller does when a leg has no usable quote. The fill functions never
+// fabricate a fill; this records the caller's intent for the empty bar.
+enum class NoQuoteAction
+{
+  Skip,    // skip the bar, try again next quote
+  Hold,    // keep the position, do not trade
+  Reject,  // reject the order outright
+};
+
+// Fraction of the half-spread an N-leg order crosses toward the touch. One leg
+// crosses the most (~0.75); each added leg earns package price improvement, to
+// ~0.56 at four legs, then flat. Linear between the ORATS endpoints.
+inline double legCrossFraction(size_t numLegs)
+{
+  if (numLegs <= 1)
+  {
+    return 0.75;
+  }
+  if (numLegs >= 4)
+  {
+    return 0.56;
+  }
+  return 0.75 - (static_cast<double>(numLegs - 1)) * ((0.75 - 0.56) / 3.0);
+}
+
+struct FillResult
+{
+  bool filled{false};
+  double price{0.0};     // realized fill price
+  double slippage{0.0};  // cost vs mid, per unit (always >= 0 when filled)
+};
+
+// Single-leg market fill: cross legCrossFraction(1) of the half-spread toward
+// the touch (above mid to buy, below mid to sell). An unusable quote returns
+// unfilled — never a mid/close fake fill.
+inline FillResult fillSingleLeg(Side side, const OptionBBO& q)
+{
+  FillResult r;
+  if (!q.valid())
+  {
+    return r;
+  }
+  const double slip = legCrossFraction(1) * q.halfSpread();
+  r.filled = true;
+  r.slippage = slip;
+  r.price = (side == Side::BUY) ? q.mid() + slip : q.mid() - slip;
+  return r;
+}
+
+struct SpreadLeg
+{
+  Side side{Side::BUY};
+  double qty{1.0};
+  OptionBBO quote;
+};
+
+struct SpreadFillResult
+{
+  bool filled{false};
+  double netDebit{0.0};  // signed package cost: + you pay, - you receive
+  double slippage{0.0};  // total cost vs the net mid (always >= 0 when filled)
+};
+
+// Atomic multi-leg spread fill. All legs fill or none — if ANY leg lacks a
+// usable quote the whole package is unfilled. The package crosses
+// legCrossFraction(numLegs) of each leg's half-spread, so per-leg slippage falls
+// as legs are added (non-linear). netDebit is the net mid plus that slippage.
+inline SpreadFillResult fillSpread(const std::vector<SpreadLeg>& legs)
+{
+  SpreadFillResult r;
+  if (legs.empty())
+  {
+    return r;
+  }
+  for (const auto& l : legs)
+  {
+    if (!l.quote.valid())
+    {
+      return r;  // atomic: one missing quote fails the whole spread
+    }
+  }
+  const double cross = legCrossFraction(legs.size());
+  double netMid = 0.0;
+  double slip = 0.0;
+  for (const auto& l : legs)
+  {
+    const double sign = (l.side == Side::BUY) ? 1.0 : -1.0;
+    netMid += sign * l.qty * l.quote.mid();
+    slip += l.qty * cross * l.quote.halfSpread();  // crossing always costs
+  }
+  r.filled = true;
+  r.slippage = slip;
+  r.netDebit = netMid + slip;
+  return r;
+}
+
+// Widen a quote around its mid by factor (>= 1) to model the spreads market
+// makers post near the close — a better proxy for the last minutes than the
+// closing print itself.
+inline OptionBBO widenQuote(const OptionBBO& q, double factor)
+{
+  const double m = q.mid();
+  const double h = q.halfSpread() * factor;
+  return OptionBBO{m - h, m + h};
+}
+
+}  // namespace flox

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,7 @@ if(FLOX_ENABLE_BACKTEST)
   add_flox_test(test_w15_calibration)
   add_flox_test(test_option_settlement)
   add_flox_test(test_option_exercise)
+  add_flox_test(test_option_fill_model)
 endif()
 
 add_flox_test(test_indicators)

--- a/tests/test_option_fill_model.cpp
+++ b/tests/test_option_fill_model.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include "flox/backtest/option_fill_model.h"
+
+#include <vector>
+
+using namespace flox;
+
+// A single-leg buy fills above the mid but no worse than the ask — it crosses
+// part of the spread, not the whole of it.
+TEST(OptionFillModelTest, SingleLegBuyCrossesPartOfSpread)
+{
+  const OptionBBO q{1.00, 1.40};  // mid 1.20, half-spread 0.20
+  const auto r = fillSingleLeg(Side::BUY, q);
+  ASSERT_TRUE(r.filled);
+  EXPECT_GT(r.price, q.mid());
+  EXPECT_LT(r.price, q.ask);
+  EXPECT_DOUBLE_EQ(r.slippage, 0.75 * q.halfSpread());  // ORATS single-leg
+  EXPECT_DOUBLE_EQ(r.price, q.mid() + 0.75 * q.halfSpread());
+}
+
+// A sell is the mirror: below the mid, above the bid.
+TEST(OptionFillModelTest, SingleLegSellMirrors)
+{
+  const OptionBBO q{1.00, 1.40};
+  const auto r = fillSingleLeg(Side::SELL, q);
+  ASSERT_TRUE(r.filled);
+  EXPECT_LT(r.price, q.mid());
+  EXPECT_GT(r.price, q.bid);
+  EXPECT_DOUBLE_EQ(r.price, q.mid() - 0.75 * q.halfSpread());
+}
+
+// An absent or locked/crossed quote never fakes a fill.
+TEST(OptionFillModelTest, NoQuoteDoesNotFakeFill)
+{
+  EXPECT_FALSE(fillSingleLeg(Side::BUY, OptionBBO{0.0, 0.0}).filled);    // no quote
+  EXPECT_FALSE(fillSingleLeg(Side::BUY, OptionBBO{1.40, 1.40}).filled);  // locked
+  EXPECT_FALSE(fillSingleLeg(Side::BUY, OptionBBO{1.50, 1.40}).filled);  // crossed
+  EXPECT_FALSE(fillSingleLeg(Side::SELL, OptionBBO{0.0, 1.40}).filled);  // one-sided
+}
+
+// Slippage per leg shrinks as legs are added: a four-leg package crosses less of
+// each spread than four separate single-leg orders would.
+TEST(OptionFillModelTest, MultiLegSlippageIsNonLinear)
+{
+  EXPECT_DOUBLE_EQ(legCrossFraction(1), 0.75);
+  EXPECT_DOUBLE_EQ(legCrossFraction(4), 0.56);
+  EXPECT_GT(legCrossFraction(1), legCrossFraction(2));
+  EXPECT_GT(legCrossFraction(2), legCrossFraction(3));
+  EXPECT_GT(legCrossFraction(3), legCrossFraction(4));
+  EXPECT_DOUBLE_EQ(legCrossFraction(10), 0.56);  // flat past four
+}
+
+// A multi-leg spread fills atomically and prices off the package cross fraction.
+TEST(OptionFillModelTest, SpreadFillsAtomicallyWithPackageImprovement)
+{
+  // Buy a vertical: long the 1.00/1.40 call, short the 0.40/0.60 call.
+  std::vector<SpreadLeg> legs = {
+      {Side::BUY, 1.0, OptionBBO{1.00, 1.40}},
+      {Side::SELL, 1.0, OptionBBO{0.40, 0.60}},
+  };
+  const auto r = fillSpread(legs);
+  ASSERT_TRUE(r.filled);
+
+  const double cross = legCrossFraction(2);
+  const double netMid = 1.20 - 0.50;          // long mid - short mid
+  const double slip = cross * (0.20 + 0.10);  // sum qty * cross * half
+  EXPECT_DOUBLE_EQ(r.slippage, slip);
+  EXPECT_DOUBLE_EQ(r.netDebit, netMid + slip);
+  EXPECT_GT(r.slippage, 0.0);  // crossing always costs
+}
+
+// One missing leg quote fails the whole atomic package.
+TEST(OptionFillModelTest, SpreadFailsAtomicallyOnMissingLeg)
+{
+  std::vector<SpreadLeg> legs = {
+      {Side::BUY, 1.0, OptionBBO{1.00, 1.40}},
+      {Side::SELL, 1.0, OptionBBO{0.0, 0.0}},  // no quote on this leg
+  };
+  EXPECT_FALSE(fillSpread(legs).filled);
+}
+
+// The headline A/B: a buy-then-sell round trip is flat at the mid but loses the
+// crossed spread under a realistic fill — i.e. mid/close fills overstate PnL.
+TEST(OptionFillModelTest, RealisticFillCostsMoreThanMid)
+{
+  const OptionBBO q{1.00, 1.40};
+  const auto buy = fillSingleLeg(Side::BUY, q);
+  const auto sell = fillSingleLeg(Side::SELL, q);
+  ASSERT_TRUE(buy.filled);
+  ASSERT_TRUE(sell.filled);
+
+  const double midRoundTrip = 0.0;                      // buy and sell at mid -> flat
+  const double realRoundTrip = sell.price - buy.price;  // negative: you lose the spread
+  EXPECT_LT(realRoundTrip, midRoundTrip);
+  EXPECT_DOUBLE_EQ(realRoundTrip, -2.0 * 0.75 * q.halfSpread());
+}
+
+// Widening models close-proximity spreads: the mid is unchanged, the spread
+// grows, and a fill therefore costs more than on the un-widened quote.
+TEST(OptionFillModelTest, WidenQuoteIncreasesFillCost)
+{
+  const OptionBBO q{1.00, 1.40};
+  const OptionBBO wide = widenQuote(q, 2.0);
+  EXPECT_DOUBLE_EQ(wide.mid(), q.mid());
+  EXPECT_DOUBLE_EQ(wide.width(), 2.0 * q.width());
+
+  const auto tight = fillSingleLeg(Side::BUY, q);
+  const auto loose = fillSingleLeg(Side::BUY, wide);
+  EXPECT_GT(loose.price, tight.price);
+}


### PR DESCRIPTION
## Summary
- Backtesting options on the mid (or the close) manufactures alpha that evaporates live; real fills cross a wide, sparse spread. This models that honestly — the headline "honest options backtest" differentiator (T007).
- OptionBBO + fillSingleLeg: a market order crosses ~0.75 of the half-spread toward the touch (ORATS), never the mid. Buy fills above mid, sell below.
- fillSpread: atomic multi-leg fill with package price improvement — slippage is non-linear in leg count, ~0.75 of each half-spread at one leg down to ~0.56 at four (legCrossFraction). Any missing leg quote fails the whole package.
- No fake fills: an absent or locked/crossed quote returns unfilled; the caller applies its NoQuoteAction (skip / hold / reject).
- widenQuote models the spreads market makers post near the close, a better proxy than the closing print.

## Test plan
- [x] Single-leg buy/sell cross part of the spread (above/below mid, inside the touch)
- [x] No-quote / locked / crossed / one-sided quotes never fake a fill
- [x] Multi-leg slippage is non-linear (0.75 -> 0.56), flat past four legs
- [x] Spread fills atomically with package improvement; one missing leg fails the package
- [x] Headline A/B: round trip flat at mid but loses the crossed spread under realistic fill (mid/close overstate PnL)
- [x] widenQuote raises fill cost with the mid unchanged
- [x] format + test-gating consistent (backtest-gated)

W16-T007