### PR TITLE
ci: silence clang-cl /GL warning and move official actions to Node 24

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -24,7 +24,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install clang-format
       run: |
         sudo apt-get update -qq
@@ -79,7 +79,7 @@ jobs:
             needs_pybind: true
     name: ${{ matrix.name }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install clang-format
       run: sudo apt-get update && sudo apt-get install -y clang-format
@@ -30,8 +30,8 @@ jobs:
   verify-docs-current:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     - name: Verify indicator docs are in sync with registry.def
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: '20'
 
@@ -465,7 +465,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install LLVM repository
       run: |
@@ -536,7 +536,7 @@ jobs:
         sanitizer: [address, undefined]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install dependencies
       run: |
@@ -587,7 +587,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install dependencies
       run: brew install cmake ninja lz4
@@ -638,7 +638,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
@@ -677,7 +677,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
@@ -719,7 +719,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install dependencies
       run: |
@@ -776,7 +776,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -12,13 +12,13 @@ jobs:
   codegen-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # ABI gate scans recent commit messages for `BREAKING:`. Need full
           # history (or at least the PR's commits) to do that.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - run: pip install mkdocs-material

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -39,11 +39,11 @@ jobs:
             arch: x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
 
@@ -87,9 +87,9 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -30,9 +30,9 @@ jobs:
         os: [ubuntu-latest, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -61,8 +61,8 @@ jobs:
     if: always() && (needs.check-actor.result == 'success' || needs.check-actor.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install build scikit-build-core pybind11
@@ -83,8 +83,8 @@ jobs:
     if: always() && (needs.check-actor.result == 'success' || needs.check-actor.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Verify bundled data is in sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,19 @@ if(NOT MSVC)
   endif()
 endif()
 
-if(MSVC)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Genuine cl.exe: whole-program optimization via /GL + /LTCG.
   target_compile_options(${FLOX} PUBLIC
     $<$<CONFIG:Release>:/O2 /GL>
   )
   target_link_options(${FLOX} PUBLIC
     $<$<CONFIG:Release>:/LTCG>
+  )
+elseif(MSVC)
+  # clang-cl has the MSVC frontend but does not accept /GL at compile time
+  # (it emits "argument unused"). Keep /O2; LTO would need -flto, not /GL.
+  target_compile_options(${FLOX} PUBLIC
+    $<$<CONFIG:Release>:/O2>
   )
 else()
   set(FLOX_RELEASE_OPTS -O3 -flto -funroll-loops)


### PR DESCRIPTION
Cleans up two sources of CI noise on the scheduled build.

Problem
- The Release build gated /GL and /LTCG on if(MSVC). CMake reports MSVC true for clang-cl too, so clang-cl received /GL, which it does not accept at compile time and reports as "argument unused during compilation: '/GL'" on every translation unit. Because the flag is PUBLIC it propagated into tests and demos, producing the wall of warnings in the windows-clang-cl job.
- Every job also printed Node 20 deprecation warnings because the official GitHub actions still targeted Node 20.

Changes
- Split the optimization branch: genuine cl.exe keeps /O2 /GL and /LTCG; clang-cl keeps /O2 only. Whole-program optimization on clang-cl would need -flto rather than /GL, so /GL was doing nothing there beyond emitting the warning.
- Bump actions/checkout to v5, actions/setup-node to v5 and actions/setup-python to v6 across all workflows. These are the first majors that run on Node 24, clearing the deprecation warnings on the official actions.

Notes
- ilammy/msvc-dev-cmd stays on v1 (no Node 24 major exists upstream yet), so one Node 20 warning remains until that action updates.
- The recent windows-clang-cl failure on the scheduled run was unrelated: vcpkg z-applocal hit "Access is denied" copying gtest DLLs, a file-lock race during parallel test deployment, not a build error. This PR does not touch that; a rerun clears it.
- CMake reconfigures cleanly on the non-MSVC path locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)