### PR TITLE
feat(mcp): agent-facing DEX routing / impact / tape-replay tools

### DIFF
--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -577,6 +577,120 @@ def build_server() -> Server:
                 },
             ),
             Tool(
+                name="route_amm_swap",
+                description=(
+                    "Best execution for a DEX swap across a set of AMM "
+                    "pools, exact to the wei. Give it the same notional and "
+                    "several venues (constant-product, Raydium CP, Uniswap "
+                    "v3) and it returns the venue that fills the most, the "
+                    "fill, and a per-venue comparison. Amounts are human "
+                    "'NUMBER SYMBOL' strings (e.g. '50000 USDC'); each pool "
+                    "carries its token symbols and decimals, so directions "
+                    "are by symbol and a mis-routed swap raises instead of "
+                    "returning a quiet zero. Requires the optional `flox-py` "
+                    "dependency."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["venues", "amount"],
+                    "properties": {
+                        "venues": {
+                            "type": "array",
+                            "description":
+                                "Pool specs. Each: {venue, token0:{symbol,"
+                                "decimals}, token1:{symbol,decimals}, ... "
+                                "venue params}. constant_product/uniswap_v2: "
+                                "reserves (['1000 WETH','2000000 USDC']), fee, "
+                                "fee_den. raydium_cp: reserves, trade_fee. "
+                                "uniswap_v3: sqrt_price_x96, liquidity, fee, "
+                                "ticks.",
+                            "items": {"type": "object", "additionalProperties": True},
+                        },
+                        "amount": {
+                            "type": "string",
+                            "description": "Input amount as 'NUMBER SYMBOL', e.g. '50000 USDC'.",
+                        },
+                        "into": {
+                            "type": "string",
+                            "description": "Out-token symbol (optional; inferred otherwise).",
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+            ),
+            Tool(
+                name="amm_price_impact",
+                description=(
+                    "The depth / slippage table for one AMM pool: the "
+                    "realized average price and price impact for each of a "
+                    "list of trade sizes, exact to the wei. Use this to "
+                    "reason about how large a trade a pool can absorb before "
+                    "quoting. Sizes are human 'NUMBER SYMBOL' strings. "
+                    "Requires the optional `flox-py` dependency."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["pool", "sizes"],
+                    "properties": {
+                        "pool": {
+                            "type": "object",
+                            "description":
+                                "A pool spec: {venue, token0:{symbol,decimals}, "
+                                "token1:{symbol,decimals}, ...venue params}.",
+                            "additionalProperties": True,
+                        },
+                        "sizes": {
+                            "type": "array",
+                            "description": "Trade sizes as 'NUMBER SYMBOL' strings.",
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+            ),
+            Tool(
+                name="replay_pool_tape",
+                description=(
+                    "Backtest a DEX position from a recorded pool history. "
+                    "Replays a list of swaps (or decoded Uniswap v2 Swap "
+                    "logs) through the exact curve and returns the price / "
+                    "reserves / LP-value / impermanent-loss / drift series "
+                    "over time. Use this to evaluate an LP position or a "
+                    "trading sequence against a real transcript. Requires "
+                    "the optional `flox-py` dependency."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["pool"],
+                    "properties": {
+                        "pool": {
+                            "type": "object",
+                            "description":
+                                "A pool spec: {venue, token0:{symbol,decimals}, "
+                                "token1:{symbol,decimals}, ...venue params} -- the "
+                                "replay's starting state.",
+                            "additionalProperties": True,
+                        },
+                        "swaps": {
+                            "type": "array",
+                            "description":
+                                "Swaps as [ts, 'NUMBER SYMBOL', into?] entries. "
+                                "Supply this or `evm_logs`.",
+                            "items": {"type": "array"},
+                        },
+                        "evm_logs": {
+                            "type": "array",
+                            "description":
+                                "Decoded Uniswap v2 Swap log dicts (data word order "
+                                "amount0In, amount1In, amount0Out, amount1Out). "
+                                "Supply this or `swaps`.",
+                            "items": {"type": "object", "additionalProperties": True},
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+            ),
+            Tool(
                 name="suggest_indicator",
                 description=(
                     "Recommend FLOX indicators for an English description "
@@ -1166,6 +1280,23 @@ def build_server() -> Server:
                     amount_in=arguments["amount_in"],
                     i=arguments.get("i", 0),
                     j=arguments.get("j", 1),
+                )
+            elif name == "route_amm_swap":
+                text = runtime.route_amm_swap(
+                    venues=arguments["venues"],
+                    amount=arguments["amount"],
+                    into=arguments.get("into"),
+                )
+            elif name == "amm_price_impact":
+                text = runtime.amm_price_impact(
+                    pool=arguments["pool"],
+                    sizes=arguments["sizes"],
+                )
+            elif name == "replay_pool_tape":
+                text = runtime.replay_pool_tape(
+                    pool=arguments["pool"],
+                    swaps=arguments.get("swaps"),
+                    evm_logs=arguments.get("evm_logs"),
                 )
             elif name == "suggest_indicator":
                 text = runtime.suggest_indicator(

--- a/mcp/flox_mcp/tools/overview.py
+++ b/mcp/flox_mcp/tools/overview.py
@@ -172,6 +172,12 @@ Mutating tools:
   indicator data over a window.
 - `price_amm_swap(venue, pool, amount_in)` — quote a DEX swap exact
   to the wei on a constant-product / Raydium CP / Uniswap v3 pool.
+- `route_amm_swap(venues, amount, into)` — best execution across pools;
+  the winning venue, the fill, and a per-venue comparison.
+- `amm_price_impact(pool, sizes)` — the depth / slippage table for a
+  pool, to size a trade before quoting.
+- `replay_pool_tape(pool, swaps | evm_logs)` — replay a recorded
+  history into a price / LP-value / impermanent-loss / drift series.
 - `whatif(...)` — counterfactual replay with overridden inputs.
 - `lookahead(strategy_code, ...)` — bias detection.
 - `replay_window(start_ns, end_ns)` — re-run a slice for debugging.

--- a/mcp/flox_mcp/tools/runtime.py
+++ b/mcp/flox_mcp/tools/runtime.py
@@ -262,6 +262,157 @@ def price_amm_swap(
     }, indent=2)
 
 
+def _import_dex_or_error() -> Tuple[Any, Optional[str]]:
+    try:
+        from flox_py import dex  # type: ignore
+        return dex, None
+    except ImportError:
+        return None, (
+            "this tool requires the optional `flox-py` package (>= the build that "
+            "ships flox_py.dex). Install it with `pip install \"flox-mcp[flox]\"`."
+        )
+
+
+def _build_dex_pool(dex: Any, spec: Any) -> Any:
+    """Build a flox.dex pool from an agent-facing spec.
+
+    spec: {venue, token0:{symbol,decimals}, token1:{symbol,decimals}, ...venue params}.
+    constant_product / uniswap_v2: reserves (["1000 WETH","2000000 USDC"]), fee, fee_den.
+    raydium_cp: reserves, trade_fee. uniswap_v3: sqrt_price_x96, liquidity, fee, ticks.
+    """
+    if not isinstance(spec, dict):
+        raise ValueError("pool must be an object of pool parameters")
+    t = spec.get("token0"), spec.get("token1")
+    if not all(isinstance(x, dict) and "symbol" in x and "decimals" in x for x in t):
+        raise ValueError("token0/token1 must be {symbol, decimals} objects")
+    t0 = dex.Token(t[0]["symbol"], int(t[0]["decimals"]))
+    t1 = dex.Token(t[1]["symbol"], int(t[1]["decimals"]))
+    v = (spec.get("venue") or "").lower()
+    if v in ("constant_product", "cp", "uniswap_v2"):
+        return dex.UniswapV2(t0, t1, reserves=spec["reserves"],
+                             fee=spec.get("fee", "0.30%"), fee_den=int(spec.get("fee_den", 1000)))
+    if v in ("raydium_cp", "raydium"):
+        return dex.RaydiumCp(t0, t1, reserves=spec["reserves"],
+                             trade_fee=spec.get("trade_fee", "0.25%"))
+    if v in ("uniswap_v3", "v3", "concentrated_liquidity"):
+        ticks = [(int(str(a)), int(str(b))) for a, b in spec.get("ticks", [])]
+        return dex.UniswapV3(t0, t1, int(str(spec["sqrt_price_x96"])),
+                             int(str(spec["liquidity"])), fee=spec.get("fee", "0.05%"), ticks=ticks)
+    raise ValueError(f"unknown venue '{spec.get('venue')}'. Use one of "
+                     "constant_product, raydium_cp, uniswap_v3.")
+
+
+def _rows_to_list(rows: Any) -> list:
+    """A flox.dex table (pandas DataFrame or list of dicts) to a list of dicts.
+
+    Wei-scale fields (reserves) are coerced to decimal strings so a JSON consumer does
+    not lose precision past 2^53; small fields (ts, price, il) keep their native type.
+    """
+    if not isinstance(rows, list):
+        rows = rows.to_dict("records")  # pandas DataFrame
+    wei_keys = ("reserve0", "reserve1")
+    out = []
+    for r in rows:
+        out.append({k: (str(val) if k in wei_keys and val is not None else val)
+                    for k, val in r.items()})
+    return out
+
+
+def route_amm_swap(venues: Any, amount: Any, into: Any = None) -> str:
+    """Best execution across a set of AMM pools, exact to the wei via flox.dex.Router.
+
+    venues: a list of pool specs (see _build_dex_pool). amount: "NUMBER SYMBOL".
+    into: the out-token symbol (optional). Returns the winning venue, the fill, and the
+    per-venue comparison table.
+    """
+    import json as _json
+
+    dex, err = _import_dex_or_error()
+    if err is not None:
+        return err
+    if not isinstance(venues, list) or not venues:
+        return "route_amm_swap: `venues` must be a non-empty list of pool specs."
+    try:
+        pools = [_build_dex_pool(dex, s) for s in venues]
+        router = dex.Router(pools)
+        best_pool, best_q = router.best(amount, into)
+        table = router.table(amount, into)
+    except Exception as e:  # noqa: BLE001
+        return f"route_amm_swap: {e}"
+    table = _rows_to_list(table)
+    return _json.dumps({
+        "amount_in": str(amount),
+        "best": {
+            "venue": best_pool.venue,
+            "out": str(best_q.out),
+            "out_wei": str(best_q.exact_wei),
+            "price_impact": float(best_q.price_impact),
+        },
+        "venues": table,
+        "note": "best execution exact to the wei via flox.dex.Router",
+    }, indent=2)
+
+
+def amm_price_impact(pool: Any, sizes: Any) -> str:
+    """The depth / slippage table for a pool: realized price and impact per size.
+
+    pool: a pool spec (see _build_dex_pool). sizes: a list of "NUMBER SYMBOL" amounts.
+    Use this to reason about size before quoting. Exact to the wei via flox.dex.
+    """
+    import json as _json
+
+    dex, err = _import_dex_or_error()
+    if err is not None:
+        return err
+    if not isinstance(sizes, list) or not sizes:
+        return "amm_price_impact: `sizes` must be a non-empty list of amounts."
+    try:
+        p = _build_dex_pool(dex, pool)
+        rows = _rows_to_list(p.depth(sizes))
+    except Exception as e:  # noqa: BLE001
+        return f"amm_price_impact: {e}"
+    return _json.dumps({
+        "venue": p.venue,
+        "spot_price": float(p.spot_price),
+        "depth": rows,
+        "note": "depth / slippage exact to the wei via flox.dex",
+    }, indent=2)
+
+
+def replay_pool_tape(pool: Any, swaps: Any = None, evm_logs: Any = None) -> str:
+    """Replay a recorded pool history through the exact curve into a backtest series.
+
+    pool: a pool spec (see _build_dex_pool). Supply either `swaps` (a list of
+    [ts, "NUMBER SYMBOL", into?]) or `evm_logs` (decoded Uniswap v2 Swap log dicts).
+    Returns the price / reserves / LP-value / IL / drift series so an agent can backtest
+    a DEX position from a transcript.
+    """
+    import json as _json
+
+    dex, err = _import_dex_or_error()
+    if err is not None:
+        return err
+    if not swaps and not evm_logs:
+        return "replay_pool_tape: supply either `swaps` or `evm_logs`."
+    try:
+        p = _build_dex_pool(dex, pool)
+        if evm_logs:
+            tape = dex.Tape.from_evm_logs(p, evm_logs)
+        else:
+            tape = dex.Tape(p).from_swaps([tuple(s) for s in swaps])
+        bt = tape.replay()
+    except Exception as e:  # noqa: BLE001
+        return f"replay_pool_tape: {e}"
+    drift = bt.attrs["drift_count"] if not isinstance(bt, list) else \
+        sum(1 for r in bt if r.get("drift"))
+    return _json.dumps({
+        "venue": p.venue,
+        "drift_count": int(drift),
+        "series": _rows_to_list(bt),
+        "note": "exact replay through the flox.dex curve",
+    }, indent=2)
+
+
 def compute_indicator(
     name: str,
     data: Any,

--- a/mcp/tests/test_dex_mcp_tools.py
+++ b/mcp/tests/test_dex_mcp_tools.py
@@ -1,0 +1,122 @@
+"""Unit tests for the DEX DX MCP tools (W24-T006).
+
+route_amm_swap / amm_price_impact / replay_pool_tape are thin server tools over the
+flox.dex comfort layer. These tests pin each tool's JSON output to the flox.dex layer it
+wraps. They need the compiled `flox_py` (with flox_py.dex) and are skipped otherwise --
+the MCP-only CI job has no compiled module.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "mcp"))
+sys.path.insert(0, str(REPO_ROOT / "build" / "python"))
+
+from flox_mcp.tools import runtime  # noqa: E402
+
+try:
+    import flox_py  # noqa: F401
+    from flox_py import dex  # noqa: F401
+    HAS_FLOX = True
+except ImportError:
+    HAS_FLOX = False
+
+skip_no_flox = pytest.mark.skipif(not HAS_FLOX, reason="flox_py.dex not importable")
+
+WETH = {"symbol": "WETH", "decimals": 18}
+USDC = {"symbol": "USDC", "decimals": 6}
+
+
+def _v2(reserves, fee="0.30%"):
+    return {"venue": "constant_product", "token0": WETH, "token1": USDC,
+            "reserves": reserves, "fee": fee}
+
+
+def _ray(reserves, trade_fee="0.25%"):
+    return {"venue": "raydium_cp", "token0": WETH, "token1": USDC,
+            "reserves": reserves, "trade_fee": trade_fee}
+
+
+# ── route_amm_swap ────────────────────────────────────────────────────
+
+
+@skip_no_flox
+def test_route_amm_swap_picks_best_and_matches_layer():
+    venues = [_v2(["1000 WETH", "2000000 USDC"]), _ray(["1000 WETH", "2000000 USDC"])]
+    out = json.loads(runtime.route_amm_swap(venues, "50000 USDC", into="WETH"))
+    # Lower fee (Raydium 0.25%) fills the most.
+    assert out["best"]["venue"] == "RaydiumCp"
+    # The reported best matches a direct flox.dex Router call to the wei.
+    ray = dex.RaydiumCp(dex.Token("WETH", 18), dex.Token("USDC", 6),
+                        reserves=("1000 WETH", "2000000 USDC"), trade_fee="0.25%")
+    assert out["best"]["out_wei"] == str(ray.quote("50000 USDC", into="WETH").exact_wei)
+    assert out["venues"][0]["venue"] == "RaydiumCp"   # sorted best-first
+
+
+@skip_no_flox
+def test_route_amm_swap_bad_input():
+    assert "non-empty list" in runtime.route_amm_swap([], "50000 USDC")
+
+
+# ── amm_price_impact ──────────────────────────────────────────────────
+
+
+@skip_no_flox
+def test_amm_price_impact_monotone_and_matches_layer():
+    out = json.loads(runtime.amm_price_impact(_v2(["1000 WETH", "2000000 USDC"]),
+                                              ["1 WETH", "50 WETH", "200 WETH"]))
+    impacts = [r["impact_pct"] for r in out["depth"]]
+    assert impacts == sorted(impacts) and impacts[0] > 0
+    assert out["spot_price"] == 2000.0
+
+
+# ── replay_pool_tape ──────────────────────────────────────────────────
+
+
+@skip_no_flox
+def test_replay_pool_tape_matches_layer():
+    pool = _v2(["1000 WETH", "2000000 USDC"])
+    out = json.loads(runtime.replay_pool_tape(
+        pool, swaps=[[1, "50 WETH"], [2, "50 WETH"], [3, "100000 USDC"]]))
+    # Drive the same swaps through the raw curve and compare the final reserves.
+    c = flox_py.AmmCurve.constant_product(1000 * 10**18, 2_000_000 * 10**6, 997, 1000)
+    c.apply_swap(0, 1, 50 * 10**18)
+    c.apply_swap(0, 1, 50 * 10**18)
+    c.apply_swap(1, 0, 100_000 * 10**6)
+    last = out["series"][-1]
+    assert last["reserve0"] == str(c.balances()[0])
+    assert last["reserve1"] == str(c.balances()[1])
+    assert out["drift_count"] == 0
+
+
+@skip_no_flox
+def test_replay_pool_tape_flags_drift():
+    pool = _v2(["1000 WETH", "2000000 USDC"])
+    # Drive it via evm_logs: one 1-WETH sell (amount0In = 1e18).
+    one = (10**18).to_bytes(32, "big").hex()
+    zero = (0).to_bytes(32, "big").hex()
+    logs = [{"blockNumber": "0x10", "data": "0x" + one + zero + zero + zero}]
+    out = json.loads(runtime.replay_pool_tape(pool, evm_logs=logs))
+    c = flox_py.AmmCurve.constant_product(1000 * 10**18, 2_000_000 * 10**6, 997, 1000)
+    c.apply_swap(0, 1, 10**18)
+    assert out["series"][-1]["reserve0"] == str(c.balances()[0])
+
+
+@skip_no_flox
+def test_replay_pool_tape_requires_input():
+    assert "supply either" in runtime.replay_pool_tape(_v2(["1000 WETH", "2000000 USDC"]))
+
+
+def test_tools_report_missing_flox_cleanly(monkeypatch):
+    """With flox_py absent the tools return a clean install hint, never a traceback."""
+    monkeypatch.setattr(runtime, "_import_dex_or_error",
+                        lambda: (None, "this tool requires the optional `flox-py` package."))
+    for call in (lambda: runtime.route_amm_swap([{}], "1 WETH"),
+                 lambda: runtime.amm_price_impact({}, ["1 WETH"]),
+                 lambda: runtime.replay_pool_tape({}, swaps=[[1, "1 WETH"]])):
+        assert "flox-py" in call()


### PR DESCRIPTION
Raise the agent-facing DEX surface (beyond the single-swap `price_amm_swap`) to the flox.dex comfort layer (W24-T002/T003/T004). Three thin server tools over `flox_py.dex`, descriptions tuned for agents:

- `route_amm_swap(venues, amount, into)` -- best execution across a set of pools via Router; returns the winning venue, the fill, and a per-venue comparison.
- `amm_price_impact(pool, sizes)` -- the depth / slippage table for a pool, so an agent can size a trade before quoting.
- `replay_pool_tape(pool, swaps | evm_logs)` -- replay a recorded history through the exact curve into a price / LP-value / impermanent-loss / drift series.

Each takes human "NUMBER SYMBOL" amounts and per-pool token symbols + decimals, so directions are by symbol and a mis-routed swap raises rather than returning a quiet zero. Wei-scale reserves are emitted as decimal strings so a JSON consumer keeps full precision past 2^53.

`mcp/tests/test_dex_mcp_tools.py` pins every tool's JSON to the flox.dex layer it wraps and checks the clean missing-flox path; the overview catalogue lists the three tools. Full MCP suite green (172 passed).

## MCP impact

Adds three MCP tools (`route_amm_swap`, `amm_price_impact`, `replay_pool_tape`) as thin wrappers over the existing flox_py.dex layer. No C-ABI / IDL / pybind change, so the bundled IR snapshot, binding manifest, and C-API data are unaffected -- `sync_mcp_data.py --check` stays green with no regeneration. The tools depend on the optional `flox-py` package and degrade to a clean install hint when it is absent.

W24-T006