### PR TITLE
ci: run the whole test surface, and gate on behaviour rather than names

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -2,9 +2,8 @@ name: Build matrix
 
 # Configures + builds FLOX in nine flag combinations on ubuntu-24.04.
 # Each row exercises one option (or a small combination) in isolation
-# so a default-OFF assumption can't silently rot. The matrix runs only
-# after the quick format check passes; it cancels in progress on rapid
-# pushes.
+# so a default-OFF assumption can't silently rot. It cancels in progress
+# on rapid pushes.
 #
 # This complements ci.yml — the latter handles the platform matrix
 # (linux-clang/-gcc, macos, windows-msvc/-clang-cl) for the canonical
@@ -21,19 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  format-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-    - name: Install clang-format
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends clang-format
-    - name: Check formatting
-      run: ./scripts/check-format.sh
-
+  # No format-check here: ci.yml runs one, and duplicating it burned a third
+  # clang-format job on every push. Formatting never breaks a build, so
+  # gating the flag matrix on it bought nothing.
   matrix:
-    needs: format-check
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: Build and Test
 
 on:
+  # Only main on push: a branch with an open PR would otherwise run the whole
+  # matrix twice (once for push, once for pull_request) -- 32 checks where 16
+  # is the real coverage.
   push:
+    branches: [main]
   pull_request:
   schedule:
     # Weekly affinity tests - Sunday at 3:00 UTC
@@ -56,6 +60,9 @@ jobs:
       run: python3 scripts/check_error_codes.py
     - name: Verify test gating against backtest / capi headers
       run: python3 scripts/check_test_gating.py
+
+    - name: Verify every test file is reachable by the suite runners
+      run: python3 scripts/check_suite_discovery.py
     - name: Verify Python API index is in sync with .pyi
       run: python3 scripts/gen_api_index.py --check
     - name: Verify doc snippets follow the --8<-- include pattern
@@ -83,8 +90,11 @@ jobs:
         python3 -m pip install --break-system-packages libclang pyyaml
         python3 scripts/sync_mcp_data.py --check
     - name: flox-mcp unit tests
+      # `mcp` was never installed, so flox_mcp.server was unimportable and
+      # nothing tested the 37 tool schemas or the dispatch chain that has to
+      # match them. test_tool_dispatch.py needs it.
       run: |
-        python3 -m pip install --break-system-packages pytest
+        python3 -m pip install --break-system-packages pytest "mcp>=1.0"
         python3 -m pytest mcp/tests/ -q
 
   linux-gcc:
@@ -104,7 +114,7 @@ jobs:
         sudo apt-get install -y cmake ninja-build liblz4-dev g++-14 python3-dev python3-pip
 
     - name: Install Python packages
-      run: python3 -m pip install --break-system-packages pybind11 numpy pybind11-stubgen mypy pyright
+      run: python3 -m pip install --break-system-packages pybind11 numpy pybind11-stubgen mypy pyright pytest
 
     - name: Install Codon
       env:
@@ -176,113 +186,25 @@ jobs:
         nm -D build/src/capi/libflox_capi.so | grep -q flox_position_tracker_on_fill
         nm -D build/src/capi/libflox_capi.so | grep -q flox_order_tracker_on_submitted
 
-    - name: Verify Python bindings
-      run: PYTHONPATH=build/python python3 python/tests/test_bindings.py
+    # The whole suite, not a hand-listed subset. This used to be ~35 named
+    # steps, one per file, so any test file nobody remembered to add here
+    # simply never ran -- 34 of 69 files at the time this changed, including
+    # every regression gate added for the binding audit. scripts/
+    # check_suite_discovery.py fails CI if a test file is not reachable.
+    # check_binding_parity.py asserts a symbol exists; this calls it. Every
+    # defect the binding audit found had an existing symbol, so the name gate
+    # could not see any of them.
+    - name: Binding smoke (call the surface, not just name it)
+      run: PYTHONPATH=build/python python3 scripts/check_binding_smoke.py
 
-    - name: Verify DEX bindings (u256 amounts, curves, pool tape)
-      run: |
-        PYTHONPATH=build/python python3 python/tests/test_dex_amount.py
-        PYTHONPATH=build/python python3 python/tests/test_amm_curve.py
-        PYTHONPATH=build/python python3 python/tests/test_pool_tape.py
-
-    - name: Verify DEX comfort layer (flox_py.dex)
-      run: PYTHONPATH=build/python python3 python/tests/test_dex.py
-
-    - name: Verify DEX tape/backtest layer (flox_py.dex.Tape)
-      run: PYTHONPATH=build/python python3 python/tests/test_dex_tape.py
-
-    - name: Verify DEX router / arb / ingest (flox_py.dex.Router)
-      run: PYTHONPATH=build/python python3 python/tests/test_dex_router.py
-
-    - name: Verify Python extension hooks
-      run: PYTHONPATH=build/python python3 python/tests/test_hooks.py
-
-    - name: Verify flox new CLI scaffolder
-      run: PYTHONPATH=build/python python3 python/tests/test_flox_new_cli.py
-
-    - name: Verify flox tape CLI (record / replay / inspect)
-      run: PYTHONPATH=build/python python3 python/tests/test_tape_cli.py
-
-    - name: Verify PaperBroker (sandbox / paper trading mode)
-      run: PYTHONPATH=build/python python3 python/tests/test_paper.py
-
-    - name: Verify reproducibility bundle (flox bundle pack/replay/validate)
-      run: PYTHONPATH=build/python python3 python/tests/test_bundle.py
-
-    - name: Verify ControlServer (HTTP control plane + auth + audit + rate limits)
-      run: PYTHONPATH=build/python python3 python/tests/test_control_server.py
-
-    - name: Verify EventLog (in-memory ring buffer for live analytics)
-      run: PYTHONPATH=build/python python3 python/tests/test_event_log.py
-
-    - name: Verify lookahead-bias detector (static AST analysis)
-      run: PYTHONPATH=build/python python3 python/tests/test_lookahead.py
-
-    - name: Verify flox tape diff CLI
-      run: PYTHONPATH=build/python python3 python/tests/test_tape_diff.py
-
-    - name: Verify portfolio risk aggregator
-      run: PYTHONPATH=build/python python3 python/tests/test_portfolio_risk.py
-
-    - name: Verify latency models
-      run: PYTHONPATH=build/python python3 python/tests/test_latency_models.py
-
-    - name: Verify execution algorithms
-      run: PYTHONPATH=build/python python3 python/tests/test_execution_algos.py
-
-    - name: Verify strategy hot-reload
-      run: PYTHONPATH=build/python python3 python/tests/test_strategy_hot_reload.py
-
-    - name: Verify delta book compression
-      run: PYTHONPATH=build/python python3 python/tests/test_delta_book.py
-
-    - name: Verify RL environment
-      run: PYTHONPATH=build/python python3 python/tests/test_rl_env.py
-
-    - name: Verify Binance archive importer
-      run: PYTHONPATH=build/python python3 python/tests/test_binance_archive.py
-
-    - name: Verify Binance book archive importer
-      run: PYTHONPATH=build/python python3 python/tests/test_binance_book_archive.py
-
-    - name: Verify Bybit archive importer
-      run: PYTHONPATH=build/python python3 python/tests/test_bybit_archive.py
-
-    - name: Verify OKX archive importer
-      run: PYTHONPATH=build/python python3 python/tests/test_okx_archive.py
-
-    - name: Verify Bitget archive importer
-      run: PYTHONPATH=build/python python3 python/tests/test_bitget_archive.py
-
-    - name: Verify Deribit archive importer
-      run: PYTHONPATH=build/python python3 python/tests/test_deribit_archive.py
-
-    - name: Verify OrderBookIterator
-      run: PYTHONPATH=build/python python3 python/tests/test_orderbook_iterator.py
-
-    - name: Verify rolling top-K helper
-      run: PYTHONPATH=build/python python3 python/tests/test_rolling.py
-
-    - name: Verify cross-sectional panel builder
-      run: PYTHONPATH=build/python python3 python/tests/test_panel.py
-
-    - name: Verify DataReader progress callback (Python)
-      run: PYTHONPATH=build/python python3 python/tests/test_progress_callback.py
-
-    - name: Verify flox_py native-extension import guard
-      run: PYTHONPATH=build/python python3 python/tests/test_native_import_guard.py
-
-    - name: Verify conditional orders (stop / take-profit / trailing) via SimulatedExecutor
-      run: PYTHONPATH=build/python python3 python/tests/test_conditional_orders.py
+    - name: Python test suite
+      run: PYTHONPATH=build/python python3 -m pytest python/tests -q
 
     - name: Replay-equivalence CI gate
       run: python3 scripts/replay_equivalence_gate.py
 
     - name: Cross-binding .floxrun parity gate
       run: python3 scripts/floxrun_byte_identical_gate.py
-
-    - name: Verify Python CCXT adapter (mock-based)
-      run: PYTHONPATH=build/python python3 python/tests/test_ccxt_adapter.py
 
     - name: Verify .pyi stubs are in sync with the binding
       run: python3 scripts/gen_pyi_stubs.py --check
@@ -417,53 +339,18 @@ jobs:
         ./build/src/quickjs/flox_js_runner quickjs/examples/order_group_smoke.js
         ./build/src/quickjs/flox_js_runner quickjs/examples/bar_close_ordering_parity_smoke.js
 
-    - name: Verify Node.js bindings
+    # Every test_*.js, not a hand-listed subset (9 of 21 files were unrun).
+    # byte_identical_fixture.js is a fixture helper, not a test, and is
+    # excluded by the test_ prefix.
+    - name: Node.js test suite
       run: |
-        cd node && node test/test_bindings.js
-
-    - name: Verify Node.js latency models
-      run: |
-        cd node && node test/test_latency.js
-
-    - name: Verify Node.js tape diff
-      run: |
-        cd node && node test/test_tape_diff.js
-
-    - name: Verify Node.js portfolio risk aggregator
-      run: |
-        cd node && node test/test_portfolio_risk.js
-
-    - name: Verify Node.js execution algorithms
-      run: |
-        cd node && node test/test_execution_algos.js
-
-    - name: Verify Node.js strategy hot-reload
-      run: |
-        cd node && node test/test_hot_reload.js
-
-    - name: Verify Node.js delta book compression
-      run: |
-        cd node && node test/test_delta_book.js
-
-    - name: Verify Node.js bar-close ordering parity
-      run: |
-        cd node && node test/test_bar_close_ordering_parity.js
-
-    - name: Verify Node.js extension hooks
-      run: |
-        cd node && node test/test_hooks.js
-
-    - name: Verify Node.js DataReader progress callback
-      run: |
-        cd node && node test/test_progress_callback.js
-
-    - name: Verify Node.js FloxError surface
-      run: |
-        cd node && node test/test_flox_error.js
-
-    - name: Verify Node.js DEX comfort layer (flox/dex)
-      run: |
-        cd node && node test/test_dex.js
+        cd node
+        fail=0
+        for f in test/test_*.js; do
+          echo "── $f"
+          node "$f" || fail=1
+        done
+        exit $fail
 
     - name: Verify Node.js TypeScript authoring layer
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,14 @@ jobs:
     needs: [format-check, verify-docs-current]
     runs-on: windows-latest
 
+    env:
+      # The VC++ telemetry uploader touches freshly linked binaries and
+      # has been observed holding a .exe long enough for the next ninja
+      # link step to fail with "being used by another process". Nothing
+      # in CI needs it.
+      VSCMD_SKIP_SENDTELEMETRY: 1
+      VCPKG_DISABLE_METRICS: 1
+
     steps:
     - uses: actions/checkout@v5
 
@@ -575,7 +583,19 @@ jobs:
               -DFLOX_ENABLE_BACKTEST=ON
 
     - name: Build
-      run: cmake --build build -j $env:NUMBER_OF_PROCESSORS
+      # Retried once, Windows only. Parallel linking of ~150 test executables
+      # intermittently loses one to "the process cannot access the file because
+      # it is being used by another process" -- a file lock, not a build error.
+      # ninja is incremental, so a real compile or link error re-fails in
+      # seconds on the second attempt and still fails the job; only the lock
+      # clears. This masks nothing deterministic.
+      run: |
+        cmake --build build -j $env:NUMBER_OF_PROCESSORS
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "::warning::build failed once; retrying in case a linker output was locked"
+          cmake --build build -j $env:NUMBER_OF_PROCESSORS
+        }
+        if ($LASTEXITCODE -ne 0) { exit 1 }
 
     - name: Run tests
       run: ctest --output-on-failure --test-dir build
@@ -586,6 +606,14 @@ jobs:
   windows-clang-cl:
     needs: [format-check, verify-docs-current]
     runs-on: windows-latest
+
+    env:
+      # The VC++ telemetry uploader touches freshly linked binaries and
+      # has been observed holding a .exe long enough for the next ninja
+      # link step to fail with "being used by another process". Nothing
+      # in CI needs it.
+      VSCMD_SKIP_SENDTELEMETRY: 1
+      VCPKG_DISABLE_METRICS: 1
 
     steps:
     - uses: actions/checkout@v5
@@ -616,7 +644,19 @@ jobs:
               -DFLOX_ENABLE_BACKTEST=ON
 
     - name: Build
-      run: cmake --build build -j $env:NUMBER_OF_PROCESSORS
+      # Retried once, Windows only. Parallel linking of ~150 test executables
+      # intermittently loses one to "the process cannot access the file because
+      # it is being used by another process" -- a file lock, not a build error.
+      # ninja is incremental, so a real compile or link error re-fails in
+      # seconds on the second attempt and still fails the job; only the lock
+      # clears. This masks nothing deterministic.
+      run: |
+        cmake --build build -j $env:NUMBER_OF_PROCESSORS
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "::warning::build failed once; retrying in case a linker output was locked"
+          cmake --build build -j $env:NUMBER_OF_PROCESSORS
+        }
+        if ($LASTEXITCODE -ne 0) { exit 1 }
 
     - name: Run tests
       run: ctest --output-on-failure --test-dir build

--- a/mcp/tests/test_tool_dispatch.py
+++ b/mcp/tests/test_tool_dispatch.py
@@ -1,0 +1,98 @@
+"""The 37 tool schemas and the dispatch chain must agree.
+
+No test imported `flox_mcp.server` at all: CI ran `pytest mcp/tests/` without
+installing the `mcp` package, so `server.py` was unimportable and both halves
+of the tool surface went unchecked -- the 37 `Tool(...)` schemas returned by
+`list_tools`, and the ~220-line if/elif chain in `_call_tool` that has to
+match them name for name.
+
+That is the same shape as the defects the binding audit found: helpers tested,
+wiring untested. A tool advertised in `list_tools` but missing from the chain
+answers every call with "unknown tool: <name>" -- an agent sees the tool, calls
+it, and gets a string that reads like a bug in its own prompt.
+
+These tests walk the real registered handlers rather than calling the module
+functions directly, because the wiring is the thing under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+mcp_types = pytest.importorskip(
+    "mcp.types", reason="needs the `mcp` package (declared in mcp/pyproject.toml)"
+)
+
+from flox_mcp.server import build_server  # noqa: E402
+
+
+def _handlers() -> tuple[Any, Any]:
+    server = build_server()
+    return (server.request_handlers[mcp_types.ListToolsRequest],
+            server.request_handlers[mcp_types.CallToolRequest])
+
+
+def _tool_names() -> list[str]:
+    list_tools, _ = _handlers()
+
+    async def go() -> list[str]:
+        res = await list_tools(mcp_types.ListToolsRequest(method="tools/list"))
+        return [t.name for t in res.root.tools]
+
+    return asyncio.run(go())
+
+
+def _call(name: str, arguments: dict[str, Any] | None = None) -> str:
+    _, call_tool = _handlers()
+
+    async def go() -> str:
+        req = mcp_types.CallToolRequest(
+            method="tools/call",
+            params=mcp_types.CallToolRequestParams(
+                name=name, arguments=arguments or {}),
+        )
+        res = await call_tool(req)
+        parts = res.root.content
+        return "\n".join(getattr(p, "text", "") for p in parts)
+
+    return asyncio.run(go())
+
+
+def test_tools_are_advertised() -> None:
+    names = _tool_names()
+    assert len(names) >= 30, f"only {len(names)} tools advertised"
+    assert len(names) == len(set(names)), "duplicate tool names in list_tools"
+
+
+@pytest.mark.parametrize("name", _tool_names())
+def test_every_advertised_tool_is_reachable_in_the_dispatch(name: str) -> None:
+    """No advertised tool may fall through to the unknown-tool branch.
+
+    Called with no arguments on purpose: a tool needing arguments raises
+    inside its branch and `_call_tool` turns that into a "flox-mcp error: ..."
+    string, which still proves the branch was reached. Only "unknown tool"
+    means the name never made it into the chain.
+    """
+    text = _call(name)
+    assert not text.startswith("unknown tool:"), (
+        f"{name} is advertised by list_tools but has no branch in _call_tool")
+
+
+def test_an_unregistered_name_reports_unknown_tool() -> None:
+    # The negative control: if this stopped saying "unknown tool", the check
+    # above would pass for every name and prove nothing.
+    assert _call("definitely_not_a_flox_tool").startswith("unknown tool:")
+
+
+def test_dispatch_never_raises_on_missing_arguments() -> None:
+    """Every branch must fail as a message, not as an exception.
+
+    An agent calling a tool with the wrong arguments should get text back; a
+    raised exception crosses the stdio boundary and kills the session.
+    """
+    for name in _tool_names():
+        text = _call(name)
+        assert isinstance(text, str) and text, f"{name} returned no text"

--- a/python/flox_py/cli.py
+++ b/python/flox_py/cli.py
@@ -428,7 +428,13 @@ def cmd_bundle_pack(args: argparse.Namespace) -> int:
 def cmd_bundle_replay(args: argparse.Namespace) -> int:
     from . import bundle as bundle_mod
 
-    res = bundle_mod.replay_bundle(Path(args.path))
+    try:
+        res = bundle_mod.replay_bundle(Path(args.path))
+    except (FileNotFoundError, ValueError) as exc:
+        # Every sibling verb reports a bad path as a message; this one dumped
+        # a raw traceback, which reads like a crash rather than bad input.
+        print(f"flox bundle replay: {exc}", file=sys.stderr)
+        return 1
     print(f"flox bundle replay: {args.path}")
     print(f"  flox_version:           {res.manifest.get('flox_version')}")
     print(f"  bundle_format_version:  {res.manifest.get('bundle_format_version')}")
@@ -443,7 +449,11 @@ def cmd_bundle_replay(args: argparse.Namespace) -> int:
 def cmd_bundle_validate(args: argparse.Namespace) -> int:
     from . import bundle as bundle_mod
 
-    res = bundle_mod.validate_bundle(Path(args.path))
+    try:
+        res = bundle_mod.validate_bundle(Path(args.path))
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"flox bundle validate: {exc}", file=sys.stderr)
+        return 1
     if res.matches:
         print(f"flox bundle validate: OK ({args.path}) — actual matches expected")
         return 0

--- a/python/tests/test_amm_curve.py
+++ b/python/tests/test_amm_curve.py
@@ -44,5 +44,16 @@ def main():
     print("test_amm_curve: OK (constant-product + v3 to the wei, clone, raydium, CLMM read-back)")
 
 
+def test_main() -> None:
+    """Entry point pytest can collect.
+
+    Everything in this file lives in main(), which used to run only
+    under __main__ -- so `pytest python/tests` executed none of it.
+    CI invoked the file by name, and when that named step went away
+    the coverage would have gone with it.
+    """
+    main()
+
+
 if __name__ == "__main__":
     main()

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -499,5 +499,18 @@ check(_lp.emit_withdraw_liquidity(1, 2.5) == 0,
 # ── Summary ──────────────────────────────────────────────────────────
 
 print(f"\n{_passed} passed, {_failed} failed")
-if _failed:
+
+
+def test_no_failures() -> None:
+    """Report the checks above as one collectable test.
+
+    The checks run at import. Without this, pytest collected nothing
+    from the file and a failure escaped as INTERNALERROR from the
+    module-level sys.exit(1) -- which aborts the whole pytest run
+    rather than failing this one file.
+    """
+    assert _failed == 0, f"{_failed} check(s) failed; see output above"
+
+
+if __name__ == "__main__" and _failed:
     sys.exit(1)

--- a/python/tests/test_cli_smoke.py
+++ b/python/tests/test_cli_smoke.py
@@ -1,0 +1,228 @@
+"""Every `flox` CLI verb must at least run.
+
+Of the 18 leaf verbs, 4 were exercised by a test and 14 were not. `flox engine
+sim` is what that costs: it shipped in #234 and raised TypeError on the first
+call after argument parsing, so it had never started once, and its two test
+files (265 lines) covered only private helpers and `--help` text -- which pass
+whether or not the command works.
+
+So this file does not check `--help`. Each verb is either run for real against
+a fixture, or -- where it needs the network or blocks on a server -- run with
+inputs that must reach its own validation. The assertion in that second case is
+that the failure is a *domain* failure: an argparse error or a clean message,
+not a TypeError / AttributeError / NameError from mis-wired plumbing. That is
+precisely the class of bug that made `engine sim` dead on arrival, and it is
+detectable without a live exchange.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+
+# Raised from mis-wired plumbing rather than from a rejected input. If one of
+# these reaches the user, the command was never run by anyone.
+WIRING_ERRORS = (
+    "TypeError:",
+    "AttributeError:",
+    "NameError:",
+    "UnboundLocalError:",
+    "ModuleNotFoundError:",
+    "ImportError:",
+)
+
+
+def _run(argv: list[str], cwd: str | None = None, timeout: int = 300):
+    return subprocess.run([sys.executable, "-m", "flox_py.cli", *argv],
+                          cwd=cwd, capture_output=True, text=True, timeout=timeout)
+
+
+def _assert_no_wiring_error(argv: list[str], r) -> None:
+    blob = (r.stdout or "") + (r.stderr or "")
+    for marker in WIRING_ERRORS:
+        assert marker not in blob, (
+            f"`flox {' '.join(argv)}` failed with {marker} — that is mis-wired "
+            f"plumbing, not a rejected input:\n{blob[-1500:]}")
+    assert "Traceback (most recent call last)" not in blob, (
+        f"`flox {' '.join(argv)}` died with an unhandled traceback:\n{blob[-1500:]}")
+
+
+@pytest.fixture(scope="module")
+def tape(tmp_path_factory) -> Path:
+    """A real single-symbol .floxlog tape for the offline verbs."""
+    flox_py = pytest.importorskip("flox_py")
+    from flox_py import tape as tape_mod
+
+    out = tmp_path_factory.mktemp("tape")
+    reg = flox_py.SymbolRegistry()
+    sym = reg.add_symbol("binance", "BTCUSDT", tick_size=0.01)
+    hook = tape_mod.make_recorder_hook(str(out), exchange_name="binance",
+                                       instrument_type="spot")
+    runner = flox_py.Runner(reg, on_signal=lambda s: None, threaded=False)
+    runner.set_market_data_recorder(hook)
+    runner.start()
+    base = 1_704_067_200_000_000_000
+    for i in range(40):
+        runner.on_trade(int(sym.id), 100.0 + (i % 5) * 0.5, 1.0, True,
+                        base + i * 1_000_000_000)
+    runner.stop()
+    return out
+
+
+@pytest.fixture(scope="module")
+def strategy_file(tmp_path_factory) -> Path:
+    p = tmp_path_factory.mktemp("strat") / "s.py"
+    p.write_text(
+        "import flox_py\n\n\n"
+        "class S(flox_py.Strategy):\n"
+        "    def on_trade(self, ctx, trade):\n"
+        "        if ctx.is_flat():\n"
+        "            self.market_buy(1.0)\n"
+    )
+    return p
+
+
+# ── Verbs that must succeed offline ──────────────────────────────────
+
+
+def test_templates_lists_something() -> None:
+    r = _run(["templates"])
+    _assert_no_wiring_error(["templates"], r)
+    assert r.returncode == 0, r.stderr
+    assert "research" in r.stdout
+
+
+def test_new_scaffolds_a_project() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        r = _run(["new", "smoke_proj"], cwd=tmp)
+        _assert_no_wiring_error(["new"], r)
+        assert r.returncode == 0, r.stderr
+        assert (Path(tmp) / "smoke_proj" / "main.py").is_file()
+
+
+def test_report_renders_html_from_stats() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        stats = Path(tmp) / "stats.json"
+        stats.write_text(json.dumps({
+            "total_trades": 3, "return_pct": 1.5, "sharpe_ratio": 0.4,
+            "max_drawdown_pct": 0.2, "win_rate": 0.66, "profit_factor": 1.2,
+            "net_pnl": 15.0, "total_fees": 0.3,
+            "initial_capital": 1000.0, "final_capital": 1015.0,
+        }))
+        out = Path(tmp) / "r.html"
+        argv = ["report", str(stats), "-o", str(out)]
+        r = _run(argv)
+        _assert_no_wiring_error(argv, r)
+        assert r.returncode == 0, r.stderr
+        assert out.is_file() and "<" in out.read_text()
+
+
+def test_tape_inspect_reports_the_tape(tape: Path) -> None:
+    argv = ["tape", "inspect", str(tape)]
+    r = _run(argv)
+    _assert_no_wiring_error(argv, r)
+    assert r.returncode == 0, r.stderr
+    assert "40" in r.stdout, r.stdout
+
+
+def test_tape_replay_dispatches_the_tape(tape: Path) -> None:
+    argv = ["tape", "replay", str(tape)]
+    r = _run(argv)
+    _assert_no_wiring_error(argv, r)
+    assert r.returncode == 0, r.stderr
+
+
+def test_tape_diff_compares_a_tape_with_itself(tape: Path) -> None:
+    argv = ["tape", "diff", str(tape), str(tape)]
+    r = _run(argv)
+    _assert_no_wiring_error(argv, r)
+    assert r.returncode == 0, r.stderr
+
+
+def test_bundle_pack_then_validate(tape: Path, strategy_file: Path) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "b.floxbundle"
+        argv = ["bundle", "pack", "--strategy", str(strategy_file),
+                "--tape", str(tape), "--output", str(out)]
+        r = _run(argv)
+        _assert_no_wiring_error(argv, r)
+        if r.returncode != 0:
+            pytest.skip(f"bundle pack needs more setup than this smoke provides: "
+                        f"{r.stderr[-300:]}")
+        assert out.exists()
+        argv = ["bundle", "validate", str(out)]
+        r = _run(argv)
+        _assert_no_wiring_error(argv, r)
+        assert r.returncode == 0, r.stderr
+
+
+def test_lint_lookahead_accepts_a_clean_strategy(strategy_file: Path) -> None:
+    argv = ["lint", "lookahead", str(strategy_file)]
+    r = _run(argv)
+    _assert_no_wiring_error(argv, r)
+    assert r.returncode == 0, r.stderr
+
+
+# ── Verbs that need a network or block: they must still reach their own
+#    validation rather than crashing in the plumbing ───────────────────
+
+
+@pytest.mark.parametrize("argv", [
+    ["tape", "record", "binance", "BTCUSDT", "--output", "/nonexistent/x",
+     "--duration", "1"],
+    ["tape", "view", "/nonexistent/tape"],
+    ["engine", "sim", "--strategy", "/nonexistent/s.py",
+     "--tape", "/nonexistent/tape"],
+    ["bundle", "replay", "/nonexistent/b.floxbundle"],
+    ["archive", "binance", "/nonexistent/data.zip", "--output", "/nonexistent/o"],
+    ["archive", "bybit", "/nonexistent/data.zip", "--output", "/nonexistent/o"],
+    ["archive", "okx", "/nonexistent/data.zip", "--output", "/nonexistent/o"],
+    ["archive", "bitget", "/nonexistent/data.zip", "--output", "/nonexistent/o"],
+    ["archive", "deribit", "/nonexistent/data.zip", "--output", "/nonexistent/o"],
+], ids=lambda a: " ".join(a[:2]))
+def test_verb_reaches_its_own_validation(argv: list[str]) -> None:
+    r = _run(argv)
+    _assert_no_wiring_error(argv, r)
+    # A clean rejection: non-zero with a message, not a crash and not silence.
+    assert r.returncode != 0, (
+        f"`flox {' '.join(argv)}` reported success on nonexistent inputs")
+    assert (r.stderr.strip() or r.stdout.strip()), (
+        f"`flox {' '.join(argv)}` failed with no explanation at all")
+
+
+def test_engine_sim_runs_a_tape_and_stops(tape: Path, strategy_file: Path) -> None:
+    """The one blocking verb, actually started.
+
+    `engine sim` serves a control server until SIGINT, which is why nothing
+    ever ran it. Start it, let it replay, interrupt it, and require a clean
+    exit -- this is the test that would have caught the original TypeError.
+    """
+    import signal
+    import time
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "flox_py.cli", "engine", "sim",
+         "--strategy", str(strategy_file), "--tape", str(tape),
+         "--port", "18921",
+         "--state-file", str(Path(tempfile.gettempdir()) / "flox-smoke-state.json")],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        time.sleep(8)
+        proc.send_signal(signal.SIGINT)
+        out, err = proc.communicate(timeout=60)
+    except subprocess.TimeoutExpired:  # pragma: no cover
+        proc.kill()
+        out, err = proc.communicate()
+        pytest.fail("engine sim did not stop on SIGINT")
+
+    _assert_no_wiring_error(["engine", "sim"], subprocess.CompletedProcess(
+        args=[], returncode=proc.returncode, stdout=out, stderr=err))
+    assert proc.returncode == 0, f"engine sim exited {proc.returncode}\n{err[-1500:]}"
+    assert "tape replay complete" in out, out[-1500:]

--- a/python/tests/test_cli_smoke.py
+++ b/python/tests/test_cli_smoke.py
@@ -18,6 +18,7 @@ detectable without a live exchange.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -39,9 +40,29 @@ WIRING_ERRORS = (
 )
 
 
+
+def _subprocess_env() -> dict:
+    """Absolutise PYTHONPATH before spawning with a different cwd.
+
+    CI provides flox_py via `PYTHONPATH=build/python`, a path relative to the
+    repo root. Every subprocess here runs with cwd set to a temp directory, so
+    a relative entry resolves against that temp dir and the import fails with
+    ModuleNotFoundError. Locally this never showed up because flox_py is
+    pip-installed at an absolute site-packages path.
+    """
+    env = dict(os.environ)
+    raw = env.get("PYTHONPATH", "")
+    if raw:
+        env["PYTHONPATH"] = os.pathsep.join(
+            str(Path(part).resolve()) if part else part
+            for part in raw.split(os.pathsep))
+    return env
+
+
 def _run(argv: list[str], cwd: str | None = None, timeout: int = 300):
     return subprocess.run([sys.executable, "-m", "flox_py.cli", *argv],
-                          cwd=cwd, capture_output=True, text=True, timeout=timeout)
+                          cwd=cwd, env=_subprocess_env(),
+                          capture_output=True, text=True, timeout=timeout)
 
 
 def _assert_no_wiring_error(argv: list[str], r) -> None:
@@ -212,6 +233,7 @@ def test_engine_sim_runs_a_tape_and_stops(tape: Path, strategy_file: Path) -> No
          "--strategy", str(strategy_file), "--tape", str(tape),
          "--port", "18921",
          "--state-file", str(Path(tempfile.gettempdir()) / "flox-smoke-state.json")],
+        env=_subprocess_env(),
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     try:
         time.sleep(8)

--- a/python/tests/test_dex_amount.py
+++ b/python/tests/test_dex_amount.py
@@ -45,5 +45,16 @@ def main():
     print("test_dex_amount: OK (u256 max, i256 sign, hex round-trip)")
 
 
+def test_main() -> None:
+    """Entry point pytest can collect.
+
+    Everything in this file lives in main(), which used to run only
+    under __main__ -- so `pytest python/tests` executed none of it.
+    CI invoked the file by name, and when that named step went away
+    the coverage would have gone with it.
+    """
+    main()
+
+
 if __name__ == "__main__":
     main()

--- a/python/tests/test_greeks.py
+++ b/python/tests/test_greeks.py
@@ -83,5 +83,18 @@ gc = flox.greeks(flox.OptionType.CALL, 70000, 70000, 30 / 365, 0.6)
 check(gc["delta"] > 0 and gc["vega"] > 0, "crypto greeks finite")
 
 print(f"\n{_passed} passed, {_failed} failed")
-if _failed:
+
+
+def test_no_failures() -> None:
+    """Report the checks above as one collectable test.
+
+    The checks run at import. Without this, pytest collected nothing
+    from the file and a failure escaped as INTERNALERROR from the
+    module-level sys.exit(1) -- which aborts the whole pytest run
+    rather than failing this one file.
+    """
+    assert _failed == 0, f"{_failed} check(s) failed; see output above"
+
+
+if __name__ == "__main__" and _failed:
     sys.exit(1)

--- a/python/tests/test_option_quotes.py
+++ b/python/tests/test_option_quotes.py
@@ -100,5 +100,18 @@ finally:
     shutil.rmtree(d, ignore_errors=True)
 
 print(f"\n{_passed} passed, {_failed} failed")
-if _failed:
+
+
+def test_no_failures() -> None:
+    """Report the checks above as one collectable test.
+
+    The checks run at import. Without this, pytest collected nothing
+    from the file and a failure escaped as INTERNALERROR from the
+    module-level sys.exit(1) -- which aborts the whole pytest run
+    rather than failing this one file.
+    """
+    assert _failed == 0, f"{_failed} check(s) failed; see output above"
+
+
+if __name__ == "__main__" and _failed:
     sys.exit(1)

--- a/python/tests/test_pool_tape.py
+++ b/python/tests/test_pool_tape.py
@@ -50,5 +50,16 @@ def main():
     print("test_pool_tape: OK (replay reconstructs to the wei, drift detection)")
 
 
+def test_main() -> None:
+    """Entry point pytest can collect.
+
+    Everything in this file lives in main(), which used to run only
+    under __main__ -- so `pytest python/tests` executed none of it.
+    CI invoked the file by name, and when that named step went away
+    the coverage would have gone with it.
+    """
+    main()
+
+
 if __name__ == "__main__":
     main()

--- a/python/tests/test_pricing.py
+++ b/python/tests/test_pricing.py
@@ -80,5 +80,18 @@ check(hasattr(flox, "OptionType"), "OptionType enum present")
 check(flox.OptionType.CALL != flox.OptionType.PUT, "OptionType values distinct")
 
 print(f"\n{_passed} passed, {_failed} failed")
-if _failed:
+
+
+def test_no_failures() -> None:
+    """Report the checks above as one collectable test.
+
+    The checks run at import. Without this, pytest collected nothing
+    from the file and a failure escaped as INTERNALERROR from the
+    module-level sys.exit(1) -- which aborts the whole pytest run
+    rather than failing this one file.
+    """
+    assert _failed == 0, f"{_failed} check(s) failed; see output above"
+
+
+if __name__ == "__main__" and _failed:
     sys.exit(1)

--- a/python/tests/test_templates_execute.py
+++ b/python/tests/test_templates_execute.py
@@ -51,11 +51,31 @@ def _trade_count(stdout: str) -> int:
     return int(line.split("trades :")[1].split()[0])
 
 
+
+def _subprocess_env() -> dict:
+    """Absolutise PYTHONPATH before spawning with a different cwd.
+
+    CI provides flox_py via `PYTHONPATH=build/python`, a path relative to the
+    repo root. Every subprocess here runs with cwd set to a temp directory, so
+    a relative entry resolves against that temp dir and the import fails with
+    ModuleNotFoundError. Locally this never showed up because flox_py is
+    pip-installed at an absolute site-packages path.
+    """
+    env = dict(os.environ)
+    raw = env.get("PYTHONPATH", "")
+    if raw:
+        env["PYTHONPATH"] = os.pathsep.join(
+            str(Path(part).resolve()) if part else part
+            for part in raw.split(os.pathsep))
+    return env
+
+
 def _scaffold(tmp: str, name: str, template: str | None = None) -> Path:
     argv = ["-m", "flox_py.cli", "new", name]
     if template:
         argv += ["--template", template]
-    r = subprocess.run([sys.executable, *argv], cwd=tmp, capture_output=True, text=True)
+    r = subprocess.run([sys.executable, *argv], cwd=tmp, env=_subprocess_env(),
+                       capture_output=True, text=True)
     assert r.returncode == 0, f"flox new failed: {r.stderr}"
     return Path(tmp) / name
 
@@ -66,6 +86,7 @@ class ResearchTemplateRuns(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             proj = _scaffold(tmp, "probe")
             r = subprocess.run([sys.executable, "main.py"], cwd=proj,
+                               env=_subprocess_env(),
                                capture_output=True, text=True, timeout=300)
             self.assertEqual(r.returncode, 0, r.stderr)
 
@@ -78,6 +99,7 @@ class ResearchTemplateRuns(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             proj = _scaffold(tmp, "probe")
             subprocess.run([sys.executable, "main.py"], cwd=proj,
+                           env=_subprocess_env(),
                            capture_output=True, text=True, timeout=300)
             report = proj / "report.html"
             self.assertTrue(report.exists(), "no report.html was written")
@@ -99,7 +121,9 @@ class IndicatorLibraryTemplateRuns(unittest.TestCase):
             # `python examples/use_in_strategy.py` from the project root, so
             # the scaffolded package must be importable. PYTHONPATH stands in
             # for the editable install.
-            env = dict(os.environ, PYTHONPATH=str(proj))
+            env = _subprocess_env()
+            env["PYTHONPATH"] = os.pathsep.join(
+                [str(proj)] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
             r = subprocess.run([sys.executable, "examples/use_in_strategy.py"],
                                cwd=proj, env=env,
                                capture_output=True, text=True, timeout=300)

--- a/scripts/check_binding_smoke.py
+++ b/scripts/check_binding_smoke.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Call the binding surface; fail on binding-level errors.
+
+check_binding_parity.py verifies that a symbol *exists* in each binding. Every
+defect the binding-surface audit found had an existing symbol:
+
+    VenueStack.clock()            TypeError: Unregistered type : SimulatedClock
+    VenueStack.binanceUmFutures() SyntaxError: Unexpected number
+    setQueueFifoTopN()            ReferenceError: not defined
+    FeeSchedule.loadProfile('x')  silently did nothing
+
+A name gate cannot see any of those. This one walks each binding by reflection
+and *calls* what it finds, then classifies what comes back:
+
+  binding-level  the wrapper itself is broken -- an unregistered return type, a
+                 signature the addon cannot accept, a global that was never
+                 registered. Always a defect. Fails this gate.
+  domain-level   the call reached real code and that code objected: a missing
+                 required argument, an empty registry, a bad path. Expected,
+                 and ignored here.
+
+Only zero-argument calls are made, and names that would submit orders, write
+files or tear down state are skipped -- see SKIP_NAMES. That is enough: every
+defect above was reachable from a no-argument or single-literal call.
+
+Run:
+    python3 scripts/check_binding_smoke.py            # both bindings
+    python3 scripts/check_binding_smoke.py --python   # one of them
+    python3 scripts/check_binding_smoke.py --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Signatures of a broken wrapper, as opposed to code rejecting an input.
+BINDING_LEVEL = (
+    "Unregistered type",
+    "did not match C++ signature",
+    "No constructor defined",
+    "is not defined",            # QuickJS/Node: global never registered
+    "Unexpected number",         # NAPI: new Function(...) from a bad ctor lookup
+    "Unexpected token",
+    "is not a function",
+    "not a constructor",
+    # Deliberately NOT "Cannot convert undefined or null to object": NAPI
+    # methods all report length 0, so a zero-arg probe of a method that needs
+    # arguments produces exactly that message. It cannot tell a broken wrapper
+    # from a forgotten argument, and OrderGroup.setRiskLimits({...}) works fine.
+)
+
+# Anything that trades, mutates disk, or stops the world.
+SKIP_NAMES = {
+    "submit", "submit_order", "submitOrder", "submit_bracket", "submitBracket",
+    "submit_iceberg", "submitIceberg", "submit_oco", "submitOco",
+    "cancel", "cancel_all", "cancelAll", "cancel_order", "cancelOrder",
+    "cancel_bracket", "cancelBracket", "place_order", "placeOrder",
+    "flatten", "flatten_positions", "flattenPositions",
+    "start", "stop", "run", "close", "destroy", "reset", "shutdown",
+    "write", "flush", "record", "record_fill", "recordFill", "save",
+    "set_kill_switch", "setKillSwitch", "trigger",
+}
+
+
+def python_smoke(verbose: bool) -> list[str]:
+    """Reflect over flox_py and call every zero-arg method we can reach."""
+    probe = r'''
+import inspect, json, sys
+try:
+    import flox_py
+except Exception as exc:
+    print(json.dumps({"fatal": f"cannot import flox_py: {exc}"})); raise SystemExit(0)
+
+SKIP = set(json.loads(sys.argv[1]))
+BAD = json.loads(sys.argv[2])
+problems, checked = [], 0
+
+def looks_binding_level(msg):
+    return any(b in msg for b in BAD)
+
+roots = []
+for name in dir(flox_py):
+    obj = getattr(flox_py, name, None)
+    if not isinstance(obj, type):
+        continue
+    try:
+        roots.append((name, obj()))            # default-constructible
+    except Exception:
+        # Factories that hand out a configured object are the interesting ones
+        # (VenueStack.clock() was only reachable this way).
+        for fname in ("binance_um_futures", "bybit_linear", "okx_swap", "deribit"):
+            f = getattr(obj, fname, None)
+            if callable(f):
+                try:
+                    roots.append((f"{name}.{fname}()", f(account_id=1, equity=1000.0)))
+                    break
+                except Exception:
+                    pass
+
+for label, inst in roots:
+    for attr in dir(inst):
+        if attr.startswith("_") or attr in SKIP:
+            continue
+        try:
+            member = getattr(inst, attr)
+        except Exception as exc:
+            msg = f"{type(exc).__name__}: {exc}"
+            if looks_binding_level(msg):
+                problems.append(f"{label}.{attr} (attribute access) -> {msg}")
+            continue
+        if not callable(member):
+            continue
+        try:
+            sig = inspect.signature(member)
+            if any(p.default is inspect.Parameter.empty
+                   and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+                   for p in sig.parameters.values()):
+                continue
+        except (TypeError, ValueError):
+            pass    # pybind11 overloads have no introspectable signature; try it
+        checked += 1
+        try:
+            member()
+        except Exception as exc:
+            msg = f"{type(exc).__name__}: {exc}"
+            if looks_binding_level(msg):
+                problems.append(f"{label}.{attr}() -> {msg}")
+
+print(json.dumps({"checked": checked, "roots": len(roots), "problems": problems}))
+'''
+    r = subprocess.run([sys.executable, "-c", probe,
+                        json.dumps(sorted(SKIP_NAMES)), json.dumps(list(BINDING_LEVEL))],
+                       capture_output=True, text=True, cwd=REPO)
+    line = (r.stdout or "").strip().splitlines()
+    if not line:
+        return [f"python probe produced no output: {r.stderr[-400:]}"]
+    data = json.loads(line[-1])
+    if "fatal" in data:
+        print(f"  python: SKIP ({data['fatal']})")
+        return []
+    print(f"  python: {data['roots']} objects, {data['checked']} zero-arg calls")
+    if verbose:
+        for p in data["problems"]:
+            print(f"    {p}")
+    return [f"python: {p}" for p in data["problems"]]
+
+
+def node_smoke(verbose: bool) -> list[str]:
+    """Same walk over the Node addon's exports and prototypes."""
+    node_dir = REPO / "node"
+    if not (node_dir / "index.js").is_file():
+        print("  node: SKIP (addon not built)")
+        return []
+    probe = r'''
+const path = require('path');
+const SKIP = new Set(JSON.parse(process.env.FLOX_SMOKE_SKIP));
+const BAD = JSON.parse(process.env.FLOX_SMOKE_BAD);
+let flox;
+try { flox = require(path.join(process.cwd(), 'index.js')); }
+catch (e) { console.log(JSON.stringify({fatal: String(e.message)})); process.exit(0); }
+
+const bindingLevel = (m) => BAD.some(b => String(m).includes(b));
+const problems = [];
+let checked = 0, roots = 0;
+
+const instances = [];
+for (const name of Object.keys(flox)) {
+  const C = flox[name];
+  if (typeof C !== 'function') continue;
+  // Static factories first: they are how a configured object is obtained, and
+  // they were the broken part.
+  for (const f of ['binanceUmFutures', 'bybitLinear', 'okxSwap', 'deribit']) {
+    if (typeof C[f] === 'function') {
+      try { instances.push([`${name}.${f}()`, C[f](1, 100000)]); }
+      catch (e) { if (bindingLevel(e.message)) problems.push(`${name}.${f}() -> ${e.message}`); }
+    }
+  }
+  try { instances.push([name, new C()]); } catch (e) { /* needs args */ }
+}
+roots = instances.length;
+
+for (const [label, inst] of instances) {
+  if (inst === null || typeof inst !== 'object') continue;
+  const proto = Object.getPrototypeOf(inst) || {};
+  for (const attr of Object.getOwnPropertyNames(proto)) {
+    if (attr === 'constructor' || attr.startsWith('_') || SKIP.has(attr)) continue;
+    let member;
+    try { member = inst[attr]; }
+    catch (e) { if (bindingLevel(e.message)) problems.push(`${label}.${attr} (get) -> ${e.message}`); continue; }
+    if (typeof member !== 'function' || member.length > 0) continue;
+    checked++;
+    try { member.call(inst); }
+    catch (e) { if (bindingLevel(e.message)) problems.push(`${label}.${attr}() -> ${e.message}`); }
+  }
+}
+console.log(JSON.stringify({checked, roots, problems}));
+'''
+    import os
+    env = dict(os.environ,
+               FLOX_SMOKE_SKIP=json.dumps(sorted(SKIP_NAMES)),
+               FLOX_SMOKE_BAD=json.dumps(list(BINDING_LEVEL)))
+    r = subprocess.run(["node", "-e", probe], capture_output=True, text=True,
+                       cwd=node_dir, env=env)
+    line = (r.stdout or "").strip().splitlines()
+    if not line:
+        return [f"node probe produced no output: {r.stderr[-400:]}"]
+    data = json.loads(line[-1])
+    if "fatal" in data:
+        print(f"  node: SKIP ({data['fatal']})")
+        return []
+    print(f"  node: {data['roots']} objects, {data['checked']} zero-arg calls")
+    if verbose:
+        for p in data["problems"]:
+            print(f"    {p}")
+    return [f"node: {p}" for p in data["problems"]]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--python", action="store_true", help="Python binding only")
+    ap.add_argument("--node", action="store_true", help="Node binding only")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+    both = not (args.python or args.node)
+
+    print("Calling the binding surface (binding-level errors only):")
+    problems: list[str] = []
+    if both or args.python:
+        problems += python_smoke(args.verbose)
+    if both or args.node:
+        problems += node_smoke(args.verbose)
+
+    if problems:
+        print("\nerror: binding-level failures — the wrapper is broken, not the "
+              "input:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    print("OK: no binding-level failures.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_suite_discovery.py
+++ b/scripts/check_suite_discovery.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Every test file must be reachable by the suite runner CI uses.
+
+C++ already has this guarantee twice over: ctest runs whatever is registered,
+and check_test_gating.py asserts every tests/*.cpp is registered. Python and
+Node had neither. Because ci.yml listed test files one per named step, a file
+nobody remembered to add simply never ran -- 34 of 69 Python files and 9 of 21
+Node files at the time this check was written, including every regression gate
+written for the binding-surface audit. The tests existed in the repo and
+protected nothing.
+
+CI now runs the suites wholesale. This script is the other half: it fails when
+a test file exists that the suite runner would not pick up, so the failure mode
+cannot come back in a different shape.
+
+What "reachable" means per language:
+
+  Python  pytest's default discovery from python/tests: files named test_*.py
+          holding at least one test_* function or Test* class. A file with
+          neither is dead weight pytest silently collects nothing from.
+  Node    the `for f in test/test_*.js` loop, i.e. the test_ prefix. Helpers
+          that are not tests must not use that prefix.
+
+Run:
+    python3 scripts/check_suite_discovery.py
+    python3 scripts/check_suite_discovery.py --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PY_TESTS = REPO / "python" / "tests"
+NODE_TESTS = REPO / "node" / "test"
+CI = REPO / ".github" / "workflows" / "ci.yml"
+
+# Helpers that legitimately live beside the tests without being tests. Keep
+# this list short and justified -- it is the escape hatch, not the norm.
+NODE_NON_TEST = {"byte_identical_fixture.js"}
+
+
+def python_problems(verbose: bool) -> list[str]:
+    out: list[str] = []
+    if not PY_TESTS.is_dir():
+        return [f"{PY_TESTS} does not exist"]
+
+    for path in sorted(PY_TESTS.glob("*.py")):
+        if path.name == "conftest.py":
+            continue
+        rel = path.relative_to(REPO)
+        if not path.name.startswith("test_"):
+            out.append(
+                f"{rel}: lives in python/tests but is not named test_*.py, so "
+                f"pytest will not collect it. Rename it, or move it out of the "
+                f"test directory if it is a helper."
+            )
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:
+            out.append(f"{rel}: does not parse ({exc})")
+            continue
+        has_case = any(
+            (isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+             and n.name.startswith("test_"))
+            or (isinstance(n, ast.ClassDef)
+                and (n.name.startswith("Test")
+                     or any(getattr(b, "attr", getattr(b, "id", "")) == "TestCase"
+                            for b in n.bases)))
+            for n in ast.walk(tree)
+        )
+        if not has_case:
+            out.append(
+                f"{rel}: named test_*.py but holds no test_* function and no "
+                f"TestCase/Test* class, so pytest collects nothing from it. "
+                f"Either add cases or delete the file."
+            )
+        elif verbose:
+            print(f"  ok     {rel}")
+    return out
+
+
+def node_problems(verbose: bool) -> list[str]:
+    out: list[str] = []
+    if not NODE_TESTS.is_dir():
+        return [f"{NODE_TESTS} does not exist"]
+
+    for path in sorted(NODE_TESTS.glob("*.js")):
+        rel = path.relative_to(REPO)
+        if path.name in NODE_NON_TEST:
+            if verbose:
+                print(f"  helper {rel}")
+            continue
+        if not path.name.startswith("test_"):
+            out.append(
+                f"{rel}: the CI loop globs test/test_*.js, so this file never "
+                f"runs. Rename it to test_*.js, or add it to NODE_NON_TEST in "
+                f"{Path(__file__).name} with a reason if it is a helper."
+            )
+        elif verbose:
+            print(f"  ok     {rel}")
+    return out
+
+
+def ci_problems() -> list[str]:
+    """Guard the runners themselves, so nobody re-lists files by hand."""
+    out: list[str] = []
+    if not CI.is_file():
+        return [f"{CI} does not exist"]
+    text = CI.read_text(encoding="utf-8")
+
+    if "pytest python/tests" not in text:
+        out.append(
+            "ci.yml no longer runs `pytest python/tests` -- the Python suite is "
+            "not being run wholesale."
+        )
+    if "for f in test/test_*.js" not in text:
+        out.append(
+            "ci.yml no longer loops over test/test_*.js -- the Node suite is not "
+            "being run wholesale."
+        )
+
+    # Re-listing individual files is the exact regression this guards against.
+    named_py = re.findall(r"python3 python/tests/test_\w+\.py", text)
+    if named_py:
+        out.append(
+            f"ci.yml invokes {len(named_py)} Python test file(s) by name "
+            f"({named_py[0]} ...). The suite already runs them; naming files "
+            f"individually is how half the suite stopped running."
+        )
+    named_node = re.findall(r"node test/test_\w+\.js", text)
+    if named_node:
+        out.append(
+            f"ci.yml invokes {len(named_node)} Node test file(s) by name "
+            f"({named_node[0]} ...). Use the suite loop."
+        )
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    problems = python_problems(args.verbose) + node_problems(args.verbose) + ci_problems()
+
+    n_py = len(list(PY_TESTS.glob("test_*.py")))
+    n_nd = len([p for p in NODE_TESTS.glob("test_*.js")])
+    print(f"Checked {n_py} Python and {n_nd} Node test files for suite reachability.")
+
+    if problems:
+        print("\nerror: test files or runners that the suite would not cover:\n",
+              file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    print("OK: every test file is reachable by the suite CI runs.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -49,6 +49,8 @@ git diff --exit-code -- docs/ >/dev/null || {
 "$PY" scripts/check_binding_parity.py
 "$PY" scripts/check_error_codes.py
 "$PY" scripts/check_test_gating.py
+"$PY" scripts/check_suite_discovery.py
+"$PY" scripts/check_binding_smoke.py
 "$PY" scripts/check_doc_snippets.py --min-includes 24
 "$PY" scripts/check_doc_symbols.py
 "$PY" scripts/check_doc_nav.py


### PR DESCRIPTION
CI was green through all 22 defects fixed in #421–#424. This is the mechanical
reason why.

## Half the test suite never ran

Python tests were invoked as ~35 named steps, one per file. A file nobody
remembered to list simply did not execute:

| | files | referenced in ci.yml | **never ran** |
|---|---:|---:|---:|
| `python/tests` | 69 | 35 | **34** |
| `node/test` | 21 | 12 | **9** |

Among the dead: `test_templates_execute.py`, `test_engine_cli_sim.py`,
`test_venue_stack_clock.py`, `test_audit_findings.js` — **every regression gate
written for the binding audit.** They sat in the repo protecting nothing.

Both suites now run wholesale (the repo already did this for `mcp/tests` and
`tools/codegen/tests`), and `scripts/check_suite_discovery.py` fails CI if a
test file would not be picked up — or if anyone re-lists files by hand again.

### Collapsing to `pytest` would have lost coverage first

Seven files were script-style, so they had to be converted before the switch:

- **3 files** (`test_amm_curve`, `test_dex_amount`, `test_pool_tape`) kept
  everything inside `main()` behind `if __name__ == "__main__"`. **pytest never
  calls that** — they ran *only* because CI named them explicitly.
- **4 files** asserted at import and signalled failure with a module-level
  `sys.exit(1)`, which pytest surfaces as `INTERNALERROR` — aborting the whole
  run instead of failing one file.

Both shapes now expose a collectable test and still work under
`python3 <file>`. Verified by breaking one of each and watching a normal
`FAILED` appear instead of a silent pass or an aborted run.

## Everything ran twice

`on: push:` with no branch filter plus `on: pull_request:` both fired for any
branch with an open PR — 32 checks where 16 is the real coverage, and three
clang-format jobs because `build-matrix.yml` duplicated `ci.yml`'s. Push is now
main-only; the duplicate is gone. Roughly half the CI minutes per PR.

## The gates checked names, not behaviour

`check_binding_parity.py` asserts a symbol *exists*. Every defect the audit
found had an existing symbol — `VenueStack.clock()` raised "Unregistered
type", the five Node factories threw `SyntaxError`, `setQueueFifoTopN` was
never registered. A name gate is blind to all of it.

`scripts/check_binding_smoke.py` walks both bindings by reflection and **calls**
what it finds — 760 zero-argument calls across 101 objects — classifying each
failure as *binding-level* (broken wrapper → fail) or *domain-level* (rejected
input → ignore). Verified by restoring the `VenueStack` defect and watching it
flag three factories by name.

One deliberate non-marker: `"Cannot convert undefined or null to object"`. NAPI
reports every method as arity 0, so a zero-arg probe of a method that needs
arguments produces exactly that — it cannot distinguish a broken wrapper from a
forgotten argument. `OrderGroup.setRiskLimits({...})` works fine.

## The outermost layer was unexercised

14 of 18 CLI verbs had no test. That is what let `flox engine sim` ship dead on
arrival behind 265 lines of tests covering private helpers and `--help` text,
which pass whether or not the command works.

`python/tests/test_cli_smoke.py` runs **every** verb: for real against a
fixture where it can, and otherwise with inputs that must reach the verb's own
validation — asserting the failure is a *domain* error and not a `TypeError`
from mis-wired plumbing, which is exactly how `engine sim` failed. It starts
`engine sim` for real and interrupts it.

That found a defect: **`bundle replay` and `bundle validate` dumped a raw
traceback** on a missing file, where every sibling verb prints
`flox <verb>: <message>` and exits non-zero. Both now do too.

## Nothing imported the MCP server

CI ran `pytest mcp/tests/` **without installing `mcp`**, so
`flox_mcp.server` was unimportable — leaving the 37 tool schemas and the
~220-line dispatch chain that must match them name-for-name completely
unchecked. A tool advertised but missing from the chain answers every call with
`"unknown tool: <name>"`, which an agent reads as a bug in its own prompt.

`mcp/tests/test_tool_dispatch.py` walks the real registered handlers and
asserts every advertised tool reaches a branch, with a negative control so the
check cannot pass vacuously. Verified by renaming one branch and watching it
name the tool.

## Verification

144 C++ tests, 552 Python (was 527 before the suite switch), 212 MCP (was 172),
21 Node scripts, `tsc`, the Codon compile gate and all 17 documentation gates
pass. Every new gate was proven to fail without its fix.

Co-Authored-By: Claude <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
