### PR TITLE
venue: optional matching-engine module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   # matrix twice (once for push, once for pull_request) -- 32 checks where 16
   # is the real coverage.
   push:
-    branches: [main]
+    branches: [main, 'venue/**']
   pull_request:
   schedule:
     # Weekly affinity tests - Sunday at 3:00 UTC
@@ -450,7 +450,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, undefined]
+        sanitizer: [address, undefined, thread]
 
     steps:
     - uses: actions/checkout@v5
@@ -757,3 +757,74 @@ jobs:
 
     - name: Verify static archive exists
       run: test -f build/connectors/libflox-connectors.a
+
+  # The venue module must stay genuinely optional: a build with it OFF has to
+  # configure, compile and pass its suite with no venue code involved. Cheap
+  # job, but it is the only thing that stops the OFF path from rotting.
+  venue-optional:
+    needs: [format-check, verify-docs-current]
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build g++-14 libgtest-dev libgmock-dev
+
+    - name: Configure without the venue
+      run: |
+        cmake -B build -G Ninja \
+              -DCMAKE_CXX_COMPILER=g++-14 \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DFLOX_BUILD_VENUE=OFF \
+              -DFLOX_BUILD_TESTS=ON \
+              -DFLOX_BUILD_DEMO=ON \
+              -DFLOX_ENABLE_BACKTEST=ON
+
+    - name: Build
+      run: cmake --build build -j$(nproc)
+
+    - name: Test
+      run: ctest --output-on-failure --test-dir build
+
+    - name: Verify nothing venue-side was built
+      run: |
+        test ! -f build/venue/libflox-venue.a
+        ! ctest --test-dir build -N | grep -qE "Test +#[0-9]+: test_venue_(matcher|engine|ledger)"
+
+  # Weekly deep run of the venue fuzzes. Pull requests run them at a
+  # CI-friendly depth; this raises the command count by an order of magnitude,
+  # which is where the rarer book divergences and reservation leaks surface.
+  venue-deep-fuzz:
+    if: github.event_name == 'schedule'
+    needs: [format-check, verify-docs-current]
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build g++-14 libgtest-dev libgmock-dev
+
+    - name: Configure
+      run: |
+        cmake -B build -G Ninja \
+              -DCMAKE_CXX_COMPILER=g++-14 \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DFLOX_BUILD_TESTS=ON \
+              -DFLOX_ENABLE_BACKTEST=ON
+
+    - name: Build the fuzz targets
+      run: cmake --build build --target test_venue_differential_fuzz test_venue_conservation_fuzz -j$(nproc)
+
+    - name: Differential fuzz (deep)
+      env:
+        FLOX_FUZZ_OPS: 2000000
+      run: ./build/venue/test_venue_differential_fuzz
+
+    - name: Conservation fuzz
+      run: ./build/venue/test_venue_conservation_fuzz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,9 @@ jobs:
       # nothing tested the 37 tool schemas or the dispatch chain that has to
       # match them. test_tool_dispatch.py needs it.
       run: |
-        python3 -m pip install --break-system-packages pytest "mcp>=1.0"
+        # Pinned below 2.0: the 2.x SDK dropped the @server.list_tools() /
+        # @server.call_tool() decorators this server is built on.
+        python3 -m pip install --break-system-packages pytest "mcp>=1.0,<2"
         python3 -m pytest mcp/tests/ -q
 
   linux-gcc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   # matrix twice (once for push, once for pull_request) -- 32 checks where 16
   # is the real coverage.
   push:
-    branches: [main, 'venue/**']
+    branches: [main]
   pull_request:
   schedule:
     # Weekly affinity tests - Sunday at 3:00 UTC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,15 @@ file(GLOB_RECURSE SRC_FILES
 # after enable_testing() so the module's tests register.
 option(FLOX_BUILD_VENUE "Build the venue module (matching engine, clearing, venue risk)" ON)
 
+# The venue ledger keeps money in native 128-bit integers so a notional can
+# never overflow and a rounding drift is impossible. MSVC and clang-cl have no
+# __int128, so the module is unavailable there until that type is ported onto
+# the portable wide-integer helpers in flox/util/int.
+if(FLOX_BUILD_VENUE AND MSVC)
+  message(STATUS "FLOX_BUILD_VENUE: no native 128-bit integers on MSVC/clang-cl; disabling.")
+  set(FLOX_BUILD_VENUE OFF CACHE BOOL "Build the venue module" FORCE)
+endif()
+
 option(FLOX_ENABLE_BACKTEST "Enable backtest module" OFF)
 if(FLOX_BUILD_VENUE AND NOT FLOX_ENABLE_BACKTEST)
   message(STATUS "FLOX_BUILD_VENUE=ON implies FLOX_ENABLE_BACKTEST=ON; enabling.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,18 @@ file(GLOB_RECURSE SRC_FILES
     src/run/*.cpp
 )
 
+# The venue module reuses backtest-side primitives (FeeSchedule,
+# RateLimitPolicy, LiquidationEngine, Account), so it implies the backtest
+# module. Declared here, before the option below, so the implication applies on
+# a first configure; the add_subdirectory(venue) itself lives further down,
+# after enable_testing() so the module's tests register.
+option(FLOX_BUILD_VENUE "Build the venue module (matching engine, clearing, venue risk)" ON)
+
 option(FLOX_ENABLE_BACKTEST "Enable backtest module" OFF)
+if(FLOX_BUILD_VENUE AND NOT FLOX_ENABLE_BACKTEST)
+  message(STATUS "FLOX_BUILD_VENUE=ON implies FLOX_ENABLE_BACKTEST=ON; enabling.")
+  set(FLOX_ENABLE_BACKTEST ON CACHE BOOL "Enable backtest module" FORCE)
+endif()
 if(FLOX_ENABLE_BACKTEST)
   file(GLOB BACKTEST_SRC_FILES src/backtest/*.cpp)
   list(APPEND SRC_FILES ${BACKTEST_SRC_FILES})
@@ -259,6 +270,11 @@ option(FLOX_BUILD_TESTS "Build tests" OFF)
 if (FLOX_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif()
+
+# Venue module (option declared above, next to the backtest implication).
+if (FLOX_BUILD_VENUE)
+  add_subdirectory(venue)
 endif()
 
 option(FLOX_BUILD_DEMO "Build demo application" OFF)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ See [the package README](./mcp/README.md) for setup and the full tool list.
 
 Native exchange connectors (Bybit, Bitget, Hyperliquid, Polymarket) live under [`connectors/`](./connectors/) and build with `-DFLOX_BUILD_CONNECTORS=ON`. The flag defaults to OFF so a backtest-only or research build doesn't pay the dependency cost. See the [connectors README](./connectors/README.md) for adapter notes and the optional Polymarket Rust toolchain step.
 
+## Venue
+
+Beyond trading on a market, FLOX can be one: the optional [`venue/`](./venue/) module adds a matching engine and the machinery around it, so many participants can trade against a single order book. See the [venue docs](https://flox-foundation.github.io/flox/venue/).
+
 ## Build options
 
 The CMake options that gate every optional artefact (bindings, demo, tools, tests, benchmarks, connectors) are catalogued in [`docs/build/feature-flags.md`](https://flox-foundation.github.io/flox/build/feature-flags/). Defaults are OFF so a bare `cmake -B build` produces only the core C++ static library.

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -43,3 +43,11 @@ target_link_libraries(market_profile_demo PRIVATE ${FLOX})
 add_executable(cex_demo src/cex_demo.cpp)
 target_include_directories(cex_demo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(cex_demo PRIVATE ${FLOX})
+
+# Multi-agent venue simulation: several agents trading against one shared book
+# through the venue matching engine (needs the venue module).
+if(FLOX_BUILD_VENUE)
+  add_executable(multi_agent_venue_demo src/multi_agent_venue_demo.cpp)
+  target_include_directories(multi_agent_venue_demo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  target_link_libraries(multi_agent_venue_demo PRIVATE flox::venue)
+endif()

--- a/demo/include/demo/latency_collector.h
+++ b/demo/include/demo/latency_collector.h
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -41,11 +42,14 @@ class LatencyCollector
 
   static constexpr size_t MaxSamples = 1 << 20;  // 1M
 
+  // Called from every connector/strategy thread: claim a slot atomically,
+  // then write the sample without contention.
   void record(LabelId id, std::chrono::nanoseconds delta)
   {
-    if (_count[id] < MaxSamples)
+    const size_t slot = _count[id].fetch_add(1, std::memory_order_relaxed);
+    if (slot < MaxSamples)
     {
-      _samples[id][_count[id]++] = delta.count();
+      _samples[id][slot] = delta.count();
     }
   }
 
@@ -53,8 +57,8 @@ class LatencyCollector
   {
     for (size_t i = 0; i < LabelCount; ++i)
     {
-      const auto n = _count[i];
-      if (n == 0 || n > MaxSamples)
+      const auto n = std::min(_count[i].load(std::memory_order_relaxed), MaxSamples);
+      if (n == 0)
       {
         continue;
       }
@@ -83,7 +87,7 @@ class LatencyCollector
 
  private:
   inline static std::array<std::array<int64_t, MaxSamples>, LabelCount> _samples{};
-  inline static std::array<size_t, LabelCount> _count{};
+  inline static std::array<std::atomic<size_t>, LabelCount> _count{};
 };
 
 }  // namespace demo

--- a/demo/src/demo_builder.cpp
+++ b/demo/src/demo_builder.cpp
@@ -84,13 +84,18 @@ std::unique_ptr<Engine> DemoBuilder::build()
     connectors.push_back(conn);
   }
 
-  subsystems.push_back(std::move(bookUpdateBus));
-  subsystems.push_back(std::move(tradeBus));
-  subsystems.push_back(std::move(barBus));
-  subsystems.push_back(std::move(execBus));
+  // Engine::stop() stops subsystems in reverse registration order, so
+  // registration must run consumers-first: a subscriber that is registered
+  // after its bus would be stopped while the bus is still delivering to it
+  // (the bar aggregator's stop() flushes and clears state the trade-bus
+  // consumers were concurrently writing).
   subsystems.push_back(std::move(execTracker));
   subsystems.push_back(std::move(trackerAdapter));
+  subsystems.push_back(std::move(execBus));
+  subsystems.push_back(std::move(barBus));
   subsystems.push_back(std::move(barAggregator));
+  subsystems.push_back(std::move(tradeBus));
+  subsystems.push_back(std::move(bookUpdateBus));
 
   return std::make_unique<Engine>(_config, std::move(subsystems), std::move(connectors));
 }

--- a/demo/src/multi_agent_venue_demo.cpp
+++ b/demo/src/multi_agent_venue_demo.cpp
@@ -1,0 +1,253 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Multi-agent venue simulation.
+ *
+ * A backtest replays a recorded tape: the market never reacts to you. Here the
+ * market IS the other participants. Several agents trade against ONE order book
+ * through the venue matching engine, so price is an emergent result of their
+ * interaction, and every fill costs someone else the other side.
+ *
+ * Agents:
+ *   - MarketMaker: quotes a two-sided spread around its own fair value, and
+ *     skews its quotes as inventory builds up (classic inventory control).
+ *   - Momentum: buys after up-ticks, sells after down-ticks.
+ *   - MeanReversion: fades moves away from a long-run anchor.
+ *   - NoiseTrader: random small market orders (uninformed flow).
+ *
+ * Everything settles through the venue venue::Ledger, so the run also demonstrates
+ * that value is conserved: the sum of all cash + inventory marked at the last
+ * price equals what was deposited, no matter who won.
+ */
+
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+
+#include "flox/book/matching_book.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace flox;
+namespace venue = flox::venue;  // qualify: flox::Trade / flox::SymbolConfig also exist
+
+namespace
+{
+constexpr SymbolId SYM = 1;
+constexpr venue::AssetId CASH = 0;
+constexpr venue::AssetId STOCK = 1;
+constexpr uint64_t VENUE_ACCOUNT = 999;
+constexpr double kStartPrice = 100.0;
+
+Price px(double v) { return Price::fromDouble(v); }
+// A quote must sit on the tick grid: the venue rejects anything else
+// (TickSizeViolation), exactly as a real exchange does.
+double onTick(double v) { return static_cast<double>(static_cast<long long>(v * 100.0 + 0.5)) / 100.0; }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+double toD(venue::Amount a) { return static_cast<double>(static_cast<int64_t>(a)) / 1e8; }
+
+venue::SymbolConfig cfg()
+{
+  venue::SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  c.baseAsset = STOCK;
+  c.quoteAsset = CASH;
+  return c;
+}
+
+// Deterministic RNG: the whole run is reproducible.
+struct Rng
+{
+  uint64_t s{0x9E3779B97F4A7C15ULL};
+  uint64_t next()
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  }
+  double uniform() { return static_cast<double>(next() % 10000) / 10000.0; }
+  bool coin() { return (next() & 1) != 0; }
+};
+
+struct Agent
+{
+  uint64_t account{};
+  std::string name;
+  const char* kind{};
+};
+}  // namespace
+
+int main()
+{
+  venue::Ledger ledger;
+  const std::vector<Agent> agents{
+      {1, "market-maker", "MM"},
+      {2, "momentum", "MOM"},
+      {3, "mean-reversion", "REV"},
+      {4, "noise", "NOISE"},
+  };
+
+  // Everyone starts with the same book value: cash + inventory.
+  constexpr double kCash = 1'000'000.0;
+  constexpr double kStock = 1'000.0;
+  for (const auto& a : agents)
+  {
+    ledger.deposit(a.account, CASH, venue::amountOf(Volume::fromDouble(kCash)));
+    ledger.deposit(a.account, STOCK, venue::amountOf(qty(kStock)));
+  }
+  const double startEquity = kCash + kStock * kStartPrice;
+
+  double lastPrice = kStartPrice;
+  uint64_t trades = 0;
+  uint64_t rejects = 0;
+  venue::MatchingEngine<MatchingBook> venue(cfg(),
+                                            [&](const venue::OutboundEvent& e)
+                                            {
+                                              if (const auto* t = std::get_if<venue::Trade>(&e))
+                                              {
+                                                lastPrice = t->price.toDouble();
+                                                ++trades;
+                                              }
+                                              if (std::get_if<venue::OrderRejected>(&e) != nullptr)
+                                              {
+                                                ++rejects;
+                                              }
+                                            });
+  venue.setLedger(&ledger, VENUE_ACCOUNT);
+
+  Rng rng;
+  OrderId nextId = 1;
+  double prevRoundClose = lastPrice;
+  double roundDelta = 0.0;   // price move produced by the previous round
+  double mmInventory = 0.0;  // maker's stock position vs its starting inventory
+
+  auto submit = [&](uint64_t account, Side side, OrderType type, double price, double quantity,
+                    TimeInForce tif)
+  {
+    venue::NewOrder o;
+    o.id = nextId++;
+    o.symbol = SYM;
+    o.accountId = account;
+    o.side = side;
+    o.type = type;
+    o.price = px(price);
+    o.quantity = qty(quantity);
+    o.tif = tif;
+    venue.submit(venue::InboundCommand{o}, static_cast<int64_t>(nextId));
+  };
+
+  constexpr int kRounds = 20'000;
+  std::printf("multi-agent venue: %d rounds, %zu agents, one shared book\n\n", kRounds,
+              agents.size());
+
+  for (int round = 0; round < kRounds; ++round)
+  {
+    // ---- market maker: quote around fair value, skewed by inventory ----
+    // As it accumulates stock it lowers both quotes to attract sellers less and
+    // buyers more -- the mechanism that keeps a real maker's position bounded.
+    {
+      const double skew = mmInventory * 0.002;
+      const double fair = lastPrice - skew;
+      const double halfSpread = 0.05;
+      submit(1, Side::BUY, OrderType::LIMIT, onTick(fair - halfSpread), 20, TimeInForce::GTC);
+      submit(1, Side::SELL, OrderType::LIMIT, onTick(fair + halfSpread), 20, TimeInForce::GTC);
+    }
+
+    // ---- momentum: chase the previous round's move ----
+    if (roundDelta > 0.02 || roundDelta < -0.02)
+    {
+      const bool up = roundDelta > 0.0;
+      submit(2, up ? Side::BUY : Side::SELL, OrderType::MARKET, 0, 1 + rng.uniform() * 2,
+             TimeInForce::IOC);
+    }
+
+    // ---- mean reversion: fade deviation from the anchor ----
+    {
+      const double dev = lastPrice - kStartPrice;
+      const double absDev = dev > 0 ? dev : -dev;
+      if (absDev > 0.10)
+      {
+        // Size scales with how stretched the price is -- the harder the push,
+        // the harder this agent leans against it.
+        const double size = 1.0 + absDev * 2.0 + rng.uniform();
+        submit(3, dev > 0 ? Side::SELL : Side::BUY, OrderType::MARKET, 0, size, TimeInForce::IOC);
+      }
+    }
+
+    // ---- noise: uninformed flow ----
+    if (rng.uniform() < 0.3)
+    {
+      submit(4, rng.coin() ? Side::BUY : Side::SELL, OrderType::MARKET, 0, 1 + rng.uniform() * 2,
+             TimeInForce::IOC);
+    }
+
+    roundDelta = lastPrice - prevRoundClose;
+    prevRoundClose = lastPrice;
+    // Spot venue: inventory is the maker's stock balance vs what it started with
+    // (positionQty is the perp position and is always flat here).
+    mmInventory = toD(ledger.total(1, STOCK)) - kStock;
+
+    // The maker refreshes quotes every round; pull the stale ones.
+    venue.submit(venue::InboundCommand{venue::MassCancel{1, SYM}}, static_cast<int64_t>(nextId++));
+
+    if (round % 5000 == 0 && round > 0)
+    {
+      std::printf("  round %5d   last=%.2f   trades=%llu\n", round, lastPrice,
+                  static_cast<unsigned long long>(trades));
+    }
+  }
+
+  // ---- results ----
+  std::printf("\nfinal price %.2f after %llu trades (%llu rejects)\n\n", lastPrice,
+              static_cast<unsigned long long>(trades), static_cast<unsigned long long>(rejects));
+  std::printf("%-16s %12s %10s %14s\n", "agent", "cash", "stock", "pnl");
+
+  double totalEquity = 0.0;
+  for (const auto& a : agents)
+  {
+    const double cash = toD(ledger.total(a.account, CASH));
+    const double stock = toD(ledger.total(a.account, STOCK));
+    const double equity = cash + stock * lastPrice;
+    totalEquity += equity;
+    std::printf("%-16s %12.2f %10.2f %+14.2f\n", a.name.c_str(), cash, stock,
+                equity - startEquity);
+  }
+
+  // The venue account holds fees (none configured here) and the clearing pool.
+  const double venueCash = toD(ledger.total(VENUE_ACCOUNT, CASH));
+  const double venueStock = toD(ledger.total(VENUE_ACCOUNT, STOCK));
+  totalEquity += venueCash + venueStock * lastPrice;
+
+  // Conservation is a property of the ASSETS, not of mark-to-market equity:
+  // cash and stock are only ever exchanged, so each total is invariant. Total
+  // equity moves with the last price because the same inventory is marked at a
+  // different level -- that is a valuation effect, not leakage.
+  double cashSum = venueCash;
+  double stockSum = venueStock;
+  for (const auto& a : agents)
+  {
+    cashSum += toD(ledger.total(a.account, CASH));
+    stockSum += toD(ledger.total(a.account, STOCK));
+  }
+  const double cash0 = kCash * static_cast<double>(agents.size());
+  const double stock0 = kStock * static_cast<double>(agents.size());
+  std::printf("\nconservation   cash %.2f -> %.2f (drift %+.8f)\n", cash0, cashSum, cashSum - cash0);
+  std::printf("               stock %.2f -> %.2f (drift %+.8f)\n", stock0, stockSum,
+              stockSum - stock0);
+  std::printf("\nequity %.2f vs %.2f start: the %+.2f is inventory re-marked at %.2f,\n",
+              totalEquity, startEquity * static_cast<double>(agents.size()),
+              totalEquity - startEquity * static_cast<double>(agents.size()), lastPrice);
+  std::printf("not leakage -- one agent's gain is another's loss.\n");
+  return 0;
+}

--- a/docs/venue/build.md
+++ b/docs/venue/build.md
@@ -26,6 +26,15 @@ library). Turning it off removes:
 A `-DFLOX_BUILD_VENUE=OFF` build configures and passes its full test suite with
 no venue code compiled at all — verify with `ctest` after building.
 
+## Platform support
+
+Linux and macOS. The module is skipped on MSVC and clang-cl: the ledger keeps
+money in native 128-bit integers (`__int128`) so a notional cannot overflow and
+a rounding drift is impossible, and those compilers have no such type. A
+Windows build simply configures with the module off — porting the money type
+onto the portable wide-integer helpers in `flox/util/int` would lift the
+restriction.
+
 ## What it costs when ON
 
 Nothing beyond the module itself. The venue links only `${FLOX}` core: no new

--- a/docs/venue/build.md
+++ b/docs/venue/build.md
@@ -1,0 +1,67 @@
+# Building with and without the venue
+
+The venue is an optional module. If you only write strategies, backtests, or
+connectors, you never pay for it.
+
+## The flag
+
+```bash
+# with the venue (default)
+cmake -S . -B build
+cmake --build build
+
+# without it — nothing venue-related is configured, compiled, or tested
+cmake -S . -B build -DFLOX_BUILD_VENUE=OFF
+cmake --build build
+```
+
+`FLOX_BUILD_VENUE` follows the repository's `FLOX_BUILD_*` convention (the flags
+that gate optional build outputs; `FLOX_ENABLE_*` gates capabilities of the core
+library). Turning it off removes:
+
+- the `flox-venue` library target and its headers from the build,
+- every venue test from `ctest`,
+- `multi_agent_venue_demo` from the demo targets.
+
+A `-DFLOX_BUILD_VENUE=OFF` build configures and passes its full test suite with
+no venue code compiled at all — verify with `ctest` after building.
+
+## What it costs when ON
+
+Nothing beyond the module itself. The venue links only `${FLOX}` core: no new
+third-party dependency is forced on you. The one heavy dependency in the module
+— OpenSSL, needed by the TLS gateway — is detected inside `venue/CMakeLists.txt`
+and is **optional**: without it the module still builds and only the TLS gateway
+test is skipped, exactly the posture `connectors/` uses.
+
+## Consuming it
+
+```cmake
+target_link_libraries(my_target PRIVATE flox::venue)
+```
+
+That brings the include prefix with it:
+
+```cpp
+#include "flox-venue/matching_engine.h"   // module
+#include "flox/book/matching_book.h"      // core (order-level books live in core)
+```
+
+## Layout
+
+```
+venue/
+  CMakeLists.txt          target flox::venue, gated by FLOX_BUILD_VENUE
+  include/flox-venue/     public headers, namespace flox::venue
+  src/                    the few non-header translation units
+  tests/                  the verification corpus (registered into flox ctest)
+  scripts/                sanitizer gate
+  benchmarks/             book microbenchmark
+  AUDIT-LOG.md            defects found and fixed while hardening the module
+  DESIGN.md               the original build plan
+```
+
+Order-level books (`flox/book/{resting_order,matching_book,ladder_book}.h`) and
+the shared utilities the venue needed (`flox/util/{crypto,wire,transport,
+websocket,system_clock}.h`) live in **core**, not the module: they are useful on
+their own and carry no venue-specific policy.

--- a/docs/venue/clearing.md
+++ b/docs/venue/clearing.md
@@ -54,7 +54,27 @@ Note the distinction the [multi-agent demo](multi-agent.md) makes explicit:
 cash and inventory are conserved *exactly*, while total mark-to-market equity
 moves with the last price. That is valuation, not leakage.
 
-## Fee policy
+## Per-symbol scale
+
+The default fixed-point scale (1e8) caps an int64 quantity at ~9.2e10 whole
+units -- too small for tokens whose circulating supply runs to 1e14. Such a
+symbol sets `priceScale`/`qtyScale` on its `SymbolConfig` (and on
+`configureSymbol` for cross margin); its price and quantity raws are then
+interpreted in those units end to end -- matching, reservation, settlement,
+margin, PnL, funding, fees, and metrics.
+
+Two invariants keep the money model simple:
+
+- **Money never changes scale.** Every quote amount in the ledger is at the
+  fixed 1e-8 scale (`venue::kMoneyScale`) regardless of the symbol that
+  produced it, so balances from symbols with different scales add up safely.
+- **A base-asset balance is the symbol's qty raw.** All symbols sharing a base
+  asset must therefore use one `qtyScale`.
+
+Scales must be positive, and `qtyScale` must divide or be a multiple of the
+money scale (any power of ten works) -- `venue::scalesValid` checks the pair.
+At the default scale every formula is bit-identical to the fixed-scale code it
+generalized, so determinism hashes and replays are unaffected.
 
 Fees flow through `flox::FeeSchedule` (maker rebate / taker fee, volume tiers).
 The venue gate reserves the **notional**, and the taker fee is charged

--- a/docs/venue/clearing.md
+++ b/docs/venue/clearing.md
@@ -1,0 +1,98 @@
+# Clearing and the ledger
+
+A matching engine that only moves quantities is a toy. `Ledger` is what makes it
+a venue that moves money.
+
+## Model
+
+Double entry, multi-asset. Every account holds, per asset, an `available` and a
+`reserved` balance in raw fixed point (1e-8 units) stored as `__int128` — wide
+enough that a notional can never overflow, and never `double`, so a rounding
+drift is impossible rather than merely unlikely.
+
+```cpp
+Ledger led;
+led.deposit(acct, USD, amountOf(Volume::fromDouble(10'000)));
+
+led.reserve(acct, USD, amt);        // available -> reserved (fails if short, no partial)
+led.release(acct, USD, amt);        // reserved -> available
+led.spendReserved(acct, USD, amt);  // reserved is paid out on a fill
+led.credit(acct, BTC, amt);         // signed
+led.debit(acct, USD, amt);          // all-or-nothing
+```
+
+Attach it to the engine and settlement happens automatically:
+
+```cpp
+venue.setLedger(&ledger, /*venue account*/ 999);
+```
+
+## Lifecycle of buying power
+
+1. **Order entry reserves.** A bid reserves quote (`limitPrice * quantity`), an
+   ask reserves base. If the reservation fails the order is rejected — this is
+   the pre-trade buying-power gate.
+2. **A fill settles.** Base and quote change hands, the over-reservation (price
+   improvement) is released, fees move to the venue account.
+3. **Every exit releases.** Cancel, IOC/FOK/MARKET residual, post-only rejection,
+   LULD rejection, GTD expiry, STP, mass-cancel, liquidation, last-look reject —
+   each returns the unspent reservation.
+
+That last point is where venues leak. A reservation stranded in `reserved` is
+invisible to a conservation-of-total check, because the money never left the
+account — it is simply frozen forever. The fuzz therefore asserts a second,
+stronger property: after the book is drained, **every account's `reserved` is
+zero**. See [Verification](verification.md).
+
+## Conservation
+
+Assets are only ever exchanged, so each asset's total across all accounts plus
+the venue account is invariant. The conservation fuzz checks this after every
+command over a random stream of all order types.
+
+Note the distinction the [multi-agent demo](multi-agent.md) makes explicit:
+cash and inventory are conserved *exactly*, while total mark-to-market equity
+moves with the last price. That is valuation, not leakage.
+
+## Fee policy
+
+Fees flow through `flox::FeeSchedule` (maker rebate / taker fee, volume tiers).
+The venue gate reserves the **notional**, and the taker fee is charged
+post-settlement. A taker with exactly the notional therefore ends fee-sized
+negative rather than being pre-rejected: conservation still holds, the venue
+still collects, and the deficit is bounded by the fee. This is a deliberate
+policy choice, pinned by a test, not an oversight.
+
+## Two margin models, on purpose
+
+`flox::venue::CrossMarginManager` and `flox::LiquidationEngine`
+(`flox/backtest/`) both liquidate. They are not duplicates — they answer
+different questions:
+
+| | `LiquidationEngine` (backtest) | `CrossMarginManager` (venue) |
+|---|---|---|
+| Money | `double` equity | `Ledger`-backed `__int128` |
+| Driven by | a mark tape | live venue state |
+| Optimised for | speed, cascade modelling, ADL ranking, mark impact | exactness: conservation per asset, multi-asset collateral haircuts, segregation |
+
+Collapsing them would either put `double` money on the venue path or force
+ledger machinery into backtests. It is the same split flox already makes between
+`SimulatedClock` and `SystemClock`: one concept, two drivers. Pick by what you
+are building; do not mix them for the same account.
+
+## Segregation
+
+`SegregationReport` answers the compliance question: is client money fully
+backed by the segregated custody balance?
+
+```cpp
+SegregationReport seg(ledger, /*house accounts*/ {VENUE, INSURANCE});
+seg.clientTotal(USD);              // sum of each client's POSITIVE balance
+seg.fullyBacked(USD, custody);
+seg.shortfall(USD, custody);       // > 0 is a reportable breach
+```
+
+Client money owed is the sum of **positive** obligations per account. A client's
+debit balance is the firm's receivable, not a reduction of what it owes other
+clients — netting it would understate the requirement and let a real custody
+shortfall report as fully backed.

--- a/docs/venue/index.md
+++ b/docs/venue/index.md
@@ -75,6 +75,10 @@ someone the other side. That enables things a tape cannot express:
 - **Money is `__int128` fixed point**, never `double`. See
   [Clearing](clearing.md) for why the venue and the backtest keep separate
   margin models.
+- **Per-symbol scale.** A symbol whose price or supply range does not fit the
+  default 1e8 scale in int64 (a meme coin with a 1e14 supply) sets its own
+  `priceScale`/`qtyScale` in `SymbolConfig`; money still settles at the fixed
+  1e-8 scale. See [Clearing](clearing.md#per-symbol-scale).
 
 ## Verification
 

--- a/docs/venue/index.md
+++ b/docs/venue/index.md
@@ -1,0 +1,91 @@
+# The venue module
+
+Everything else in flox helps you **trade on a market**. This module lets you
+**be the market**: match participants' orders against each other, clear the
+money that changes hands, and manage the risk of standing in the middle.
+
+It is an optional module — the same shape as `connectors/` — so the core library
+stays lean for people who never need it. See
+[Building with and without the venue](build.md).
+
+```cpp
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/ledger.h"
+#include "flox/book/matching_book.h"
+
+namespace venue = flox::venue;   // qualify venue types; see the namespace note below
+using namespace flox;
+
+venue::Ledger ledger;
+ledger.deposit(/*account*/ 1, /*asset*/ 0, venue::amountOf(Quantity::fromDouble(10)));
+
+venue::MatchingEngine<MatchingBook> engine(cfg, [](const venue::OutboundEvent&) { /* publish */ });
+engine.setLedger(&ledger, /*venue account*/ 999);
+engine.submit(venue::InboundCommand{order});
+```
+
+## Why this exists
+
+A backtest replays a recorded tape. Whatever you do, the tape does not care:
+your fills never move the price, your size never runs out of liquidity, and no
+counterparty ever adapts. That is fine for a first pass and misleading for
+anything sensitive to impact, queue position, or crowding.
+
+With a venue in the loop the market **is** the other participants. Price becomes
+an emergent result of who is quoting and who is taking, and every fill costs
+someone the other side. That enables things a tape cannot express:
+
+- **Multi-agent simulation** — many strategies (or AI agents) trading against
+  one book, with impact and adaptation as emergent behaviour. See
+  [Multi-agent simulation](multi-agent.md).
+- **Realistic execution research** — queue priority, iceberg refills, self-trade
+  prevention, last-look rejection, auction uncrosses.
+- **Running an actual venue** — clearing, margin, liquidation, insurance, ADL,
+  funding, market data, recovery, and a network perimeter.
+
+## The pieces
+
+| Area | What it does | Read more |
+|---|---|---|
+| Books | Order-level price-time and pro-rata matching books | [Matching](matching.md) |
+| Matching engine | Order lifecycle: TIF, stops, OCO, peg, iceberg, auctions, LULD | [Matching](matching.md) |
+| Ledger | Double-entry money, conservation-exact | [Clearing](clearing.md) |
+| Derivatives risk | Margin, liquidation, insurance, ADL, funding, mark price | [Risk](risk.md) |
+| Runtime | Single-writer sequenced core, journal, deterministic replay | [Runtime and recovery](runtime.md) |
+| Market data | Venue events to an L2 feed (ITCH-style) | [Market data](market-data.md) |
+| Perimeter | TCP/WS/TLS/UDP gateways, sessions, FIX/OUCH/REST codecs, control plane | [Perimeter](perimeter.md) |
+
+## Design notes
+
+- **Namespace `flox::venue`.** Nested, so venue vocabulary can reuse names the
+  strategy side already owns — `Trade` and `SymbolConfig` exist in both. Scalars
+  (`Price`, `Quantity`, `Side`, `OrderId`) come from `flox/common.h` as
+  everywhere else.
+
+    Because the two sets overlap, do **not** pull both in unqualified: a
+    translation unit that does `using namespace flox;` *and*
+    `using namespace flox::venue;` makes `Trade` and `SymbolConfig` ambiguous as
+    soon as it also includes `flox/book/trade.h` or `flox/engine/engine_config.h`.
+    Prefer `namespace venue = flox::venue;` and qualify (`venue::SymbolConfig`),
+    or import only what you need.
+- **Include prefix `<flox-venue/...>`**, target `flox::venue`.
+- **Order-level books live in core** (`flox/book/`), next to the aggregate
+  `NLevelOrderBook`, because they are useful on their own. Everything that only
+  makes sense for a venue lives in the module.
+- **Money is `__int128` fixed point**, never `double`. See
+  [Clearing](clearing.md) for why the venue and the backtest keep separate
+  margin models.
+
+## Verification
+
+The venue core is fuzz-proven in flox CI, not just unit-tested:
+
+- **Differential fuzz** — the reference book and the O(1) ladder are driven in
+  lockstep over a random command stream; they must emit a byte-identical event
+  stream and never leave a crossed book.
+- **Conservation fuzz** — value is never created or destroyed, and after the
+  book is drained every account's `reserved` returns to zero.
+
+Plus a sanitizer gate (ASAN/UBSAN/TSAN) over the parsers, fuzzes and concurrent
+paths. See [Verification](verification.md), and `venue/AUDIT-LOG.md` for the
+defects this corpus caught while the module was hardened.

--- a/docs/venue/market-data.md
+++ b/docs/venue/market-data.md
@@ -1,0 +1,78 @@
+# Market data
+
+The engine emits `OutboundEvent`s about individual orders. A market data feed is
+a different thing: an ordered, sequenced stream that subscribers can apply to
+rebuild the book. `MarketDataPublisher` is the bridge.
+
+```cpp
+MarketDataPublisher<> md([](const MdMessage& m) { multicast(m); },
+                         /*tickSize*/ Price::fromDouble(0.01), /*symbol*/ 1);
+
+MatchingEngine<MatchingBook> venue(cfg, [&](const OutboundEvent& e)
+                                   {
+                                     md.onEvent(e);   // fan the venue stream into MD
+                                     ledgerOrMetrics(e);
+                                   });
+
+md.book();   // flox::NLevelOrderBook kept in step with the venue book
+```
+
+## Messages
+
+| `MdType` | Meaning | `qty` field |
+|---|---|---|
+| `AddOrder` | an order joined the book | shown quantity |
+| `Trade` | a print (`id` is the taker) | executed quantity |
+| `Executed` | a resting order was hit | displayed remaining |
+| `Cancel` | an order left the book | — |
+| `Replace` | an order was repriced/resized | displayed remaining |
+| `Triggered` | a stop fired | — |
+
+Every message carries a monotonically increasing `seq`, so a consumer can detect
+a gap and request a resend.
+
+## Depth is the aggregate, kept in step
+
+The publisher maintains a `flox::NLevelOrderBook` — the same aggregate book type
+strategies consume elsewhere — so market-data depth and the venue's internal
+order-level book stay in agreement. That agreement is not assumed: the test
+suite drives 300k commands and periodically compares the publisher's full depth
+against the engine's book.
+
+## Icebergs never leak
+
+An iceberg shows a peak and hides the rest. The public feed must only ever see
+the peak, or the book can be probed for hidden size by watching what the feed
+reports.
+
+That is why `OrderExecuted` carries **two** quantities:
+
+- `leavesQty` — the whole remaining (peak + hidden), for the **owner's**
+  execution report. You should see your own order in full.
+- `displayLeaves` — the displayed peak, for the **public feed**.
+
+The publisher drives depth from `displayLeaves`. Using the whole remaining would
+both leak the reserve and, on a partial peak fill, corrupt the level aggregate.
+
+## ITCH codec and multicast
+
+`itch_codec.h` encodes `MdMessage` into a fixed 46-byte big-endian frame, and
+`UdpMdPublisher` (`udp_multicast.h`) publishes it over IP multicast (with `UdpMdSubscriber` on the receiving end) — the shape a real feed takes.
+
+```cpp
+std::vector<uint8_t> buf;
+ItchCodec::encode(msg, buf);                       // appends the frame
+
+MdMessage out;
+const bool ok = ItchCodec::decode(buf.data(), buf.size(), out);   // false if short
+```
+
+The decoder bounds-checks before reading, and is exercised by the parser fuzz
+against hostile input alongside the FIX/OUCH/REST parsers.
+
+## Tape
+
+`tape_recorder.h` writes the outbound stream through flox's
+`BinaryLogWriter`, so a venue session records into the same binary format the
+rest of flox reads — the tape a venue produces can be replayed by ordinary flox
+tooling.

--- a/docs/venue/matching.md
+++ b/docs/venue/matching.md
@@ -1,0 +1,126 @@
+# Matching
+
+## Two books, one interface
+
+Order-level books live in core (`flox/book/`) and are distinct from
+`NLevelOrderBook`, which aggregates per-level totals for market data. Matching
+needs individual orders: to keep time priority, cancel by id, and refill icebergs.
+
+| Book | Shape | Use |
+|---|---|---|
+| `MatchingBook` | `std::map` + `std::list`, allocates | Reference oracle. Obviously correct, easy to reason about. |
+| `LadderBook` | tick-indexed dense ladders, intrusive FIFO over a node pool, occupancy bitmap | Performance path. O(1) best, O(1) next level, no steady-state allocation. |
+
+They are interchangeable (`MatchingEngine<MatchingBook>` /
+`MatchingEngine<LadderBook>`) and are held to be **observationally identical** by
+a differential fuzz — see [Verification](verification.md).
+
+```cpp
+LadderBook book(LadderBook::Config{
+    .basePriceRaw = 0,
+    .tickRaw      = Price::fromDouble(0.01).raw(),
+    .numLevels    = 20000,     // price band height, in ticks
+    .maxOrders    = 1 << 20}); // node pool capacity
+```
+
+## Matching policies
+
+`Matcher<Book>` implements the allocation rule:
+
+- **Price-time (FIFO)** — the default. Best price first; within a price, oldest
+  order first.
+- **Pro-rata** — allocation at a level is proportional to resting size, with the
+  usual leftover pass.
+
+```cpp
+Matcher<MatchingBook> m(MatchPolicy::ProRata);
+m.setStpGroup(/*account*/ 10, /*firm*/ 1);   // firm-scope self-trade prevention
+```
+
+### Self-trade prevention
+
+Four modes, applied when the aggressor and the maker share an STP scope (the
+account, or the firm group registered via `setStpGroup`):
+
+| Mode | Effect |
+|---|---|
+| `CancelNewest` | the incoming order is killed |
+| `CancelOldest` | the resting order is pulled, matching continues |
+| `CancelBoth` | both go |
+| `Decrement` | the smaller leg is removed, the larger is reduced by that size; no trade |
+
+STP interacts with `FOK`: an all-or-none order cannot count liquidity it would
+never be allowed to trade with, so the precheck excludes same-scope resting size.
+
+## Order types and time in force
+
+`NewOrder` carries the full venue vocabulary:
+
+- **Types** — `LIMIT`, `MARKET`, `STOP_MARKET`, `STOP_LIMIT`, `TAKE_PROFIT*`,
+  `TRAILING_STOP`.
+- **TIF** — `GTC`, `IOC`, `FOK`, `GTD` (with `expiryNs`), `POST_ONLY`.
+- **Iceberg** — `visibleQuantity` shows a peak and hides the rest; the hidden
+  reserve is real liquidity for matching but never leaks to the public feed.
+- **Peg** — `PegRef::{Bid,Ask,Mid}` plus a signed offset; repriced at each submit
+  boundary, tick-aligned, clamped so it never crosses.
+- **OCO** — `ocoGroup`; a fill on one leg cancels its siblings.
+- **Reduce-only** — perp orders that may only reduce a position, re-capped on
+  submit, trigger, and modify.
+
+## The engine
+
+`MatchingEngine<Book>` owns the lifecycle around the matcher: validation, risk
+gates, stops, expiry, pegs, auctions, clearing, and event emission.
+
+```cpp
+SymbolConfig cfg;
+cfg.id = 1;
+cfg.tickSize = Price::fromDouble(0.01);
+cfg.minPrice = Price::fromDouble(1);      // 0 = unchecked
+cfg.maxPrice = Price::fromDouble(1000);
+cfg.baseAsset = 0;
+cfg.quoteAsset = 1;
+
+MatchingEngine<MatchingBook> venue(cfg, [](const OutboundEvent& e) { publish(e); });
+venue.submit(InboundCommand{order}, tsNs);
+```
+
+Every state-mutating input is an `InboundCommand`: `NewOrder`, `CancelOrder`,
+`ModifyOrder`, `MassCancel`, `Quote`, `LastLookDecision`, `SetMark`,
+`ApplyFunding`, `AdminCmd`. That is what makes deterministic replay possible —
+see [Runtime and recovery](runtime.md).
+
+### Pre-trade risk
+
+Configured on `SymbolConfig` and adjustable live (operators tighten during
+volatility without a restart):
+
+| Control | Config | Live setter |
+|---|---|---|
+| Tick / lot / min quantity | `tickSize`, `lotSize`, `minQty` | — |
+| Price band (collar) | `minPrice`, `maxPrice` | — |
+| Fat finger | `maxOrderQty`, `maxOrderNotional` | `setFatFinger` |
+| LULD volatility band | `luldBps`, `luldHaltNs` | `setLuldBps` |
+| Max resting orders per account | `maxOpenOrders` | `setMaxOpenOrders` |
+| Max position (perp) | `maxPositionQty` | `setPositionLimit` |
+| Margin requirement | `initialMarginBps`, `maintenanceMarginBps` | `setMarginBps` |
+| Halt | `halted` | `setHalted` |
+
+### Market-maker features
+
+- **Last look** — `lastLookWindowNs`: the maker holds a fill and answers with
+  `LastLookDecision`. On reject or timeout the held quantity does not trade, and
+  both sides' reservations are returned.
+- **MMP** — `setMmp(account, qtyLimit, windowNs)`: if an account is filled faster
+  than its limit inside the window, its book is pulled and `MmpTriggered` fires.
+- **Mass quote** — `Quote` replaces both sides of a two-sided quote atomically.
+
+### Auctions and halts
+
+Sequenced through `AdminCmd`, so they survive replay:
+
+- `BeginPreOpen` — accumulate without matching (a crossed book is allowed).
+- `OpenContinuous` — uncross at the single volume-maximising price, then resume.
+- `ResumeAuction` — clear a halt into a re-opening auction.
+- `HaltAndCancelAll` — emergency: halt and pull the resting book.
+- `Halt` / `Resume`.

--- a/docs/venue/multi-agent.md
+++ b/docs/venue/multi-agent.md
@@ -1,0 +1,94 @@
+# Multi-agent simulation
+
+A tape-replay backtest has one participant: you. The recorded market cannot
+respond to your orders, so impact, queue position, and crowding are assumptions
+baked into a fill model rather than outcomes you observe.
+
+Point several agents at one venue and those become emergent. Price is whatever
+the interaction produces; every fill has a counterparty who now holds the other
+side and reacts to it.
+
+## Run the demo
+
+```bash
+cmake -S . -B build -DFLOX_BUILD_DEMO=ON
+cmake --build build --target multi_agent_venue_demo
+./build/demo/multi_agent_venue_demo
+```
+
+Source: `demo/src/multi_agent_venue_demo.cpp`.
+
+Four agents share one book through the matching engine, settling through the
+ledger:
+
+| Agent | Behaviour |
+|---|---|
+| market maker | two-sided quotes around fair value, skewed as inventory builds |
+| momentum | chases the previous round's move |
+| mean reversion | fades deviation from an anchor, sized by how stretched it is |
+| noise | small random market orders (uninformed flow) |
+
+```
+final price 99.93 after 32605 trades (0 rejects)
+
+agent                    cash      stock            pnl
+market-maker       1002001.71    1005.42       +2473.42
+momentum            992094.14    1052.51       -2728.80
+mean-reversion      996010.11    1047.09        +645.58
+noise              1009894.05     894.98        -670.20
+
+conservation   cash 4000000.00 -> 4000000.00 (drift +0.00000000)
+               stock  4000.00 ->    4000.00 (drift +0.00000000)
+```
+
+The maker earns the spread, momentum pays for chasing — nobody scripted that
+distribution, it falls out of the interaction. Cash and inventory are conserved
+exactly; total mark-to-market equity moves with the last price, which is
+valuation, not leakage.
+
+## What this surfaces that a tape cannot
+
+The demo is deliberately easy to destabilise, because the instability is the
+point:
+
+- **Momentum ignition.** Weaken the mean-reversion agent or deepen the momentum
+  clip and price runs away until it pins against the price band. A tape replay
+  can never show you this: the recorded market does not chase your own flow.
+- **Inventory limits.** The maker's skew is what stops it accumulating without
+  bound. Remove it and the maker ends up holding the whole move.
+- **Liquidity exhaustion.** Size the takers past the maker's quoted depth and
+  fills start walking the book — real slippage, not a slippage parameter.
+
+The demo prints a reject counter alongside trades for exactly this reason: when
+the market stops working, you want to see *why*. During development it was a
+non-zero reject count that revealed quotes drifting off the tick grid, which the
+engine was correctly rejecting.
+
+## Building your own
+
+The pattern is small: construct a venue, deposit balances, then loop over your
+agents submitting `InboundCommand`s and reading back the events.
+
+```cpp
+Ledger ledger;
+MatchingEngine<MatchingBook> venue(cfg, [&](const OutboundEvent& e) {
+  if (const auto* t = std::get_if<Trade>(&e)) { lastPrice = t->price.toDouble(); }
+});
+venue.setLedger(&ledger, VENUE_ACCOUNT);
+
+for (int round = 0; round < rounds; ++round) {
+  for (auto& agent : agents) agent.act(venue, lastPrice);
+}
+```
+
+Two things to get right:
+
+1. **Quote on the tick grid.** The venue rejects anything else
+   (`TickSizeViolation`), as a real exchange does.
+2. **Refresh quotes deliberately.** A maker that never cancels leaves stale
+   orders behind; `MassCancel` per account is the usual way to pull a quote set.
+
+For a multi-symbol simulation, put each symbol behind `SymbolRouter`, which
+routes commands to the owning engine. There is no cross-symbol matching, so
+symbols are independent — to actually run them concurrently, give each its own
+`SequencedShard` (the router itself dispatches inline).

--- a/docs/venue/perimeter.md
+++ b/docs/venue/perimeter.md
@@ -1,0 +1,96 @@
+# Perimeter: gateways, protocols, control plane
+
+Everything so far assumes commands arrive from somewhere. The perimeter is where
+untrusted bytes become `InboundCommand`s — and where a venue is most exposed.
+
+## Gateways
+
+| Gateway | Transport |
+|---|---|
+| `TcpGateway` | length-prefixed frames over TCP |
+| `WsGateway` | RFC 6455 WebSocket (handshake + frames) |
+| `TlsGateway` | TLS termination via OpenSSL (**optional dependency**) |
+| `UdpMdPublisher` / `UdpMdSubscriber` | outbound market data over IP multicast |
+
+```cpp
+TcpGateway gw([](const uint8_t* p, size_t n) { return OuchCodec::decode(p, n); });
+gw.start(port, [&](const InboundCommand& cmd, const Responder& respond) {
+  venue.submit(cmd);
+});
+gw.stop();
+```
+
+`SocketAcceptor` carries the shared accept machinery. Each connection runs its
+loop inside a `try/catch`: a decode or allocation failure drops **that
+connection**, never the process.
+
+## Sessions
+
+`GatewaySession` sits between the socket and the engine:
+
+- **Authentication** — API-key HMAC logon (`apiKey:timestamp` signed with the
+  shared secret), constant-time comparison, timestamp-skew window.
+- **Account binding** — a session bound to an account **stamps that account onto
+  every command**. Without this a client could act as any account simply by
+  writing a different id in the payload; with it the wire value is overwritten.
+  Account `0` is the explicit "unbound / trusted transport" sentinel.
+- **Rate limiting** — per session, via `flox::RateLimitPolicy`.
+- **Cancel-on-disconnect** — optionally pulls the session's resting orders when
+  the connection drops.
+
+## Wire protocols
+
+| Codec | Notes |
+|---|---|
+| `OuchCodec` | binary, full fidelity — every field round-trips, including `reduceOnly`, `peg`, `expiryNs`, `ocoGroup`, `lastLook` |
+| `FixCodec` | FIX 4.4: `D`/`F`/`G` in, `ExecutionReport` out, with `BodyLength` and validated `CheckSum` |
+| `RestJson` | REST/JSON adoption path |
+| `ItchCodec` | outbound market data |
+
+A dropped field here is not cosmetic: a `reduceOnly` flag lost on the wire turns
+a risk-reducing order into one that opens a position. Round-trip tests pin every
+field.
+
+## Hostile input
+
+The perimeter is fuzzed, and the rules are explicit:
+
+- **Length prefixes are capped before allocation** — `flox::net::kMaxFrame`
+  (`flox/util/transport.h`) and `flox::ws::kMaxFramePayload`
+  (`flox/util/websocket.h`), 16 MiB, both in core alongside the framing they
+  guard. A 4-byte header must never be able to reserve gigabytes.
+- **WebSocket extended length is overflow-safe.** The naive completeness check
+  `n < off + len` wraps for a 64-bit length; the comparison is done as
+  `len > n - off` instead, and an absurd length is a protocol error that closes
+  the connection rather than a value that reaches `resize`.
+- **A parse error closes one connection.** It never becomes a process-wide
+  failure.
+
+`test_venue_parser_fuzz` drives all decoders with random and adversarial input;
+the sanitizer gate runs it under ASAN/UBSAN.
+
+## Control plane
+
+`InstrumentRegistry` is the venue admin surface — list instruments, halt/resume,
+adjust tick, lot, bands, trigger reference — and `ControlApi` exposes it as
+JSON-RPC, with `ControlServer` serving it over TCP.
+
+```cpp
+api.handle(R"({"method":"halt","symbol":1,"halted":true})");
+api.handle(R"({"method":"setBand","symbol":1,"minPrice":90,"maxPrice":110})");
+```
+
+Actions that change **matchable state** (auction transitions, emergency
+cancel-all, halts) go through the sequenced `AdminCmd` path instead, so they are
+journalled and survive replay. Configuration knobs recover from the
+configuration store. See [Runtime and recovery](runtime.md).
+
+Deploy the control plane on an internal interface: it has no authentication of
+its own.
+
+## Observability
+
+`Metrics` counts orders, trades, rejects by reason, and fills; `Gauges` samples
+venue state (open interest, position count, best bid/ask, mark age, feed-breaker
+state); `prometheus.h` renders the exposition format and `MetricsServer` serves
+it over HTTP for scraping.

--- a/docs/venue/risk.md
+++ b/docs/venue/risk.md
@@ -1,0 +1,126 @@
+# Derivatives risk
+
+A spot venue only has to move assets that exist. A derivatives venue extends
+credit, so it needs margin, a defensible mark, a liquidation path, and a
+backstop for when liquidation is not enough.
+
+## Isolated margin (in the engine)
+
+Set `SymbolConfig::linearPerp` and the engine clears a linear perpetual:
+
+- **Initial margin on entry.** `notional * initialMarginBps` is reserved in quote
+  collateral; insufficient margin rejects the order.
+- **Netting positions** with an average entry price.
+- **Mark-to-market PnL** realised into collateral through the venue clearing
+  pool — a long's profit is funded by a short's loss, so value is conserved.
+- **Reduce-only** orders are capped to the opposing position (they can never
+  open or flip), re-checked on submit, on stop trigger, and on modify.
+- **Maintenance sweep.** `setMarkPrice` walks every position; anything whose
+  equity (posted margin + unrealised PnL, plus a negative wallet if the account
+  is overdrawn) falls under the maintenance requirement is force-closed.
+
+```cpp
+cfg.linearPerp = true;
+cfg.initialMarginBps = 1000;      // 10x
+cfg.maintenanceMarginBps = 500;
+cfg.autoDeleverage = true;
+
+venue.submit(InboundCommand{SetMark{SYM, Price::fromDouble(49'500)}}, tsNs);
+```
+
+`SetMark` and `ApplyFunding` are **commands**, not method calls, so a replay
+reproduces every mark-driven liquidation and funding payment exactly.
+
+## Liquidation waterfall
+
+1. **Cancel the account's resting orders.** Their initial margin is the
+   account's own collateral; freeing it first means a total-equity-solvent
+   account covers its own shortfall instead of the insurance fund paying out.
+2. **Force-close at the mark** through the clearing pool.
+3. **Insurance fund** (the venue account) absorbs a negative-equity deficit.
+4. **ADL** claws the remainder from the most profitable opposite-side positions:
+   each winner is closed at the bankruptcy price, forgoing exactly the gain that
+   absorbs the deficit and keeping the excess. Victim selection uses a **total
+   order** (`uPnl desc, then account, then symbol`) so it never depends on hash
+   iteration or an unstable sort — a replica must pick the same victim.
+
+## Portfolio (cross) margin
+
+`CrossMarginManager` runs margin across an account's whole book instead of per
+position, so a profit on one symbol offsets a loss on another.
+
+```cpp
+CrossMarginManager cm(ledger, /*collateral asset*/ USD, VENUE, onLiquidation, /*adl*/ true);
+cm.configureSymbol(BTC, /*imBps*/ 1000, /*mmBps*/ 500);
+cm.setMark(BTC, Price::fromDouble(50'000));
+
+cm.canOpen(acct, BTC, Side::BUY, qtyRaw, priceRaw);  // pre-trade gate
+cm.applyFill(acct, BTC, Side::BUY, qtyRaw, priceRaw);
+cm.equity(acct);            // collateral basket + unrealised PnL
+cm.withdrawable(acct);      // never lets collateral behind open positions leave
+cm.openInterestRaw();       // venue-wide risk gauge
+```
+
+`setLiquidationsPaused(true)` is the operator switch used when the price feed is
+untrustworthy — see the circuit breaker below.
+
+## Multi-asset collateral
+
+`CollateralSchedule` values a basket with per-asset haircuts. An unconfigured
+asset is worth **zero**, not full value, so forgetting to configure something is
+safe rather than dangerous. During liquidation the venue buys the non-quote
+collateral and the insurance fund only covers the remainder; every conversion is
+balanced per asset.
+
+## Mark and index price
+
+A mark you can push is a mark someone will push. `index_feed.h` builds one that
+resists that:
+
+```cpp
+IndexAggregator idx(/*stalenessNs*/ 5'000'000'000, /*maxDeviationBps*/ 500, /*minSources*/ 3);
+idx.update(sourceId, price, tsNs);   // several external spot venues
+idx.hasIndex(nowNs);                 // enough fresh sources?
+idx.index(nowNs);                    // median, stale sources and outliers dropped
+```
+
+The mark is then the median of `{index, last trade, impact-mid}`, clamped into a
+band around the index. **Impact-mid** is a VWAP walked into the *live book* to a
+notional depth, not the top of book — so dust or a spoofed top level cannot move
+the mark.
+
+## Feed circuit breaker
+
+`MarkFeedDriver` watches the feed and pauses liquidations when it goes stale:
+
+```cpp
+MarkFeedDriver driver(...);
+const bool publish = driver.onTick(nowNs, lastTradeRaw, impactMidRaw);
+driver.paused();          // liquidations halted while the index is not fresh
+driver.markAgeNs(nowNs);  // export as a health gauge
+```
+
+Liquidating traders on a frozen price is how venues turn an outage into an
+incident. The breaker makes that failure mode explicit and observable.
+
+## Funding
+
+Two sources behind one settlement path:
+
+- **`FundingSchedule`** (`flox/backtest/`) replays a recorded rate tape.
+- **`FundingCalculator`** (`flox-venue/funding_rate.h`) computes the rate live:
+  premium (mark vs index) plus a clamped interest component, capped.
+
+The live path is TWAP by default — sample the premium across the interval and
+settle on the average, so a momentary dislocation cannot swing the payment:
+
+```cpp
+FundingCalculator f;
+f.sample(mark, index);          // repeatedly across the interval
+const double rate = f.intervalRate();
+f.resetSamples();
+```
+
+`FundingScheduler` closes the loop (sample, settle at the boundary, reset).
+Settlement is zero-sum: longs pay shorts or the reverse, and the charges across
+a balanced book sum to zero.

--- a/docs/venue/runtime.md
+++ b/docs/venue/runtime.md
@@ -1,0 +1,92 @@
+# Runtime and recovery
+
+## Single-writer core
+
+`SequencedShard` runs a symbol's engine as a single-writer state machine behind
+the flox `EventBus` (Disruptor). Commands are published to the ingress ring;
+one consumer journals each command write-ahead and then applies it. There is no
+lock on the matching path and no shared mutable state to race over — the
+property TSAN is pointed at in the gate.
+
+```cpp
+SequencedShard<LadderBook> shard(cfg, journalPath, book);
+shard.submit(InboundCommand{order});   // published to the ring
+shard.journaled();                     // records written
+```
+
+Symbols are independent: there is no cross-symbol matching in a CLOB, so each
+one can run on its own shard. `SymbolRouter` is the dispatch layer for that — it
+owns an engine per symbol, routes a command to the right one, and exposes
+`shardOf()` for partitioning. Note it dispatches **inline on the calling
+thread**: it is symbol-keyed routing, not a thread pool. Running shards
+concurrently means driving several `SequencedShard`s, each with its own
+consumer.
+
+```cpp
+SymbolRouter<MatchingBook> router(/*shards*/ 4);
+auto& engine = router.addSymbol(cfg, sink);
+router.submit(cmd);                       // routed by symbol
+router.snapshotAccount(acct);             // cross-shard view for a reconnecting client
+```
+
+## Determinism
+
+Same commands in, same events out, byte for byte. That is what makes replay and
+hot standby meaningful, and it is enforced rather than assumed:
+
+- **Every state-mutating input is a command.** Orders, cancels, modifies, mass
+  cancels, quotes, last-look decisions — and also the things that are tempting
+  to leave as method calls: `SetMark`, `ApplyFunding`, and `AdminCmd` (auction
+  transitions, halts, emergency cancel-all). A crash after an opening uncross
+  must recover the same book, so the uncross has to be *in the stream*.
+- **No order-sensitive decision reads an unordered container.** Anywhere output
+  depends on processing order — ADL victim choice, liquidation order, peg
+  repricing, expiry, mass cancel — the ids are collected and sorted first, so a
+  replica on a different STL or build makes the same choices.
+- **`event_hash.h`** folds the outbound stream into a rolling hash, so two runs
+  can be compared in one comparison instead of field by field.
+
+Persistent instrument configuration (tick, lot, bands, risk limits) is recovered
+from the configuration store, not the WAL, and is therefore deliberately **not**
+an `AdminCmd`.
+
+## Journal and replay
+
+```cpp
+Journal j(path);
+j.append(cmd, tsNs);        // write-ahead: record, then apply
+j.flush();
+
+for (const auto& [ts, cmd] : Journal::loadTimed(path)) engine.submit(cmd, ts);
+```
+
+Records are `[ts:8][tag:1][struct]`; every command type is trivially copyable
+(enforced by `static_assert`), so a record is a tag plus a raw blob. The
+sequencer timestamp is stored, so `loadTimed` reproduces time-dependent
+behaviour — GTD expiry, last-look windows, MMP windows, LULD pauses — at the
+same points it happened live.
+
+Replaying from empty must reconstruct an identical ledger, book, positions, and
+reservations. `test_venue_engine` asserts the event-stream hash and the ledger
+match after a round trip; `test_venue_venue` covers the auction case, replaying a
+journal whose stream contains an `AdminCmd` uncross.
+
+## Clock
+
+Time enters through `IClock`, so the same code runs on simulated and real time:
+
+| Implementation | Use |
+|---|---|
+| `SimulatedClock` | backtests, deterministic replay |
+| `SystemClock` (`flox/util/system_clock.h`) | live |
+
+## Client recovery
+
+- **`ResendBuffer`** keeps per-session outbound events for gap-fill, and
+  `GapDetector` tells a client when it missed a sequence.
+- **`snapshotAccount`** returns an account's open orders (with the true
+  remaining quantity, hidden reserve included — the owner sees its whole order,
+  unlike the public feed), pending stops, and position, so a reconnecting client
+  can reconcile in one shot rather than replaying everything.
+- **Cancel-on-disconnect** optionally pulls a session's resting orders when the
+  connection drops.

--- a/docs/venue/verification.md
+++ b/docs/venue/verification.md
@@ -1,0 +1,90 @@
+# Verification
+
+A venue moves real money, so "the tests pass" is a weak claim. This module is
+held to properties that hold over *random* command streams, and the properties
+were chosen because each one caught defects the previous one could not see.
+
+Run it all:
+
+```bash
+cd build && ctest                    # unit suites + fuzzes
+../venue/scripts/run_sanitizers.sh   # ASAN/UBSAN over parsers and fuzzes, TSAN over concurrency
+```
+
+## Differential fuzz
+
+`test_venue_differential_fuzz` drives the map-reference `MatchingBook` and the
+O(1) `LadderBook` in **lockstep** over a random stream of limits, markets, IOC,
+post-only, cancels, modifies and pegs. After every command:
+
+- both engines must have emitted an identical event stream (compared as a
+  rolling hash), and
+- neither book may be crossed.
+
+The reference book is the oracle: any ladder divergence fails with the command
+index. Depth is CI-friendly by default; set `FLOX_FUZZ_OPS` for a deep run
+(2M commands verified).
+
+## Conservation fuzz
+
+`test_venue_conservation_fuzz` asserts money properties over a random stream
+across five scenarios — spot, perp, perp with ADL, cross-margin, and multi-asset
+collateral:
+
+1. **Conservation of total.** Each asset's total across accounts plus the venue
+   account never changes.
+2. **The reserved invariant.** After the book is drained, every account's
+   `reserved` must be zero.
+
+The second exists because the first is not enough — and that gap is the central
+lesson of this module.
+
+## Why conservation-of-total is not enough
+
+Each of these defects passed the check above it, and each round of hardening
+added the property that would have caught it:
+
+| Property | Catches | Example defect it caught |
+|---|---|---|
+| conservation of total | money created or destroyed in aggregate | ADL crediting a winner while the deficit vanished |
+| **reserved invariant** (drain → `reserved == 0`) | buying power frozen forever — total is fine, the funds are simply stuck | residual reservations not released on IOC/FOK/reject paths |
+| **per-order** reservation consistency | one order over-releasing, masked by other orders in the same account's aggregate | iceberg modify releasing against the displayed peak instead of the full size |
+| **per-account equity + insurance payout** | mis-socialization: right total, wrong recipient | insurance paying out to an account that was solvent on total equity |
+| **insertion-order independence** | a replica making a different choice from the same logical state | ADL victim chosen by hash iteration order |
+| **made-whole on non-fill** | funds frozen when a fill does *not* happen | last-look reject stranding both sides' reservations |
+| **positive-obligation netting** | a debit balance masking a real custody shortfall | segregation reporting a short custody balance as fully backed |
+
+Several of these compound: funding driving a wallet negative while a position
+kept the account alive made states reachable that the ADL and segregation
+defects then exploited. Finding one exposed the next.
+
+`venue/AUDIT-LOG.md` is the full catalogue — every defect with the regression
+test that pins it, each proven to fail before the fix and pass after.
+
+## Sanitizers
+
+`venue/scripts/run_sanitizers.sh` builds and runs:
+
+- **ASAN + UBSAN** over the parsers (hostile network input), both fuzzes, the
+  venue harnesses, and the recovery/journal paths. UBSAN is set to halt on the
+  first diagnostic — it is what caught a signed-overflow in the LULD band
+  computation on a high-priced instrument.
+- **TSAN** over the sequenced single-writer core and the multi-threaded
+  gateways.
+
+## Determinism gates
+
+- `test_venue_engine` replays a journal into a fresh engine and requires an
+  identical event-stream hash and ledger. `test_venue_venue` does the same for a
+  stream containing an `AdminCmd` auction uncross — which is why auctions are
+  sequenced commands rather than method calls.
+- Tie-breaks are asserted directly: equal-score ADL candidates must resolve to
+  the same victim under a reversed insertion order, and mass-cancel must emit in
+  ascending order id regardless of insertion order.
+
+## Book agreement
+
+Market-data depth is compared against the engine's book over 300k commands,
+periodically at full depth rather than only top-of-book — the check that
+surfaced an iceberg's hidden reserve leaking into the public feed on a partial
+peak fill.

--- a/include/flox/book/ladder_book.h
+++ b/include/flox/book/ladder_book.h
@@ -1,0 +1,673 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * O(1) tick-indexed ladder matching book: the performance-path order-level
+ * resting book the reference MatchingBook is measured against (same interface).
+ *
+ * Design:
+ * - Two dense price ladders (bids, asks), one Level per tick over a bounded
+ *   price band. Level index = (price - base) / tick, so price<->level is O(1).
+ * - Intrusive FIFO order list per level (time priority) over a preallocated
+ *   node pool with a free list -- zero allocations in steady state.
+ * - An occupancy bitmap per side + a cached best cursor: best is O(1), and the
+ *   next non-empty level on a cursor move is a single word scan.
+ * - Order id -> node via an open-addressing table (no per-order allocation).
+ *
+ * The band is enforced upstream by the engine's price collar (SymbolConfig
+ * min/maxPrice); in-band is a precondition of addResting.
+ */
+#pragma once
+
+#include "flox/book/resting_order.h"
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace flox
+{
+
+class LadderBook
+{
+ public:
+  struct Config
+  {
+    int64_t basePriceRaw{};  // price.raw() of level 0
+    int64_t tickRaw{};       // raw ticks per level (> 0)
+    int32_t numLevels{};     // ladder height per side
+    int32_t maxOrders{};     // node-pool capacity
+  };
+
+  explicit LadderBook(Config c)
+      : base_(c.basePriceRaw),
+        tick_(c.tickRaw),
+        numLevels_(c.numLevels),
+        bidLevels_(static_cast<size_t>(c.numLevels)),
+        askLevels_(static_cast<size_t>(c.numLevels)),
+        nodes_(static_cast<size_t>(c.maxOrders)),
+        bidBits_(wordsFor(c.numLevels), 0),
+        askBits_(wordsFor(c.numLevels), 0)
+  {
+    for (int32_t i = 0; i < c.maxOrders; ++i)
+    {
+      nodes_[static_cast<size_t>(i)].nextFree = i + 1;
+    }
+    if (c.maxOrders > 0)
+    {
+      nodes_[static_cast<size_t>(c.maxOrders) - 1].nextFree = -1;
+    }
+    freeHead_ = c.maxOrders > 0 ? 0 : -1;
+
+    idxCap_ = 1;
+    while (idxCap_ < static_cast<size_t>(c.maxOrders) * 2 + 1)
+    {
+      idxCap_ <<= 1;
+    }
+    idx_.assign(idxCap_, Slot{});
+  }
+
+  bool contains(OrderId id) const noexcept { return findSlot(id) != -1; }
+  bool empty() const noexcept { return count_ == 0; }
+  bool full() const noexcept { return freeHead_ == -1; }
+
+  void addResting(Side side, const RestingOrder& o) noexcept
+  {
+    const int32_t lvl = levelOf(o.price);
+    if (lvl < 0 || lvl >= numLevels_)
+    {
+      return;  // out of band -- engine's collar must prevent this
+    }
+    const int32_t n = allocNode();
+    if (n < 0)
+    {
+      return;  // capacity -- engine should gate via full() before matching
+    }
+    Node& node = nodes_[static_cast<size_t>(n)];
+    node.order = o;
+    node.level = lvl;
+    node.side = side;
+    node.prev = -1;
+    node.next = -1;
+
+    Level& level = levelRef(side, lvl);
+    if (level.head < 0)
+    {
+      level.head = level.tail = n;
+      setBit(bitsRef(side), lvl);
+      onLevelOccupied(side, lvl);
+    }
+    else
+    {
+      nodes_[static_cast<size_t>(level.tail)].next = n;
+      node.prev = level.tail;
+      level.tail = n;
+    }
+    level.totalQty += o.leaves + o.hidden;  // hidden reserve is real liquidity
+    insertSlot(o.id, n);                    // count_ is maintained by allocNode/freeNode
+  }
+
+  const RestingOrder* find(OrderId id) const noexcept
+  {
+    const int32_t n = findSlot(id);
+    return n < 0 ? nullptr : &nodes_[static_cast<size_t>(n)].order;
+  }
+
+  // In-place leaves reduction (keeps FIFO position). Caller guarantees
+  // newLeaves <= current and > 0.
+  bool reduce(OrderId id, Quantity newLeaves) noexcept
+  {
+    const int32_t n = findSlot(id);
+    if (n < 0)
+    {
+      return false;
+    }
+    Node& node = nodes_[static_cast<size_t>(n)];
+    levelRef(node.side, node.level).totalQty -= (node.order.leaves - newLeaves);
+    node.order.leaves = newLeaves;
+    return true;
+  }
+
+  // Reduce an order (by id) by `by`, with iceberg refill+requeue when its peak
+  // is exhausted, else remove it. Used by pro-rata matching.
+  void consumeById(OrderId id, Quantity by) noexcept
+  {
+    const int32_t n = findSlot(id);
+    if (n < 0)
+    {
+      return;
+    }
+    Node& node = nodes_[static_cast<size_t>(n)];
+    node.order.leaves -= by;
+    levelRef(node.side, node.level).totalQty -= by;
+    if (!node.order.leaves.isZero())
+    {
+      return;
+    }
+    if (!node.order.hidden.isZero())
+    {
+      const Quantity newVis =
+          (node.order.peak < node.order.hidden) ? node.order.peak : node.order.hidden;
+      node.order.leaves = newVis;
+      node.order.hidden = node.order.hidden - newVis;
+      moveToTail(node.side, node.level, n);
+      return;
+    }
+    unlink(n);
+    eraseSlot(id);
+    freeNode(n);
+  }
+
+  std::optional<RestingOrder> cancel(OrderId id) noexcept
+  {
+    const int32_t n = findSlot(id);
+    if (n < 0)
+    {
+      return std::nullopt;
+    }
+    const RestingOrder copy = nodes_[static_cast<size_t>(n)].order;
+    unlink(n);
+    eraseSlot(id);
+    freeNode(n);
+    return copy;
+  }
+
+  RestingOrder* peekBest(Side restingSide) noexcept
+  {
+    const int32_t lvl = (restingSide == Side::BUY) ? bestBidLevel_ : bestAskLevel_;
+    if (lvl < 0)
+    {
+      return nullptr;
+    }
+    const int32_t head = levelRef(restingSide, lvl).head;
+    return head < 0 ? nullptr : &nodes_[static_cast<size_t>(head)].order;
+  }
+
+  // Aggregated (price, total qty) per level, best-first. Used by auction uncross.
+  void levels(Side side, std::vector<std::pair<Price, Quantity>>& out) const
+  {
+    out.clear();
+    if (side == Side::BUY)
+    {
+      for (int32_t l = bestBidLevel_; l >= 0; l = highestSetAtOrBelow(bidBits_, l - 1))
+      {
+        out.emplace_back(priceOf(l), bidLevels_[static_cast<size_t>(l)].totalQty);
+      }
+    }
+    else
+    {
+      for (int32_t l = bestAskLevel_; l >= 0; l = lowestSetAtOrAbove(askBits_, l + 1))
+      {
+        out.emplace_back(priceOf(l), askLevels_[static_cast<size_t>(l)].totalQty);
+      }
+    }
+  }
+
+  // Copy all orders at the best price of `restingSide` in FIFO order.
+  void bestLevel(Side restingSide, std::vector<RestingOrder>& out) const
+  {
+    out.clear();
+    const int32_t lvl = (restingSide == Side::BUY) ? bestBidLevel_ : bestAskLevel_;
+    if (lvl < 0)
+    {
+      return;
+    }
+    const Level& level =
+        (restingSide == Side::BUY) ? bidLevels_[static_cast<size_t>(lvl)]
+                                   : askLevels_[static_cast<size_t>(lvl)];
+    for (int32_t idx = level.head; idx >= 0; idx = nodes_[static_cast<size_t>(idx)].next)
+    {
+      out.push_back(nodes_[static_cast<size_t>(idx)].order);
+    }
+  }
+
+  void fillBest(Side restingSide, Quantity by) noexcept
+  {
+    const int32_t lvl = (restingSide == Side::BUY) ? bestBidLevel_ : bestAskLevel_;
+    if (lvl < 0)
+    {
+      return;
+    }
+    Level& level = levelRef(restingSide, lvl);
+    const int32_t head = level.head;
+    Node& node = nodes_[static_cast<size_t>(head)];
+    node.order.leaves -= by;
+    level.totalQty -= by;
+    if (node.order.leaves.isZero())
+    {
+      if (!node.order.hidden.isZero())
+      {
+        // iceberg: expose the next peak, re-queue at the tail (lose priority).
+        const Quantity newVis =
+            (node.order.peak < node.order.hidden) ? node.order.peak : node.order.hidden;
+        node.order.leaves = newVis;
+        node.order.hidden = node.order.hidden - newVis;
+        requeueFrontToTail(restingSide, lvl, head);
+      }
+      else
+      {
+        const OrderId id = node.order.id;
+        unlink(head);  // clears the bit + advances cursor when the level empties
+        eraseSlot(id);
+        freeNode(head);
+      }
+    }
+  }
+
+  std::optional<Price> bestBid() const noexcept
+  {
+    return bestBidLevel_ < 0 ? std::nullopt : std::optional<Price>{priceOf(bestBidLevel_)};
+  }
+  std::optional<Price> bestAsk() const noexcept
+  {
+    return bestAskLevel_ < 0 ? std::nullopt : std::optional<Price>{priceOf(bestAskLevel_)};
+  }
+
+  Quantity availableWithin(Side takerSide, Price limit, bool isMarket) const noexcept
+  {
+    Quantity total{};
+    if (takerSide == Side::BUY)
+    {
+      const int32_t limitLvl = isMarket ? (numLevels_ - 1) : clampLevel(limit);
+      for (int32_t l = bestAskLevel_; l >= 0 && l <= limitLvl;
+           l = lowestSetAtOrAbove(askBits_, l + 1))
+      {
+        total += askLevels_[static_cast<size_t>(l)].totalQty;
+      }
+    }
+    else
+    {
+      const int32_t limitLvl = isMarket ? 0 : clampLevel(limit);
+      for (int32_t l = bestBidLevel_; l >= 0 && l >= limitLvl;
+           l = highestSetAtOrBelow(bidBits_, l - 1))
+      {
+        total += bidLevels_[static_cast<size_t>(l)].totalQty;
+      }
+    }
+    return total;
+  }
+
+  // availableWithin, skipping makers for which skip(acct) is true. Iterates the
+  // per-level node lists (not the aggregate totalQty) so an STP-aware FOK
+  // precheck can exclude same-scope liquidity. See MatchingBook::availableWithinExcl.
+  template <class Skip>
+  Quantity availableWithinExcl(Side takerSide, Price limit, bool isMarket, Skip skip) const noexcept
+  {
+    Quantity total{};
+    if (takerSide == Side::BUY)
+    {
+      const int32_t limitLvl = isMarket ? (numLevels_ - 1) : clampLevel(limit);
+      for (int32_t l = bestAskLevel_; l >= 0 && l <= limitLvl;
+           l = lowestSetAtOrAbove(askBits_, l + 1))
+      {
+        for (int32_t idx = askLevels_[static_cast<size_t>(l)].head; idx >= 0;
+             idx = nodes_[static_cast<size_t>(idx)].next)
+        {
+          const RestingOrder& o = nodes_[static_cast<size_t>(idx)].order;
+          if (!skip(o.accountId))
+          {
+            total += o.leaves + o.hidden;
+          }
+        }
+      }
+    }
+    else
+    {
+      const int32_t limitLvl = isMarket ? 0 : clampLevel(limit);
+      for (int32_t l = bestBidLevel_; l >= 0 && l >= limitLvl;
+           l = highestSetAtOrBelow(bidBits_, l - 1))
+      {
+        for (int32_t idx = bidLevels_[static_cast<size_t>(l)].head; idx >= 0;
+             idx = nodes_[static_cast<size_t>(idx)].next)
+        {
+          const RestingOrder& o = nodes_[static_cast<size_t>(idx)].order;
+          if (!skip(o.accountId))
+          {
+            total += o.leaves + o.hidden;
+          }
+        }
+      }
+    }
+    return total;
+  }
+
+ private:
+  struct Level
+  {
+    int32_t head{-1};
+    int32_t tail{-1};
+    Quantity totalQty{};
+  };
+  struct Node
+  {
+    RestingOrder order{};
+    int32_t prev{-1};
+    int32_t next{-1};
+    int32_t level{-1};
+    Side side{};
+    int32_t nextFree{-1};
+  };
+  struct Slot
+  {
+    OrderId id{};
+    int32_t node{-1};
+    uint8_t state{0};  // 0 empty, 1 occupied, 2 tombstone
+  };
+
+  static size_t wordsFor(int32_t levels) noexcept
+  {
+    return static_cast<size_t>((levels + 63) / 64);
+  }
+
+  int32_t levelOf(Price p) const noexcept
+  {
+    return static_cast<int32_t>((p.raw() - base_) / tick_);
+  }
+  int32_t clampLevel(Price p) const noexcept
+  {
+    const int64_t l = (p.raw() - base_) / tick_;
+    if (l < 0)
+    {
+      return -1;
+    }
+    if (l >= numLevels_)
+    {
+      return numLevels_ - 1;
+    }
+    return static_cast<int32_t>(l);
+  }
+  Price priceOf(int32_t lvl) const noexcept
+  {
+    return Price::fromRaw(base_ + static_cast<int64_t>(lvl) * tick_);
+  }
+
+  Level& levelRef(Side s, int32_t lvl) noexcept
+  {
+    return (s == Side::BUY) ? bidLevels_[static_cast<size_t>(lvl)]
+                            : askLevels_[static_cast<size_t>(lvl)];
+  }
+  std::vector<uint64_t>& bitsRef(Side s) noexcept { return (s == Side::BUY) ? bidBits_ : askBits_; }
+
+  static void setBit(std::vector<uint64_t>& v, int32_t i) noexcept
+  {
+    v[static_cast<size_t>(i) >> 6] |= (1ULL << (static_cast<unsigned>(i) & 63U));
+  }
+  static void clearBit(std::vector<uint64_t>& v, int32_t i) noexcept
+  {
+    v[static_cast<size_t>(i) >> 6] &= ~(1ULL << (static_cast<unsigned>(i) & 63U));
+  }
+
+  static int32_t highestSetAtOrBelow(const std::vector<uint64_t>& v, int32_t i) noexcept
+  {
+    if (i < 0)
+    {
+      return -1;
+    }
+    size_t w = static_cast<size_t>(i) >> 6;
+    const unsigned bit = static_cast<unsigned>(i) & 63U;
+    uint64_t mask = (bit == 63U) ? ~0ULL : ((1ULL << (bit + 1U)) - 1ULL);
+    uint64_t word = v[w] & mask;
+    while (true)
+    {
+      if (word != 0)
+      {
+        return static_cast<int32_t>((w << 6) + static_cast<size_t>(63 - __builtin_clzll(word)));
+      }
+      if (w == 0)
+      {
+        return -1;
+      }
+      --w;
+      word = v[w];
+    }
+  }
+
+  int32_t lowestSetAtOrAbove(const std::vector<uint64_t>& v, int32_t i) const noexcept
+  {
+    if (i >= numLevels_)
+    {
+      return -1;
+    }
+    if (i < 0)
+    {
+      i = 0;
+    }
+    size_t w = static_cast<size_t>(i) >> 6;
+    const unsigned bit = static_cast<unsigned>(i) & 63U;
+    uint64_t mask = ~((1ULL << bit) - 1ULL);
+    uint64_t word = v[w] & mask;
+    while (true)
+    {
+      if (word != 0)
+      {
+        const int32_t idx =
+            static_cast<int32_t>((w << 6) + static_cast<size_t>(__builtin_ctzll(word)));
+        return idx < numLevels_ ? idx : -1;
+      }
+      ++w;
+      if (w >= v.size())
+      {
+        return -1;
+      }
+      word = v[w];
+    }
+  }
+
+  void onLevelOccupied(Side s, int32_t lvl) noexcept
+  {
+    if (s == Side::BUY)
+    {
+      if (lvl > bestBidLevel_)
+      {
+        bestBidLevel_ = lvl;
+      }
+    }
+    else
+    {
+      if (bestAskLevel_ < 0 || lvl < bestAskLevel_)
+      {
+        bestAskLevel_ = lvl;
+      }
+    }
+  }
+
+  void onLevelEmptied(Side s, int32_t lvl) noexcept
+  {
+    clearBit(bitsRef(s), lvl);
+    if (s == Side::BUY)
+    {
+      if (lvl == bestBidLevel_)
+      {
+        bestBidLevel_ = highestSetAtOrBelow(bidBits_, lvl - 1);
+      }
+    }
+    else
+    {
+      if (lvl == bestAskLevel_)
+      {
+        bestAskLevel_ = lowestSetAtOrAbove(askBits_, lvl + 1);
+      }
+    }
+  }
+
+  // Move the level's head node to its tail (iceberg refill re-queue). Precondition:
+  // n == level.head and the level has >= 2 nodes handled; single-node is a no-op.
+  void requeueFrontToTail(Side side, int32_t lvl, int32_t n) noexcept
+  {
+    Level& level = levelRef(side, lvl);
+    if (level.head == level.tail)
+    {
+      return;  // single node -- already at the tail
+    }
+    Node& node = nodes_[static_cast<size_t>(n)];
+    level.head = node.next;
+    nodes_[static_cast<size_t>(node.next)].prev = -1;
+    node.prev = level.tail;
+    node.next = -1;
+    nodes_[static_cast<size_t>(level.tail)].next = n;
+    level.tail = n;
+  }
+
+  // Move any node in a level to its tail (pro-rata iceberg refill re-queue).
+  void moveToTail(Side side, int32_t lvl, int32_t n) noexcept
+  {
+    Level& level = levelRef(side, lvl);
+    if (level.tail == n)
+    {
+      return;  // already at the tail
+    }
+    Node& node = nodes_[static_cast<size_t>(n)];
+    if (node.prev >= 0)
+    {
+      nodes_[static_cast<size_t>(node.prev)].next = node.next;
+    }
+    else
+    {
+      level.head = node.next;
+    }
+    nodes_[static_cast<size_t>(node.next)].prev = node.prev;  // node.next valid (n != tail)
+    node.prev = level.tail;
+    node.next = -1;
+    nodes_[static_cast<size_t>(level.tail)].next = n;
+    level.tail = n;
+  }
+
+  void unlink(int32_t n) noexcept
+  {
+    Node& node = nodes_[static_cast<size_t>(n)];
+    Level& level = levelRef(node.side, node.level);
+    level.totalQty -= (node.order.leaves + node.order.hidden);
+    if (node.prev >= 0)
+    {
+      nodes_[static_cast<size_t>(node.prev)].next = node.next;
+    }
+    else
+    {
+      level.head = node.next;
+    }
+    if (node.next >= 0)
+    {
+      nodes_[static_cast<size_t>(node.next)].prev = node.prev;
+    }
+    else
+    {
+      level.tail = node.prev;
+    }
+    if (level.head < 0)
+    {
+      level.totalQty = Quantity{};  // exact-zero guard against fixed-point drift
+      onLevelEmptied(node.side, node.level);
+    }
+    node.prev = node.next = -1;
+    node.level = -1;
+  }
+
+  int32_t allocNode() noexcept
+  {
+    if (freeHead_ < 0)
+    {
+      return -1;
+    }
+    const int32_t idx = freeHead_;
+    freeHead_ = nodes_[static_cast<size_t>(idx)].nextFree;
+    ++count_;
+    return idx;
+  }
+  void freeNode(int32_t idx) noexcept
+  {
+    nodes_[static_cast<size_t>(idx)] = Node{};
+    nodes_[static_cast<size_t>(idx)].nextFree = freeHead_;
+    freeHead_ = idx;
+    --count_;
+  }
+
+  // ---- open-addressing id index ----
+  size_t hash(OrderId id) const noexcept
+  {
+    uint64_t x = id;
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdULL;
+    x ^= x >> 33;
+    return static_cast<size_t>(x) & (idxCap_ - 1);
+  }
+  void insertSlot(OrderId id, int32_t node) noexcept
+  {
+    size_t h = hash(id);
+    size_t firstTomb = idxCap_;
+    for (size_t i = 0; i < idxCap_; ++i)
+    {
+      const size_t k = (h + i) & (idxCap_ - 1);
+      if (idx_[k].state == 1)
+      {
+        continue;
+      }
+      if (idx_[k].state == 2)
+      {
+        if (firstTomb == idxCap_)
+        {
+          firstTomb = k;
+        }
+        continue;
+      }
+      const size_t dst = (firstTomb != idxCap_) ? firstTomb : k;
+      idx_[dst] = Slot{id, node, 1};
+      return;
+    }
+  }
+  int32_t findSlot(OrderId id) const noexcept
+  {
+    const size_t h = hash(id);
+    for (size_t i = 0; i < idxCap_; ++i)
+    {
+      const size_t k = (h + i) & (idxCap_ - 1);
+      if (idx_[k].state == 0)
+      {
+        return -1;
+      }
+      if (idx_[k].state == 1 && idx_[k].id == id)
+      {
+        return idx_[k].node;
+      }
+    }
+    return -1;
+  }
+  void eraseSlot(OrderId id) noexcept
+  {
+    const size_t h = hash(id);
+    for (size_t i = 0; i < idxCap_; ++i)
+    {
+      const size_t k = (h + i) & (idxCap_ - 1);
+      if (idx_[k].state == 0)
+      {
+        return;
+      }
+      if (idx_[k].state == 1 && idx_[k].id == id)
+      {
+        idx_[k].state = 2;
+        return;
+      }
+    }
+  }
+
+  int64_t base_;
+  int64_t tick_;
+  int32_t numLevels_;
+  std::vector<Level> bidLevels_;
+  std::vector<Level> askLevels_;
+  std::vector<Node> nodes_;
+  std::vector<uint64_t> bidBits_;
+  std::vector<uint64_t> askBits_;
+  std::vector<Slot> idx_;
+  size_t idxCap_{0};
+  int32_t freeHead_{-1};
+  int32_t bestBidLevel_{-1};
+  int32_t bestAskLevel_{-1};
+  int32_t count_{0};
+};
+
+}  // namespace flox

--- a/include/flox/book/ladder_book.h
+++ b/include/flox/book/ladder_book.h
@@ -25,6 +25,7 @@
 
 #include "flox/book/resting_order.h"
 
+#include <bit>
 #include <cstdint>
 #include <optional>
 #include <utility>
@@ -416,7 +417,7 @@ class LadderBook
     {
       if (word != 0)
       {
-        return static_cast<int32_t>((w << 6) + static_cast<size_t>(63 - __builtin_clzll(word)));
+        return static_cast<int32_t>((w << 6) + static_cast<size_t>(63 - std::countl_zero(word)));
       }
       if (w == 0)
       {
@@ -446,7 +447,7 @@ class LadderBook
       if (word != 0)
       {
         const int32_t idx =
-            static_cast<int32_t>((w << 6) + static_cast<size_t>(__builtin_ctzll(word)));
+            static_cast<int32_t>((w << 6) + static_cast<size_t>(std::countr_zero(word)));
         return idx < numLevels_ ? idx : -1;
       }
       ++w;

--- a/include/flox/book/matching_book.h
+++ b/include/flox/book/matching_book.h
@@ -1,0 +1,353 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Order-level resting book with price-time (FIFO) priority. Distinct from the
+ * aggregate NLevelOrderBook (market-data depth): this tracks individual orders
+ * so it can match, cancel by id, and refill icebergs.
+ *
+ * STAGE-0 REFERENCE IMPLEMENTATION. Correctness-first: std::map + std::list,
+ * which ALLOCATES on the hot path. This is deliberate tech-debt for stage 0 so
+ * the matcher can be built and tested against a provably correct book. It MUST
+ * be replaced by the fixed-capacity, zero-alloc O(1) ladder described in
+ * PLAN.md 4.3 (direct tick-indexed array + occupancy bitmap for O(1) best and
+ * O(1) next-level) before any latency claim. The public surface below is the
+ * seam the ladder plugs into unchanged.
+ */
+#pragma once
+
+#include "flox/book/resting_order.h"
+
+#include <functional>
+#include <list>
+#include <map>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+namespace flox
+{
+
+class MatchingBook
+{
+ public:
+  bool contains(OrderId id) const noexcept { return index_.count(id) != 0; }
+
+  bool empty() const noexcept { return bids_.empty() && asks_.empty(); }
+
+  void addResting(Side side, const RestingOrder& o)
+  {
+    auto& lst = (side == Side::BUY) ? bids_[o.price] : asks_[o.price];
+    lst.push_back(o);
+    lst.back().side = side;
+    index_[o.id] = Loc{side, o.price, std::prev(lst.end())};
+  }
+
+  const RestingOrder* find(OrderId id) const
+  {
+    auto it = index_.find(id);
+    return it == index_.end() ? nullptr : &*it->second.pos;
+  }
+
+  // In-place leaves reduction (keeps FIFO position). Caller guarantees
+  // newLeaves <= current and > 0.
+  bool reduce(OrderId id, Quantity newLeaves)
+  {
+    auto it = index_.find(id);
+    if (it == index_.end())
+    {
+      return false;
+    }
+    it->second.pos->leaves = newLeaves;
+    return true;
+  }
+
+  // Reduce an order (by id) by `by`, with iceberg refill+requeue when its peak
+  // is exhausted, else remove it. Used by pro-rata matching.
+  void consumeById(OrderId id, Quantity by)
+  {
+    auto iit = index_.find(id);
+    if (iit == index_.end())
+    {
+      return;
+    }
+    const Loc loc = iit->second;
+    RestingOrder& order = *loc.pos;
+    order.leaves -= by;
+    if (!order.leaves.isZero())
+    {
+      return;
+    }
+    if (!order.hidden.isZero())
+    {
+      const Quantity newVis = (order.peak < order.hidden) ? order.peak : order.hidden;
+      order.leaves = newVis;
+      order.hidden = order.hidden - newVis;
+      auto& lst = (loc.side == Side::BUY) ? bids_[loc.price] : asks_[loc.price];
+      lst.splice(lst.end(), lst, loc.pos);  // requeue to tail; iterator stays valid
+      return;
+    }
+    if (loc.side == Side::BUY)
+    {
+      auto lvl = bids_.find(loc.price);
+      lvl->second.erase(loc.pos);
+      if (lvl->second.empty())
+      {
+        bids_.erase(lvl);
+      }
+    }
+    else
+    {
+      auto lvl = asks_.find(loc.price);
+      lvl->second.erase(loc.pos);
+      if (lvl->second.empty())
+      {
+        asks_.erase(lvl);
+      }
+    }
+    index_.erase(iit);
+  }
+
+  std::optional<RestingOrder> cancel(OrderId id)
+  {
+    auto it = index_.find(id);
+    if (it == index_.end())
+    {
+      return std::nullopt;
+    }
+    const Loc loc = it->second;
+    const RestingOrder copy = *loc.pos;
+
+    if (loc.side == Side::BUY)
+    {
+      auto lvl = bids_.find(loc.price);
+      lvl->second.erase(loc.pos);
+      if (lvl->second.empty())
+      {
+        bids_.erase(lvl);
+      }
+    }
+    else
+    {
+      auto lvl = asks_.find(loc.price);
+      lvl->second.erase(loc.pos);
+      if (lvl->second.empty())
+      {
+        asks_.erase(lvl);
+      }
+    }
+    index_.erase(it);
+    return copy;
+  }
+
+  // Aggregated (price, total qty) per level, best-first (bids descending, asks
+  // ascending). Used by the auction uncross.
+  void levels(Side side, std::vector<std::pair<Price, Quantity>>& out) const
+  {
+    out.clear();
+    if (side == Side::BUY)
+    {
+      for (const auto& [p, lst] : bids_)
+      {
+        Quantity q{};
+        for (const auto& o : lst)
+        {
+          q += o.leaves + o.hidden;
+        }
+        out.emplace_back(p, q);
+      }
+    }
+    else
+    {
+      for (const auto& [p, lst] : asks_)
+      {
+        Quantity q{};
+        for (const auto& o : lst)
+        {
+          q += o.leaves + o.hidden;
+        }
+        out.emplace_back(p, q);
+      }
+    }
+  }
+
+  // Copy all orders at the best price of `restingSide` in FIFO order (pro-rata
+  // matching enumerates the whole level).
+  void bestLevel(Side restingSide, std::vector<RestingOrder>& out) const
+  {
+    out.clear();
+    if (restingSide == Side::BUY)
+    {
+      if (!bids_.empty())
+      {
+        for (const auto& o : bids_.begin()->second)
+        {
+          out.push_back(o);
+        }
+      }
+    }
+    else
+    {
+      if (!asks_.empty())
+      {
+        for (const auto& o : asks_.begin()->second)
+        {
+          out.push_back(o);
+        }
+      }
+    }
+  }
+
+  // Head order (FIFO) at the best price of `restingSide`, or nullptr.
+  RestingOrder* peekBest(Side restingSide) noexcept
+  {
+    if (restingSide == Side::BUY)
+    {
+      if (bids_.empty())
+      {
+        return nullptr;
+      }
+      auto& lst = bids_.begin()->second;
+      return lst.empty() ? nullptr : &lst.front();
+    }
+    if (asks_.empty())
+    {
+      return nullptr;
+    }
+    auto& lst = asks_.begin()->second;
+    return lst.empty() ? nullptr : &asks_.begin()->second.front();
+  }
+
+  // Reduce the best head by `by`; drop it (and its level) when depleted.
+  void fillBest(Side restingSide, Quantity by)
+  {
+    if (restingSide == Side::BUY)
+    {
+      fillFront(bids_, by);
+    }
+    else
+    {
+      fillFront(asks_, by);
+    }
+  }
+
+  std::optional<Price> bestBid() const noexcept
+  {
+    if (bids_.empty())
+    {
+      return std::nullopt;
+    }
+    return bids_.begin()->first;
+  }
+
+  std::optional<Price> bestAsk() const noexcept
+  {
+    if (asks_.empty())
+    {
+      return std::nullopt;
+    }
+    return asks_.begin()->first;
+  }
+
+  // Total resting quantity a taker of `takerSide` could sweep at prices that
+  // cross `limit` (or the whole opposite side when `isMarket`). Used for the
+  // FOK all-or-none precheck.
+  Quantity availableWithin(Side takerSide, Price limit, bool isMarket) const
+  {
+    return availableWithinExcl(takerSide, limit, isMarket, [](uint64_t)
+                               { return false; });
+  }
+
+  // availableWithin, skipping makers for which skip(acct) is true. An STP-aware
+  // FOK precheck uses this: same-STP-scope liquidity can never fill the taker (it
+  // is canceled/decremented, not traded), so it must not count toward "can this
+  // order fully fill" -- otherwise a FOK+STP rests instead of being killed.
+  template <class Skip>
+  Quantity availableWithinExcl(Side takerSide, Price limit, bool isMarket, Skip skip) const
+  {
+    Quantity total{};
+    if (takerSide == Side::BUY)
+    {
+      for (const auto& [px, lst] : asks_)
+      {
+        if (!isMarket && limit < px)
+        {
+          break;
+        }
+        for (const auto& o : lst)
+        {
+          if (!skip(o.accountId))
+          {
+            total += o.leaves + o.hidden;  // hidden reserve is real liquidity
+          }
+        }
+      }
+    }
+    else
+    {
+      for (const auto& [px, lst] : bids_)
+      {
+        if (!isMarket && px < limit)
+        {
+          break;
+        }
+        for (const auto& o : lst)
+        {
+          if (!skip(o.accountId))
+          {
+            total += o.leaves + o.hidden;
+          }
+        }
+      }
+    }
+    return total;
+  }
+
+ private:
+  struct Loc
+  {
+    Side side{};
+    Price price{};
+    std::list<RestingOrder>::iterator pos{};
+  };
+
+  template <class Map>
+  void fillFront(Map& m, Quantity by)
+  {
+    auto lvl = m.begin();
+    auto& lst = lvl->second;
+    auto& head = lst.front();
+    head.leaves -= by;
+    if (head.leaves.isZero())
+    {
+      if (!head.hidden.isZero())
+      {
+        // iceberg: expose the next peak, re-queue at the tail (lose priority).
+        const Quantity newVis = (head.peak < head.hidden) ? head.peak : head.hidden;
+        head.leaves = newVis;
+        head.hidden = head.hidden - newVis;
+        lst.splice(lst.end(), lst, lst.begin());  // splice preserves the index_ iterator
+      }
+      else
+      {
+        index_.erase(head.id);
+        lst.pop_front();
+        if (lst.empty())
+        {
+          m.erase(lvl);
+        }
+      }
+    }
+  }
+
+  // bids descending (best = highest), asks ascending (best = lowest)
+  std::map<Price, std::list<RestingOrder>, std::greater<Price>> bids_;
+  std::map<Price, std::list<RestingOrder>, std::less<Price>> asks_;
+  std::unordered_map<OrderId, Loc> index_;
+};
+
+}  // namespace flox

--- a/include/flox/book/resting_order.h
+++ b/include/flox/book/resting_order.h
@@ -1,0 +1,36 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include "flox/common.h"
+
+#include <cstdint>
+
+namespace flox
+{
+
+// A single order resting on an order-level matching book (price-time FIFO or
+// pro-rata). Distinct from the aggregate NLevelOrderBook, which only tracks
+// per-level totals for market data. Shared by every matching-book implementation
+// and by the matcher, which holds a RestingOrder* to the current best maker.
+struct RestingOrder
+{
+  OrderId id{};
+  uint64_t accountId{};
+  Price price{};
+  Quantity leaves{};  // currently displayed (executable now)
+  Side side{};
+  Quantity hidden{};  // iceberg reserve beyond the displayed peak (0 = none)
+  Quantity peak{};    // iceberg display size (0 = non-iceberg)
+  bool lastLook{};    // maker holds fills for a last-look window before confirming
+  bool reduceOnly{};  // perp: may only reduce the account's position, never open/flip
+};
+
+}  // namespace flox

--- a/include/flox/log/atomic_logger.h
+++ b/include/flox/log/atomic_logger.h
@@ -60,6 +60,10 @@ class AtomicLogger final : public ILogger
     size_t length;
     char message[MAX_MESSAGE_SIZE];
     std::chrono::system_clock::time_point timestamp;
+    // Publication flag. A producer claims a slot by advancing _writeIndex, so
+    // the consumer can see the index move before the payload is written; it
+    // must wait for this to be set (release) before reading the fields.
+    std::atomic<bool> ready{false};
   };
 
   AtomicLoggerOptions _opts;
@@ -80,6 +84,7 @@ class AtomicLogger final : public ILogger
   void flushLoop();
   void rotateIfNeeded();
   void rotate();
+  void consumeSlot(size_t idx);
   void writeToOutput(const LogEntry& entry);
   void formatTimestamp(std::chrono::system_clock::time_point ts, char* buf, size_t bufSize);
 };

--- a/include/flox/replay/readers/binary_log_reader.h
+++ b/include/flox/replay/readers/binary_log_reader.h
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <span>
@@ -300,6 +301,12 @@ class BinaryLogReader
 
  private:
   bool scanSegments();
+
+  // Build the segment index exactly once, safely, from a const context.
+  // The index is immutable after the first scan, so const readers may then run
+  // concurrently; without this the first scan could race a reader on another
+  // thread (a replay loop scanning lazily while the owner asks for timeRange).
+  bool ensureScanned() const;
   bool readSegment(const std::filesystem::path& path, EventCallback& callback);
   bool readSegmentFrom(const SegmentInfo& segment, int64_t start_ts_ns, EventCallback& callback);
   bool readSegmentStreaming(const std::filesystem::path& path, EventCallback& callback);
@@ -319,6 +326,7 @@ class BinaryLogReader
   ReaderStats _stats;
   std::vector<SegmentInfo> _segments;
   bool _scanned{false};
+  mutable std::once_flag _scan_once;
   ProgressCallback _progress_cb;
   std::chrono::milliseconds _progress_interval{1000};
 };

--- a/include/flox/util/crypto.h
+++ b/include/flox/util/crypto.h
@@ -1,0 +1,255 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace flox::crypto
+{
+
+// ---- SHA-1 ----
+inline std::array<uint8_t, 20> sha1(const uint8_t* data, size_t len)
+{
+  uint32_t h[5] = {0x67452301u, 0xEFCDAB89u, 0x98BADCFEu, 0x10325476u, 0xC3D2E1F0u};
+  auto rol = [](uint32_t x, int c)
+  { return (x << c) | (x >> (32 - c)); };
+
+  std::vector<uint8_t> msg(data, data + len);
+  const uint64_t bits = static_cast<uint64_t>(len) * 8;
+  msg.push_back(0x80);
+  while (msg.size() % 64 != 56)
+  {
+    msg.push_back(0);
+  }
+  for (int i = 7; i >= 0; --i)
+  {
+    msg.push_back(static_cast<uint8_t>(bits >> (i * 8)));
+  }
+
+  for (size_t off = 0; off < msg.size(); off += 64)
+  {
+    uint32_t w[80];
+    for (int i = 0; i < 16; ++i)
+    {
+      w[i] = (uint32_t(msg[off + i * 4]) << 24) | (uint32_t(msg[off + i * 4 + 1]) << 16) |
+             (uint32_t(msg[off + i * 4 + 2]) << 8) | uint32_t(msg[off + i * 4 + 3]);
+    }
+    for (int i = 16; i < 80; ++i)
+    {
+      w[i] = rol(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+    }
+    uint32_t a = h[0], b = h[1], c = h[2], d = h[3], e = h[4];
+    for (int i = 0; i < 80; ++i)
+    {
+      uint32_t f, k;
+      if (i < 20)
+      {
+        f = (b & c) | (~b & d);
+        k = 0x5A827999u;
+      }
+      else if (i < 40)
+      {
+        f = b ^ c ^ d;
+        k = 0x6ED9EBA1u;
+      }
+      else if (i < 60)
+      {
+        f = (b & c) | (b & d) | (c & d);
+        k = 0x8F1BBCDCu;
+      }
+      else
+      {
+        f = b ^ c ^ d;
+        k = 0xCA62C1D6u;
+      }
+      const uint32_t t = rol(a, 5) + f + e + k + w[i];
+      e = d;
+      d = c;
+      c = rol(b, 30);
+      b = a;
+      a = t;
+    }
+    h[0] += a;
+    h[1] += b;
+    h[2] += c;
+    h[3] += d;
+    h[4] += e;
+  }
+  std::array<uint8_t, 20> out{};
+  for (int i = 0; i < 5; ++i)
+  {
+    for (int j = 0; j < 4; ++j)
+    {
+      out[i * 4 + j] = static_cast<uint8_t>(h[i] >> (24 - j * 8));
+    }
+  }
+  return out;
+}
+
+// ---- SHA-256 ----
+inline std::array<uint8_t, 32> sha256(const uint8_t* data, size_t len)
+{
+  static const uint32_t K[64] = {
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+      0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+      0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+      0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+      0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+      0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+      0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+      0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+      0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+      0xc67178f2};
+  uint32_t h[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                   0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  auto ror = [](uint32_t x, int c)
+  { return (x >> c) | (x << (32 - c)); };
+
+  std::vector<uint8_t> msg(data, data + len);
+  const uint64_t bits = static_cast<uint64_t>(len) * 8;
+  msg.push_back(0x80);
+  while (msg.size() % 64 != 56)
+  {
+    msg.push_back(0);
+  }
+  for (int i = 7; i >= 0; --i)
+  {
+    msg.push_back(static_cast<uint8_t>(bits >> (i * 8)));
+  }
+
+  for (size_t off = 0; off < msg.size(); off += 64)
+  {
+    uint32_t w[64];
+    for (int i = 0; i < 16; ++i)
+    {
+      w[i] = (uint32_t(msg[off + i * 4]) << 24) | (uint32_t(msg[off + i * 4 + 1]) << 16) |
+             (uint32_t(msg[off + i * 4 + 2]) << 8) | uint32_t(msg[off + i * 4 + 3]);
+    }
+    for (int i = 16; i < 64; ++i)
+    {
+      const uint32_t s0 = ror(w[i - 15], 7) ^ ror(w[i - 15], 18) ^ (w[i - 15] >> 3);
+      const uint32_t s1 = ror(w[i - 2], 17) ^ ror(w[i - 2], 19) ^ (w[i - 2] >> 10);
+      w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+    uint32_t a = h[0], b = h[1], c = h[2], d = h[3], e = h[4], f = h[5], g = h[6], hh = h[7];
+    for (int i = 0; i < 64; ++i)
+    {
+      const uint32_t S1 = ror(e, 6) ^ ror(e, 11) ^ ror(e, 25);
+      const uint32_t ch = (e & f) ^ (~e & g);
+      const uint32_t t1 = hh + S1 + ch + K[i] + w[i];
+      const uint32_t S0 = ror(a, 2) ^ ror(a, 13) ^ ror(a, 22);
+      const uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+      const uint32_t t2 = S0 + maj;
+      hh = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+    h[0] += a;
+    h[1] += b;
+    h[2] += c;
+    h[3] += d;
+    h[4] += e;
+    h[5] += f;
+    h[6] += g;
+    h[7] += hh;
+  }
+  std::array<uint8_t, 32> out{};
+  for (int i = 0; i < 8; ++i)
+  {
+    for (int j = 0; j < 4; ++j)
+    {
+      out[i * 4 + j] = static_cast<uint8_t>(h[i] >> (24 - j * 8));
+    }
+  }
+  return out;
+}
+
+// ---- HMAC-SHA256 ----
+inline std::array<uint8_t, 32> hmacSha256(const uint8_t* key, size_t keyLen, const uint8_t* msg,
+                                          size_t msgLen)
+{
+  uint8_t k[64] = {0};
+  if (keyLen > 64)
+  {
+    const auto kh = sha256(key, keyLen);
+    std::memcpy(k, kh.data(), 32);
+  }
+  else
+  {
+    std::memcpy(k, key, keyLen);
+  }
+  uint8_t ipad[64], opad[64];
+  for (int i = 0; i < 64; ++i)
+  {
+    ipad[i] = k[i] ^ 0x36;
+    opad[i] = k[i] ^ 0x5c;
+  }
+  std::vector<uint8_t> inner(ipad, ipad + 64);
+  inner.insert(inner.end(), msg, msg + msgLen);
+  const auto ih = sha256(inner.data(), inner.size());
+  std::vector<uint8_t> outer(opad, opad + 64);
+  outer.insert(outer.end(), ih.begin(), ih.end());
+  return sha256(outer.data(), outer.size());
+}
+
+// ---- base64 ----
+inline std::string base64(const uint8_t* data, size_t len)
+{
+  static const char* tbl = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  size_t i = 0;
+  for (; i + 3 <= len; i += 3)
+  {
+    const uint32_t n = (uint32_t(data[i]) << 16) | (uint32_t(data[i + 1]) << 8) | data[i + 2];
+    out += tbl[(n >> 18) & 63];
+    out += tbl[(n >> 12) & 63];
+    out += tbl[(n >> 6) & 63];
+    out += tbl[n & 63];
+  }
+  if (len - i == 1)
+  {
+    const uint32_t n = uint32_t(data[i]) << 16;
+    out += tbl[(n >> 18) & 63];
+    out += tbl[(n >> 12) & 63];
+    out += "==";
+  }
+  else if (len - i == 2)
+  {
+    const uint32_t n = (uint32_t(data[i]) << 16) | (uint32_t(data[i + 1]) << 8);
+    out += tbl[(n >> 18) & 63];
+    out += tbl[(n >> 12) & 63];
+    out += tbl[(n >> 6) & 63];
+    out += "=";
+  }
+  return out;
+}
+
+inline std::string toHex(const uint8_t* data, size_t len)
+{
+  static const char* h = "0123456789abcdef";
+  std::string out;
+  out.reserve(len * 2);
+  for (size_t i = 0; i < len; ++i)
+  {
+    out += h[data[i] >> 4];
+    out += h[data[i] & 15];
+  }
+  return out;
+}
+
+}  // namespace flox::crypto

--- a/include/flox/util/system_clock.h
+++ b/include/flox/util/system_clock.h
@@ -1,0 +1,39 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+#include "flox/backtest/abstract_clock.h"
+
+#include <chrono>
+
+namespace flox
+{
+
+// Live (wall-clock) IClock implementation. Backtest drives time through
+// SimulatedClock; live systems drive it through SystemClock, so time-dependent
+// code (GTD expiry, last-look windows, funding intervals) can depend on the same
+// IClock abstraction in both modes -- the production-parity promise. `nowNs`
+// returns UNIX nanoseconds so it lines up with market-data timestamps.
+class SystemClock : public IClock
+{
+ public:
+  UnixNanos nowNs() const override
+  {
+    return static_cast<UnixNanos>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                      std::chrono::system_clock::now().time_since_epoch())
+                                      .count());
+  }
+
+  // Real time cannot be advanced or rewound; the driver-side advance is a no-op
+  // so a SystemClock is drop-in wherever an IClock is expected.
+  void advanceTo(UnixNanos /*ns*/) override {}
+};
+
+}  // namespace flox

--- a/include/flox/util/transport.h
+++ b/include/flox/util/transport.h
@@ -1,0 +1,146 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include <unistd.h>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace flox::net
+{
+
+// Upper bound on a single length-prefixed frame. Venue messages are tiny; this
+// only has to be generous enough for a batched snapshot while bounding the
+// allocation a 4-byte length prefix can trigger.
+inline constexpr uint32_t kMaxFrame = 16u << 20;  // 16 MiB
+
+inline bool writeAll(int fd, const uint8_t* p, size_t n)
+{
+  size_t off = 0;
+  while (off < n)
+  {
+    const ssize_t w = ::write(fd, p + off, n - off);
+    if (w <= 0)
+    {
+      return false;
+    }
+    off += static_cast<size_t>(w);
+  }
+  return true;
+}
+
+inline bool readAll(int fd, uint8_t* p, size_t n)
+{
+  size_t off = 0;
+  while (off < n)
+  {
+    const ssize_t r = ::read(fd, p + off, n - off);
+    if (r <= 0)
+    {
+      return false;  // EOF or error
+    }
+    off += static_cast<size_t>(r);
+  }
+  return true;
+}
+
+// Framing: [u32 big-endian length][payload].
+inline bool writeFrame(int fd, const uint8_t* p, size_t n)
+{
+  const uint8_t hdr[4] = {static_cast<uint8_t>(n >> 24), static_cast<uint8_t>(n >> 16),
+                          static_cast<uint8_t>(n >> 8), static_cast<uint8_t>(n)};
+  return writeAll(fd, hdr, 4) && writeAll(fd, p, n);
+}
+
+inline bool readFrame(int fd, std::vector<uint8_t>& out)
+{
+  uint8_t hdr[4];
+  if (!readAll(fd, hdr, 4))
+  {
+    return false;
+  }
+  const uint32_t len = (static_cast<uint32_t>(hdr[0]) << 24) | (static_cast<uint32_t>(hdr[1]) << 16) |
+                       (static_cast<uint32_t>(hdr[2]) << 8) | static_cast<uint32_t>(hdr[3]);
+  // Reject a hostile length prefix before allocating: a 4-byte header must not be
+  // able to make us reserve up to 4 GiB (per-connection amplification DoS / OOM).
+  if (len > kMaxFrame)
+  {
+    return false;
+  }
+  out.resize(len);
+  return len == 0 || readAll(fd, out.data(), len);
+}
+
+// Kernel-bypass backend. The POSIX helpers above are the reference. On Linux
+// with FME_IO_URING the gateway drives io_uring (submission/completion rings,
+// no per-syscall overhead); DPDK / OpenOnload plug in the same way in colo.
+// Built only on Linux with liburing (link -luring); the portable build stays
+// dependency-free. Untested off Linux -- this is the real integration code.
+#if defined(__linux__) && defined(FME_IO_URING)
+#include <liburing.h>
+
+class IoUring
+{
+ public:
+  explicit IoUring(unsigned entries = 256) { io_uring_queue_init(entries, &ring_, 0); }
+  ~IoUring() { io_uring_queue_exit(&ring_); }
+
+  bool readAll(int fd, uint8_t* p, size_t n)
+  {
+    size_t off = 0;
+    while (off < n)
+    {
+      io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+      io_uring_prep_read(sqe, fd, p + off, static_cast<unsigned>(n - off), 0);
+      io_uring_submit(&ring_);
+      io_uring_cqe* cqe = nullptr;
+      if (io_uring_wait_cqe(&ring_, &cqe) < 0 || cqe->res <= 0)
+      {
+        if (cqe)
+        {
+          io_uring_cqe_seen(&ring_, cqe);
+        }
+        return false;
+      }
+      off += static_cast<size_t>(cqe->res);
+      io_uring_cqe_seen(&ring_, cqe);
+    }
+    return true;
+  }
+
+  bool writeAll(int fd, const uint8_t* p, size_t n)
+  {
+    size_t off = 0;
+    while (off < n)
+    {
+      io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+      io_uring_prep_write(sqe, fd, p + off, static_cast<unsigned>(n - off), 0);
+      io_uring_submit(&ring_);
+      io_uring_cqe* cqe = nullptr;
+      if (io_uring_wait_cqe(&ring_, &cqe) < 0 || cqe->res <= 0)
+      {
+        if (cqe)
+        {
+          io_uring_cqe_seen(&ring_, cqe);
+        }
+        return false;
+      }
+      off += static_cast<size_t>(cqe->res);
+      io_uring_cqe_seen(&ring_, cqe);
+    }
+    return true;
+  }
+
+ private:
+  io_uring ring_{};
+};
+#endif
+
+}  // namespace flox::net

--- a/include/flox/util/websocket.h
+++ b/include/flox/util/websocket.h
@@ -1,0 +1,178 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox/util/crypto.h"
+
+#include <cctype>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace flox::ws
+{
+
+inline std::string acceptKey(const std::string& clientKey)
+{
+  static const char* kGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+  const std::string s = clientKey + kGuid;
+  const auto h = crypto::sha1(reinterpret_cast<const uint8_t*>(s.data()), s.size());
+  return crypto::base64(h.data(), h.size());
+}
+
+// Build the 101 Switching Protocols response from the client's request headers.
+// Returns "" if no Sec-WebSocket-Key is present.
+inline std::string handshakeResponse(const std::string& request)
+{
+  std::string lower(request.size(), '\0');
+  for (size_t i = 0; i < request.size(); ++i)
+  {
+    lower[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(request[i])));
+  }
+  const std::string tag = "sec-websocket-key:";
+  const auto pos = lower.find(tag);
+  if (pos == std::string::npos)
+  {
+    return {};
+  }
+  size_t s = pos + tag.size();
+  while (s < request.size() && request[s] == ' ')
+  {
+    ++s;
+  }
+  size_t e = request.find("\r\n", s);
+  if (e == std::string::npos)
+  {
+    e = request.size();
+  }
+  std::string key = request.substr(s, e - s);
+  while (!key.empty() && (key.back() == ' ' || key.back() == '\r'))
+  {
+    key.pop_back();
+  }
+  return "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+         "Sec-WebSocket-Accept: " +
+         acceptKey(key) + "\r\n\r\n";
+}
+
+enum class Opcode : uint8_t
+{
+  Cont = 0x0,
+  Text = 0x1,
+  Binary = 0x2,
+  Close = 0x8,
+  Ping = 0x9,
+  Pong = 0xA,
+};
+
+// Build an unmasked server->client frame (FIN set).
+inline std::vector<uint8_t> buildFrame(Opcode op, const uint8_t* payload, size_t n)
+{
+  std::vector<uint8_t> f;
+  f.push_back(static_cast<uint8_t>(0x80 | static_cast<uint8_t>(op)));
+  if (n < 126)
+  {
+    f.push_back(static_cast<uint8_t>(n));
+  }
+  else if (n < 65536)
+  {
+    f.push_back(126);
+    f.push_back(static_cast<uint8_t>(n >> 8));
+    f.push_back(static_cast<uint8_t>(n));
+  }
+  else
+  {
+    f.push_back(127);
+    for (int i = 7; i >= 0; --i)
+    {
+      f.push_back(static_cast<uint8_t>(n >> (i * 8)));
+    }
+  }
+  f.insert(f.end(), payload, payload + n);
+  return f;
+}
+
+// Largest payload we will buffer/allocate for one frame. Venue messages are
+// tiny; this only has to be generous enough for a batched snapshot. It caps the
+// per-connection buffer and, crucially, bounds the resize() below.
+inline constexpr uint64_t kMaxFramePayload = 16u << 20;  // 16 MiB
+// Sentinel return from parseFrame meaning "protocol violation -- close the
+// connection" (distinct from 0 = "need more bytes"). Without it, an oversized or
+// overflowing length would either crash on resize or spin reading forever.
+inline constexpr size_t kParseError = static_cast<size_t>(-1);
+
+// Parse one frame; returns bytes consumed (0 if incomplete, kParseError on a
+// protocol violation). Unmasks client payloads.
+inline size_t parseFrame(const uint8_t* p, size_t n, Opcode& op, std::vector<uint8_t>& payload)
+{
+  if (n < 2)
+  {
+    return 0;
+  }
+  op = static_cast<Opcode>(p[0] & 0x0F);
+  const bool masked = (p[1] & 0x80) != 0;
+  uint64_t len = p[1] & 0x7F;
+  size_t off = 2;
+  if (len == 126)
+  {
+    if (n < 4)
+    {
+      return 0;
+    }
+    len = (uint64_t(p[2]) << 8) | p[3];
+    off = 4;
+  }
+  else if (len == 127)
+  {
+    if (n < 10)
+    {
+      return 0;
+    }
+    len = 0;
+    for (int i = 0; i < 8; ++i)
+    {
+      len = (len << 8) | p[2 + i];
+    }
+    off = 10;
+  }
+  // Reject an absurd/hostile length BEFORE any allocation. Also makes the
+  // completeness check below safe: len is bounded, so off + len cannot wrap.
+  if (len > kMaxFramePayload)
+  {
+    return kParseError;
+  }
+  uint8_t mask[4] = {0, 0, 0, 0};
+  if (masked)
+  {
+    if (n < off + 4)
+    {
+      return 0;
+    }
+    for (int i = 0; i < 4; ++i)
+    {
+      mask[i] = p[off + i];
+    }
+    off += 4;
+  }
+  // off <= n holds here (each length/mask branch validated it), so n - off does
+  // not underflow; comparing len against it avoids the off + len overflow that
+  // a 64-bit extended length (code 127) could otherwise use to defeat the guard.
+  if (len > static_cast<uint64_t>(n - off))
+  {
+    return 0;
+  }
+  payload.resize(len);
+  for (uint64_t i = 0; i < len; ++i)
+  {
+    payload[i] = p[off + i] ^ (masked ? mask[i & 3] : 0);
+  }
+  return off + len;
+}
+
+}  // namespace flox::ws

--- a/include/flox/util/wire.h
+++ b/include/flox/util/wire.h
@@ -1,0 +1,68 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace flox::wire
+{
+
+inline void put(std::vector<uint8_t>& o, uint64_t v, int bytes)
+{
+  for (int i = bytes - 1; i >= 0; --i)
+  {
+    o.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xFFU));
+  }
+}
+
+inline uint64_t get(const uint8_t* p, int bytes)
+{
+  uint64_t v = 0;
+  for (int i = 0; i < bytes; ++i)
+  {
+    v = (v << 8) | p[i];
+  }
+  return v;
+}
+
+struct Reader
+{
+  const uint8_t* p{};
+  size_t n{};
+  size_t o{};
+  bool ok{true};
+
+  bool need(size_t k) const { return o + k <= n; }
+
+  uint8_t u8()
+  {
+    if (!need(1))
+    {
+      ok = false;
+      return 0;
+    }
+    return p[o++];
+  }
+  uint64_t u(int bytes)
+  {
+    if (!need(static_cast<size_t>(bytes)))
+    {
+      ok = false;
+      return 0;
+    }
+    const uint64_t v = get(p + o, bytes);
+    o += static_cast<size_t>(bytes);
+    return v;
+  }
+  int64_t i(int bytes) { return static_cast<int64_t>(u(bytes)); }
+};
+
+}  // namespace flox::wire

--- a/mcp/flox_mcp/data/binding_manifest.json
+++ b/mcp/flox_mcp/data/binding_manifest.json
@@ -11376,6 +11376,11 @@
           "name": "ConfidenceInterval"
         },
         {
+          "header": "include/flox/book/ladder_book.h",
+          "kind": "type",
+          "name": "Config"
+        },
+        {
           "header": "include/flox/execution/order_journey_tracer.h",
           "kind": "type",
           "name": "Config"
@@ -12011,6 +12016,11 @@
           "name": "IndividualPosition"
         },
         {
+          "header": "include/flox/util/transport.h",
+          "kind": "type",
+          "name": "IoUring"
+        },
+        {
           "header": "include/flox/aggregator/bar_series.h",
           "kind": "type",
           "name": "Iterator"
@@ -12046,6 +12056,11 @@
           "name": "L3Snapshot"
         },
         {
+          "header": "include/flox/book/ladder_book.h",
+          "kind": "type",
+          "name": "LadderBook"
+        },
+        {
           "header": "include/flox/backtest/latency_distribution.h",
           "kind": "type",
           "name": "LatencyDistribution"
@@ -12077,6 +12092,11 @@
         },
         {
           "header": "include/flox/backtest/order_queue_tracker.h",
+          "kind": "type",
+          "name": "Level"
+        },
+        {
+          "header": "include/flox/book/ladder_book.h",
           "kind": "type",
           "name": "Level"
         },
@@ -12134,6 +12154,11 @@
           "header": "include/flox/execution/live_queue_position_estimator.h",
           "kind": "type",
           "name": "LiveQueueSnapshot"
+        },
+        {
+          "header": "include/flox/book/matching_book.h",
+          "kind": "type",
+          "name": "Loc"
         },
         {
           "header": "include/flox/position/multi_mode_position_tracker.h",
@@ -12204,6 +12229,11 @@
           "header": "include/flox/backtest/simulated_executor.h",
           "kind": "type",
           "name": "MarketState"
+        },
+        {
+          "header": "include/flox/book/matching_book.h",
+          "kind": "type",
+          "name": "MatchingBook"
         },
         {
           "header": "include/flox/replay/ops/segment_ops.h",
@@ -12304,6 +12334,11 @@
           "header": "include/flox/book/nlevel_order_book.h",
           "kind": "type",
           "name": "NLevelOrderBook"
+        },
+        {
+          "header": "include/flox/book/ladder_book.h",
+          "kind": "type",
+          "name": "Node"
         },
         {
           "header": "include/flox/indicator/indicator_pipeline.h",
@@ -12761,6 +12796,11 @@
           "name": "ReadProgress"
         },
         {
+          "header": "include/flox/util/wire.h",
+          "kind": "type",
+          "name": "Reader"
+        },
+        {
           "header": "include/flox/replay/readers/binary_log_reader.h",
           "kind": "type",
           "name": "ReaderConfig"
@@ -12839,6 +12879,11 @@
           "header": "include/flox/replay/abstract_replay_source.h",
           "kind": "type",
           "name": "ReplaySpeed"
+        },
+        {
+          "header": "include/flox/book/resting_order.h",
+          "kind": "type",
+          "name": "RestingOrder"
         },
         {
           "header": "include/flox/risk/portfolio_risk.h",
@@ -13016,6 +13061,11 @@
           "name": "Slot"
         },
         {
+          "header": "include/flox/book/ladder_book.h",
+          "kind": "type",
+          "name": "Slot"
+        },
+        {
           "header": "include/flox/replay/delta_book.h",
           "kind": "type",
           "name": "Snapshot"
@@ -13189,6 +13239,11 @@
           "header": "include/flox/strategy/symbol_state_map.h",
           "kind": "type",
           "name": "SymbolStateMap"
+        },
+        {
+          "header": "include/flox/util/system_clock.h",
+          "kind": "type",
+          "name": "SystemClock"
         },
         {
           "header": "include/flox/indicator/dema.h",
@@ -14712,6 +14767,11 @@
         },
         {
           "kind": "method",
+          "name": "ensureScanned",
+          "parent": "BinaryLogReader"
+        },
+        {
+          "kind": "method",
           "name": "forEach",
           "parent": "BinaryLogReader"
         },
@@ -15637,7 +15697,42 @@
         },
         {
           "kind": "method",
+          "name": "addResting",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "available",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "availableWithin",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "availableWithinExcl",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "bestAsk",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "bestBid",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "bestLevel",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "cancel",
           "parent": "Config"
         },
         {
@@ -15657,6 +15752,31 @@
         },
         {
           "kind": "method",
+          "name": "consumeById",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "contains",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "empty",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "fillBest",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "find",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "forEach",
           "parent": "Config"
         },
@@ -15672,7 +15792,17 @@
         },
         {
           "kind": "method",
+          "name": "full",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "journey",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "levels",
           "parent": "Config"
         },
         {
@@ -15707,12 +15837,22 @@
         },
         {
           "kind": "method",
+          "name": "peekBest",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "reader",
           "parent": "Config"
         },
         {
           "kind": "method",
           "name": "recordCount",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "reduce",
           "parent": "Config"
         },
         {
@@ -17817,6 +17957,16 @@
         },
         {
           "kind": "method",
+          "name": "readAll",
+          "parent": "IoUring"
+        },
+        {
+          "kind": "method",
+          "name": "writeAll",
+          "parent": "IoUring"
+        },
+        {
+          "kind": "method",
           "name": "begin",
           "parent": "Iterator"
         },
@@ -18512,6 +18662,16 @@
         },
         {
           "kind": "method",
+          "name": "fillFront",
+          "parent": "Loc"
+        },
+        {
+          "kind": "method",
+          "name": "consumeSlot",
+          "parent": "LogEntry"
+        },
+        {
+          "kind": "method",
           "name": "flushLoop",
           "parent": "LogEntry"
         },
@@ -18814,6 +18974,81 @@
           "kind": "method",
           "name": "updateTrailingStops",
           "parent": "MarketState"
+        },
+        {
+          "kind": "method",
+          "name": "addResting",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "availableWithin",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "availableWithinExcl",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "bestAsk",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "bestBid",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "bestLevel",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "cancel",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "consumeById",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "contains",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "empty",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "fillBest",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "find",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "levels",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "peekBest",
+          "parent": "MatchingBook"
+        },
+        {
+          "kind": "method",
+          "name": "reduce",
+          "parent": "MatchingBook"
         },
         {
           "kind": "method",
@@ -21157,6 +21392,26 @@
         },
         {
           "kind": "method",
+          "name": "i",
+          "parent": "Reader"
+        },
+        {
+          "kind": "method",
+          "name": "need",
+          "parent": "Reader"
+        },
+        {
+          "kind": "method",
+          "name": "u",
+          "parent": "Reader"
+        },
+        {
+          "kind": "method",
+          "name": "u8",
+          "parent": "Reader"
+        },
+        {
+          "kind": "method",
           "name": "passes",
           "parent": "ReaderFilter"
         },
@@ -22262,7 +22517,52 @@
         },
         {
           "kind": "method",
+          "name": "allocNode",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "bitsRef",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "clampLevel",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "clearBit",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
           "name": "emitBar",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "eraseSlot",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "findSlot",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "freeNode",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "hash",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "highestSetAtOrBelow",
           "parent": "Slot"
         },
         {
@@ -22272,12 +22572,52 @@
         },
         {
           "kind": "method",
+          "name": "insertSlot",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "levelOf",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "levelRef",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "lowestSetAtOrAbove",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "moveToTail",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
           "name": "numTimeframes",
           "parent": "Slot"
         },
         {
           "kind": "method",
+          "name": "onLevelEmptied",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "onLevelOccupied",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
           "name": "onTrade",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "priceOf",
           "parent": "Slot"
         },
         {
@@ -22288,6 +22628,16 @@
         {
           "kind": "method",
           "name": "processSlot",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "requeueFrontToTail",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "setBit",
           "parent": "Slot"
         },
         {
@@ -22308,6 +22658,16 @@
         {
           "kind": "method",
           "name": "timeframes",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "unlink",
+          "parent": "Slot"
+        },
+        {
+          "kind": "method",
+          "name": "wordsFor",
           "parent": "Slot"
         },
         {
@@ -23104,6 +23464,16 @@
           "kind": "method",
           "name": "tryGet",
           "parent": "SymbolStateMap"
+        },
+        {
+          "kind": "method",
+          "name": "advanceTo",
+          "parent": "SystemClock"
+        },
+        {
+          "kind": "method",
+          "name": "nowNs",
+          "parent": "SystemClock"
         },
         {
           "kind": "method",

--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -22,6 +22,7 @@ from .tools import (
     lookahead as lookahead_tool,
     lookup,
     overview,
+    venue as venue_tool,
     positions,
     record_data as record_data_tool,
     runtime,
@@ -39,6 +40,23 @@ def build_server() -> Server:
     @server.list_tools()
     async def _list_tools() -> list[Tool]:
         return [
+            Tool(
+                name="flox_venue_guide",
+                description=(
+                    "Use when the user wants to BUILD A MARKET rather than "
+                    "trade on one: simulate several agents/strategies against "
+                    "one shared order book, model market impact with reacting "
+                    "counterparties, or run a matching engine, clearing "
+                    "ledger, margin/liquidation, market-data feed or venue "
+                    "gateway. Returns a Markdown guide to the optional FLOX "
+                    "venue module (flox::venue): headers, order vocabulary, "
+                    "derivatives waterfall, the multi-agent demo, build flag, "
+                    "and verification posture. No arguments. Cheap; pure "
+                    "bundled text. NOT for an ordinary single-strategy "
+                    "backtest over historical data -- use run_backtest."
+                ),
+                inputSchema={"type": "object", "properties": {}},
+            ),
             Tool(
                 name="flox_overview",
                 description=(
@@ -1193,6 +1211,8 @@ def build_server() -> Server:
         try:
             if name == "flox_overview":
                 text = overview.flox_overview()
+            elif name == "flox_venue_guide":
+                text = venue_tool.flox_venue_guide()
             elif name == "list_indicators":
                 text = indicators.list_indicators(filter=arguments.get("filter"))
             elif name == "lookup_error_code":

--- a/mcp/flox_mcp/tools/venue.py
+++ b/mcp/flox_mcp/tools/venue.py
@@ -1,0 +1,142 @@
+"""flox_venue_guide — the venue module surface for AI agents.
+
+FLOX is normally used to build strategies that trade *on* a market. The
+optional venue module lets you build the market itself: order-level
+matching, clearing, derivatives risk, market data, and a network
+perimeter. An agent asked to "simulate several traders against one
+book", "model market impact with reacting counterparties", or "run a
+matching engine" has no way to discover that surface from the
+strategy-side tools, so it lives here.
+
+Bundled text (no live data); update alongside the venue docs.
+"""
+from __future__ import annotations
+
+
+_GUIDE = """# FLOX venue module
+
+Build a market rather than trade on one. Optional module, same shape as
+`connectors/`: target `flox::venue`, include prefix `<flox-venue/...>`,
+namespace `flox::venue`, gated by `-DFLOX_BUILD_VENUE` (build without it
+entirely with `=OFF`).
+
+Full docs: https://flox-foundation.github.io/flox/venue/
+
+## When to reach for it
+
+- **Multi-agent simulation.** Many strategies or agents trading against
+  ONE book, so price, impact, and adaptation are emergent instead of
+  assumed. A tape-replay backtest cannot express this: the recorded
+  market never reacts to your orders.
+- **Execution research.** Queue priority, iceberg refills, self-trade
+  prevention, last-look rejection, auction uncrosses.
+- **Running a venue.** Clearing, margin, liquidation, insurance, ADL,
+  funding, market data, recovery, network perimeter.
+
+If the user only wants a single strategy against historical data, the
+ordinary backtest path (`run_backtest`) is the right tool, not this.
+
+## Minimal venue
+
+```cpp
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/ledger.h"
+#include "flox/book/matching_book.h"
+
+using namespace flox;
+using namespace flox::venue;
+
+SymbolConfig cfg;
+cfg.id = 1;
+cfg.tickSize   = Price::fromDouble(0.01);
+cfg.minPrice   = Price::fromDouble(1);      // 0 = unchecked
+cfg.maxPrice   = Price::fromDouble(1000);
+cfg.baseAsset  = 0;
+cfg.quoteAsset = 1;
+
+Ledger ledger;
+ledger.deposit(acct, /*asset*/ 1, amountOf(Volume::fromDouble(10'000)));
+
+MatchingEngine<MatchingBook> venue(cfg, [](const OutboundEvent& e) { publish(e); });
+venue.setLedger(&ledger, /*venue account*/ 999);
+venue.submit(InboundCommand{order}, tsNs);
+```
+
+Books: `MatchingBook` (map reference, obviously correct) and
+`LadderBook` (tick-indexed, O(1) best, no steady-state allocation).
+Interchangeable, and held identical by a differential fuzz.
+
+## Surface map
+
+| Need | Header |
+|---|---|
+| Matching, order lifecycle, auctions, LULD | `flox-venue/matching_engine.h`, `flox-venue/matcher.h` |
+| Books | `flox/book/{matching_book,ladder_book}.h` (core) |
+| Money (double entry, `__int128`, conservation-exact) | `flox-venue/ledger.h` |
+| Portfolio margin, collateral haircuts, segregation | `flox-venue/{cross_margin,collateral,segregation}.h` |
+| Mark/index price, feed circuit breaker | `flox-venue/{index_feed,mark_feed_driver}.h` |
+| Funding (live rate + scheduler) | `flox-venue/{funding_rate,funding_scheduler}.h` |
+| Single-writer runtime, WAL, replay determinism | `flox-venue/{sequenced_shard,journal,event_hash}.h` |
+| Market data out (L2 + ITCH) | `flox-venue/{market_data,itch_codec}.h` |
+| Gateways, sessions, FIX/OUCH/REST | `flox-venue/{tcp_gateway,ws_gateway,tls_gateway,session,fix_codec,ouch_codec,rest_json}.h` |
+| Control plane, metrics | `flox-venue/{control_api,metrics,prometheus}.h` |
+
+## Order vocabulary
+
+Types LIMIT / MARKET / STOP / TAKE_PROFIT / TRAILING; TIF GTC, IOC,
+FOK, GTD (`expiryNs`), POST_ONLY; iceberg (`visibleQuantity`); peg
+(Bid/Ask/Mid + offset); OCO (`ocoGroup`); reduce-only; STP in four
+modes with account or firm scope.
+
+Every state-mutating input is an `InboundCommand` (`NewOrder`,
+`CancelOrder`, `ModifyOrder`, `MassCancel`, `Quote`,
+`LastLookDecision`, `SetMark`, `ApplyFunding`, `AdminCmd`) — that is
+what makes deterministic journal replay possible.
+
+## Derivatives
+
+Set `cfg.linearPerp = true` plus `initialMarginBps` /
+`maintenanceMarginBps`. Marks arrive as `SetMark` commands and drive
+the maintenance sweep. Waterfall on a bankruptcy: cancel the account's
+resting orders (freeing its own collateral) -> force-close at the mark
+-> insurance fund -> ADL from the most profitable opposite side,
+closed at the bankruptcy price.
+
+For whole-account margin across symbols use `CrossMarginManager`.
+Note the deliberate split: `flox::LiquidationEngine`
+(`flox/backtest/`) is the backtest-side model on `double` equity;
+`CrossMarginManager` is the venue-side one backed by the ledger in
+`__int128`. Do not mix them for the same account.
+
+## Multi-agent demo
+
+`demo/src/multi_agent_venue_demo.cpp` — market maker, momentum,
+mean-reversion and noise agents on one book.
+
+```bash
+cmake -S . -B build -DFLOX_BUILD_DEMO=ON
+cmake --build build --target multi_agent_venue_demo
+./build/demo/multi_agent_venue_demo
+```
+
+Emergent result: the maker earns the spread, momentum pays for
+chasing, and cash plus inventory are conserved exactly. Two things to
+get right when writing agents: quote on the tick grid (the venue
+rejects anything else) and refresh quotes with `MassCancel`.
+
+## Verification posture
+
+The core is fuzz-proven in CI, not just unit-tested: a differential
+fuzz (reference book vs ladder in lockstep, identical event stream, no
+crossed book; `FLOX_FUZZ_OPS` for a deep run) and a conservation fuzz
+(value never created or destroyed, and after the book drains every
+account's `reserved` returns to zero). Plus an ASAN/UBSAN/TSAN gate:
+`venue/scripts/run_sanitizers.sh`.
+
+`venue/AUDIT-LOG.md` catalogues the defects this corpus caught, each
+with the regression test that pins it.
+"""
+
+
+def flox_venue_guide() -> str:
+    return _GUIDE

--- a/mcp/tests/test_polyglot_tools.py
+++ b/mcp/tests/test_polyglot_tools.py
@@ -21,6 +21,7 @@ from flox_mcp.tools import (
     lookup,
     overview,
     scaffold,
+    venue,
 )
 
 
@@ -452,3 +453,34 @@ def test_flox_overview_covers_control_plane_safety():
     assert "scope" in out.lower()
     assert "out-of-band" in out.lower() or "OOB" in out
     assert "audit" in out.lower()
+
+
+# ── flox_venue_guide ──────────────────────────────────────────────────
+
+
+def test_flox_venue_guide_covers_the_module_surface():
+    """The venue guide is how an agent discovers that FLOX can BE a
+    market, not just trade on one. It must name the build flag, the
+    include prefix, and the pieces an agent needs to assemble one."""
+    out = venue.flox_venue_guide()
+    assert len(out) > 500
+    # How to get it at all.
+    assert "FLOX_BUILD_VENUE" in out
+    assert "flox-venue/" in out
+    assert "flox::venue" in out
+    # The capability that justifies the module.
+    assert "Multi-agent" in out or "multi-agent" in out
+    # Core pieces an agent has to reach for.
+    assert "matching_engine.h" in out
+    assert "ledger.h" in out
+    assert "cross_margin" in out
+    # Steer away from the wrong tool for a plain historical backtest.
+    assert "run_backtest" in out
+
+
+def test_flox_venue_guide_flags_the_two_margin_models():
+    """The venue and backtest margin models coexist deliberately;
+    an agent that mixes them for one account gets wrong numbers."""
+    out = venue.flox_venue_guide()
+    assert "LiquidationEngine" in out
+    assert "CrossMarginManager" in out

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,6 +206,18 @@ nav:
           - CI Configuration: how-to/ci.md
           - Contributing: how-to/contributing.md
 
+  - Venue:
+      - Overview: venue/index.md
+      - Building with/without the venue: venue/build.md
+      - Matching: venue/matching.md
+      - Clearing and the ledger: venue/clearing.md
+      - Derivatives risk: venue/risk.md
+      - Runtime and recovery: venue/runtime.md
+      - Market data: venue/market-data.md
+      - Perimeter: venue/perimeter.md
+      - Multi-agent simulation: venue/multi-agent.md
+      - Verification: venue/verification.md
+
   - Explanation:
       - explanation/README.md
       - Architecture: explanation/architecture.md

--- a/src/backtest/backtest_runner.cpp
+++ b/src/backtest/backtest_runner.cpp
@@ -476,38 +476,55 @@ void BacktestRunner::notifyPaused()
   }
 }
 
+// The flag stores below happen under _mutex: waitForResume evaluates its
+// predicate with the lock held, so a store+notify outside the lock can land
+// between the predicate check and the sleep and the wakeup is lost forever.
+
 void BacktestRunner::resume()
 {
-  _stepRequested.store(false, std::memory_order_release);
-  _paused.store(false, std::memory_order_release);
+  {
+    std::lock_guard lock(_mutex);
+    _stepRequested.store(false, std::memory_order_release);
+    _paused.store(false, std::memory_order_release);
+  }
   _cv.notify_all();
 }
 
 void BacktestRunner::step()
 {
-  _stepMode.store(BacktestMode::Step, std::memory_order_release);
-  _stepRequested.store(true, std::memory_order_release);
-  _paused.store(false, std::memory_order_release);
+  {
+    std::lock_guard lock(_mutex);
+    _stepMode.store(BacktestMode::Step, std::memory_order_release);
+    _stepRequested.store(true, std::memory_order_release);
+    _paused.store(false, std::memory_order_release);
+  }
   _cv.notify_all();
 }
 
 void BacktestRunner::stepUntil(BacktestMode mode)
 {
-  _stepMode.store(mode, std::memory_order_release);
-  _stepRequested.store(true, std::memory_order_release);
-  _paused.store(false, std::memory_order_release);
+  {
+    std::lock_guard lock(_mutex);
+    _stepMode.store(mode, std::memory_order_release);
+    _stepRequested.store(true, std::memory_order_release);
+    _paused.store(false, std::memory_order_release);
+  }
   _cv.notify_all();
 }
 
 void BacktestRunner::pause()
 {
+  std::lock_guard lock(_mutex);
   _paused.store(true, std::memory_order_release);
 }
 
 void BacktestRunner::stop()
 {
-  _running.store(false, std::memory_order_release);
-  _paused.store(false, std::memory_order_release);
+  {
+    std::lock_guard lock(_mutex);
+    _running.store(false, std::memory_order_release);
+    _paused.store(false, std::memory_order_release);
+  }
   _cv.notify_all();
 }
 

--- a/src/backtest/liquidation_engine.cpp
+++ b/src/backtest/liquidation_engine.cpp
@@ -471,6 +471,7 @@ void LiquidationEngine::runInsuranceAndAdlPhase(SymbolId symbol,
     size_t idx;
     double score;
     double upnl;
+    uint64_t accountId;  // stable tie-break key (see the sort below)
   };
   std::vector<AdlCandidate> candidates;
 
@@ -506,7 +507,7 @@ void LiquidationEngine::runInsuranceAndAdlPhase(SymbolId symbol,
     const double upnl = p.quantity * (markPrice - p.entryPrice);
     if (upnl > 0.0)
     {
-      candidates.push_back({nullptr, i, scorePosition(p, upnl), upnl});
+      candidates.push_back({nullptr, i, scorePosition(p, upnl), upnl, p.accountId});
     }
   }
   // Account candidates.
@@ -527,14 +528,29 @@ void LiquidationEngine::runInsuranceAndAdlPhase(SymbolId symbol,
       const double upnl = p.quantity * (markPrice - p.entryPrice);
       if (upnl > 0.0)
       {
-        candidates.push_back({acct, i, scorePosition(p, upnl), upnl});
+        candidates.push_back({acct, i, scorePosition(p, upnl), upnl, p.accountId});
       }
     }
   }
 
+  // Deterministic total order: rank by ADL score, then break ties on a stable
+  // key (accountId, position index) so the closeout queue does not depend on
+  // std::sort's handling of equal scores across STL/build versions -- required
+  // for backtest reproducibility / live-parity when several opposite-side
+  // winners share the same score.
   std::sort(candidates.begin(), candidates.end(),
             [](const AdlCandidate& a, const AdlCandidate& b)
-            { return a.score > b.score; });
+            {
+              if (a.score != b.score)
+              {
+                return a.score > b.score;
+              }
+              if (a.accountId != b.accountId)
+              {
+                return a.accountId < b.accountId;
+              }
+              return a.idx < b.idx;
+            });
 
   // Track indexes per source so we can erase descending after the
   // close loop.
@@ -546,6 +562,14 @@ void LiquidationEngine::runInsuranceAndAdlPhase(SymbolId symbol,
     {
       break;
     }
+    // ADL closes the winner at the bankruptcy price (spec: liquidation-and-adl):
+    // it forgoes only the gain needed to absorb the remaining deficit (capped at
+    // its own uPnl) and keeps any excess. Crediting the FULL mark uPnl while
+    // decrementing the deficit -- as before -- leaves the deficit unfunded, i.e.
+    // creates money against a conservation-exact ledger (the winner is made whole
+    // AND the bankrupt's loss vanishes). Confiscate exactly `absorbed`.
+    const double absorbed = std::min(totalDeficit, c.upnl);
+    const double realized = c.upnl - absorbed;  // gain above the bankruptcy price
     if (c.owner == nullptr)
     {
       const auto& p = _positions[c.idx];
@@ -555,25 +579,23 @@ void LiquidationEngine::runInsuranceAndAdlPhase(SymbolId symbol,
     else
     {
       auto& p = c.owner->positionsMut()[c.idx];
-      // Credit the account's equity (cross mode) or the leg's
-      // isolated_equity (isolated mode) with the realised PnL. The
-      // mark price is the close benchmark for ADL — no executor
-      // routing on ADL closes by spec.
+      // Credit the account's equity (cross) or the leg's isolated_equity
+      // (isolated) with the RETAINED PnL after the ADL haircut.
       if (c.owner->marginMode() == MarginMode::Cross)
       {
-        c.owner->addEquity(c.upnl);
+        c.owner->addEquity(realized);
       }
       else
       {
-        p.equity += c.upnl;
+        p.equity += realized;
       }
       out.adlClosedOut.push_back(p.accountId);
       acctClose[c.owner].push_back(c.idx);
     }
-    totalDeficit -= c.upnl;
+    totalDeficit -= absorbed;
     ++_statAdlCloseouts;
     ++out.adlCloseoutsCount;
-    _deficitsPaidByAdl.push_back(c.upnl);
+    _deficitsPaidByAdl.push_back(absorbed);
     if (_firstAdlTickIdx == UINT64_MAX)
     {
       _firstAdlTickIdx = tickIdx;

--- a/src/log/atomic_logger.cpp
+++ b/src/log/atomic_logger.cpp
@@ -86,6 +86,9 @@ void AtomicLogger::log(LogLevel level, std::string_view msg)
   entry.length = std::min(msg.size(), MAX_MESSAGE_SIZE - 1);
   std::memcpy(entry.message, msg.data(), entry.length);
   entry.message[entry.length] = '\0';
+  // Publish only now: everything above must be visible to the consumer before
+  // it is allowed to read this slot.
+  entry.ready.store(true, std::memory_order_release);
 
   _cv.notify_one();
 }
@@ -103,7 +106,7 @@ void AtomicLogger::flushLoop()
     {
       rotateIfNeeded();
       const size_t idx = _readIndex.fetch_add(1, std::memory_order_acq_rel) % BUFFER_SIZE;
-      writeToOutput(_buffer[idx]);
+      consumeSlot(idx);
     }
   }
 
@@ -111,7 +114,7 @@ void AtomicLogger::flushLoop()
   {
     rotateIfNeeded();
     const size_t idx = _readIndex.fetch_add(1) % BUFFER_SIZE;
-    writeToOutput(_buffer[idx]);
+    consumeSlot(idx);
   }
 }
 
@@ -150,6 +153,20 @@ void AtomicLogger::rotate()
   _file = std::fopen(path.c_str(), "w");
   _bytesWritten = 0;
   _lastRotation = std::chrono::system_clock::now();
+}
+
+// Read a claimed slot once its producer has published it. The slot index can
+// become visible before the payload is written, so spin briefly on the flag
+// instead of racing the producer.
+void AtomicLogger::consumeSlot(size_t idx)
+{
+  LogEntry& entry = _buffer[idx];
+  while (!entry.ready.load(std::memory_order_acquire))
+  {
+    std::this_thread::yield();
+  }
+  writeToOutput(entry);
+  entry.ready.store(false, std::memory_order_relaxed);
 }
 
 void AtomicLogger::writeToOutput(const LogEntry& entry)

--- a/src/replay/binary_log_reader.cpp
+++ b/src/replay/binary_log_reader.cpp
@@ -655,6 +655,14 @@ void BinaryLogReader::clearProgressCallback()
   _progress_cb = nullptr;
 }
 
+bool BinaryLogReader::ensureScanned() const
+{
+  std::call_once(_scan_once,
+                 [this]
+                 { const_cast<BinaryLogReader*>(this)->scanSegments(); });
+  return _scanned;
+}
+
 bool BinaryLogReader::scanSegments()
 {
   if (_scanned)
@@ -893,7 +901,7 @@ bool BinaryLogReader::readSegmentFrom(const SegmentInfo& segment, int64_t start_
 
 bool BinaryLogReader::forEach(EventCallback callback)
 {
-  if (!scanSegments())
+  if (!ensureScanned())
   {
     return false;
   }
@@ -939,7 +947,7 @@ bool BinaryLogReader::run(std::span<IAggregator* const> aggregators,
       // missing directory) we leave total_events = 0 and report
       // pct=0.0 to the callback. The walk itself will then fail and
       // surface the underlying error to the caller.
-      if (scanSegments())
+      if (ensureScanned())
       {
         for (const auto& seg : _segments)
         {
@@ -1007,7 +1015,7 @@ bool BinaryLogReader::run(std::span<IAggregator* const> aggregators,
 
   // Auto / multi-thread path. Resolve n_threads after scanning the
   // segment list so we can cap to actual segment count.
-  if (!scanSegments())
+  if (!ensureScanned())
   {
     return false;
   }
@@ -1228,7 +1236,7 @@ bool BinaryLogReader::run(std::span<IAggregator* const> aggregators,
 
 bool BinaryLogReader::streamForEach(EventCallback callback)
 {
-  if (!scanSegments())
+  if (!ensureScanned())
   {
     return false;
   }
@@ -1246,7 +1254,7 @@ bool BinaryLogReader::streamForEach(EventCallback callback)
 
 bool BinaryLogReader::streamForEachFrom(int64_t start_ts_ns, EventCallback callback)
 {
-  if (!scanSegments())
+  if (!ensureScanned())
   {
     return false;
   }
@@ -1480,7 +1488,7 @@ bool BinaryLogReader::readSegmentStreamingFrom(const SegmentInfo& segment,
 
 bool BinaryLogReader::forEachFrom(int64_t start_ts_ns, EventCallback callback)
 {
-  if (!scanSegments())
+  if (!ensureScanned())
   {
     return false;
   }
@@ -1507,7 +1515,7 @@ bool BinaryLogReader::forEachFrom(int64_t start_ts_ns, EventCallback callback)
 
 std::optional<std::pair<int64_t, int64_t>> BinaryLogReader::timeRange() const
 {
-  if (_segments.empty())
+  if (!ensureScanned() || _segments.empty())
   {
     return std::nullopt;
   }
@@ -1647,7 +1655,7 @@ DatasetSummary BinaryLogReader::inspectWithSymbols(const std::filesystem::path& 
 
 DatasetSummary BinaryLogReader::summary()
 {
-  scanSegments();
+  ensureScanned();
 
   DatasetSummary result;
   result.data_dir = _config.data_dir;
@@ -1691,7 +1699,7 @@ DatasetSummary BinaryLogReader::summary()
 
 uint64_t BinaryLogReader::count()
 {
-  scanSegments();
+  ensureScanned();
 
   uint64_t total = 0;
   for (const auto& segment : _segments)

--- a/src/replay/parallel_reader.cpp
+++ b/src/replay/parallel_reader.cpp
@@ -49,7 +49,13 @@ ParallelReader::ParallelReader(ParallelReaderConfig config) : _config(std::move(
 
 ParallelReader::~ParallelReader()
 {
-  _shutdown.store(true);
+  {
+    // Store under the queue mutex: the workers' wait predicate reads _shutdown
+    // with the lock held, so an unlocked store+notify can slip between the
+    // predicate check and the sleep and the worker never wakes (join hangs).
+    std::lock_guard lock(_queue_mutex);
+    _shutdown.store(true);
+  }
   _queue_cv.notify_all();
 
   for (auto& worker : _workers)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,8 @@ if(FLOX_ENABLE_BACKTEST)
   add_flox_test(test_option_settlement)
   add_flox_test(test_option_exercise)
   add_flox_test(test_option_fill_model)
+  add_flox_test(test_system_clock)
+  add_flox_test(test_matching_book)
 endif()
 
 add_flox_test(test_indicators)

--- a/tests/test_account.cpp
+++ b/tests/test_account.cpp
@@ -342,17 +342,19 @@ TEST(Account, CrossAccountDeficitTriggersAdlAcrossAccounts)
   e.attachAccount(&aShort);
 
   // BTC drops 20% (-10000 for aLong, +10000 for aShort). aLong
-  // liquidates with 10k deficit. ADL closes aShort's profitable
-  // BTC short to absorb the deficit; aShort's equity is credited
-  // with the realised +10k.
+  // liquidates with a 10k deficit. ADL closes aShort's profitable
+  // BTC short at the bankruptcy price: it forgoes exactly the gain
+  // that absorbs the deficit and keeps only the excess.
   const double aShortEquityBefore = aShort.equity();
   const auto out = e.onMark(BTC, 40'000.0);
   EXPECT_GE(out.liquidationsCount, 1u);
   EXPECT_GE(out.adlCloseoutsCount, 1u);
   // aShort's BTC position should be gone (ADL'd).
   EXPECT_EQ(aShort.positionCount(), 0u);
-  // aShort's equity rose by the realised +10k from the ADL close.
-  EXPECT_GT(aShort.equity(), aShortEquityBefore);
+  // Deficit (10k) == the winner's gain (10k), so the whole gain is
+  // confiscated and equity is unchanged. Crediting the full +10k here
+  // would leave the deficit unfunded, i.e. create money.
+  EXPECT_DOUBLE_EQ(aShort.equity(), aShortEquityBefore);
 }
 
 TEST(Account, IsolatedAndCrossAccountsCoexist)

--- a/tests/test_interactive_runner.cpp
+++ b/tests/test_interactive_runner.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 #include <thread>
+#include <utility>
 #include <vector>
 
 using namespace flox;
@@ -88,9 +89,53 @@ std::vector<replay::ReplayEvent> createTestEvents(size_t count)
 
 }  // namespace
 
+// Sanitizer builds run the runner thread several times slower, so a wall-clock
+// budget that is generous natively goes flaky under TSAN on a loaded CI runner.
+#if defined(__SANITIZE_THREAD__) || defined(__SANITIZE_ADDRESS__)
+constexpr int kTimeoutScale = 20;
+#elif defined(__has_feature)
+#if __has_feature(thread_sanitizer) || __has_feature(address_sanitizer)
+constexpr int kTimeoutScale = 20;
+#else
+constexpr int kTimeoutScale = 1;
+#endif
+#else
+constexpr int kTimeoutScale = 1;
+#endif
+
+// Stops the runner and joins on every exit path. A test that ASSERT_*s while
+// the worker thread is live returns from the test body with the thread still
+// joinable, and std::thread's destructor then calls std::terminate -- aborting
+// the whole binary and hiding both the real failure and every later test.
+class RunnerThread
+{
+ public:
+  template <typename Fn>
+  RunnerThread(BacktestRunner& runner, Fn&& fn) : _runner(runner), _t(std::forward<Fn>(fn))
+  {
+  }
+
+  ~RunnerThread()
+  {
+    _runner.stop();
+    if (_t.joinable())
+    {
+      _t.join();
+    }
+  }
+
+  RunnerThread(const RunnerThread&) = delete;
+  RunnerThread& operator=(const RunnerThread&) = delete;
+
+ private:
+  BacktestRunner& _runner;
+  std::thread _t;
+};
+
 // Helper to wait for a condition with timeout
 template <typename Pred>
-bool waitFor(Pred pred, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+bool waitFor(Pred pred,
+             std::chrono::milliseconds timeout = std::chrono::milliseconds(1000 * kTimeoutScale))
 {
   auto start = std::chrono::steady_clock::now();
   while (!pred())
@@ -116,8 +161,8 @@ TEST(InteractiveRunnerTest, StepExecutesOneEvent)
                           { ++eventsSeen; });
 
   // Run in background thread
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   // Wait for initial pause
   ASSERT_TRUE(waitFor([&]()
@@ -138,10 +183,6 @@ TEST(InteractiveRunnerTest, StepExecutesOneEvent)
   ASSERT_TRUE(waitFor([&]()
                       { return eventsSeen.load() >= 3 && runner.isPaused(); }));
   EXPECT_EQ(eventsSeen.load(), 3);
-
-  // Stop and join
-  runner.stop();
-  t.join();
 }
 
 TEST(InteractiveRunnerTest, RunUntilBreakpoint)
@@ -154,8 +195,8 @@ TEST(InteractiveRunnerTest, RunUntilBreakpoint)
   // Break after 50 events
   runner.addBreakpoint(Breakpoint::afterEvents(50));
 
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   ASSERT_TRUE(waitFor([&]()
                       { return runner.isPaused(); }));
@@ -169,9 +210,6 @@ TEST(InteractiveRunnerTest, RunUntilBreakpoint)
   EXPECT_TRUE(state.isPaused);
   EXPECT_GE(state.eventCount, 50u);
   EXPECT_FALSE(state.isFinished);
-
-  runner.stop();
-  t.join();
 }
 
 TEST(InteractiveRunnerTest, RunToCompletion)
@@ -181,8 +219,8 @@ TEST(InteractiveRunnerTest, RunToCompletion)
 
   BacktestRunner runner;
 
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   ASSERT_TRUE(waitFor([&]()
                       { return runner.isPaused(); }));
@@ -197,8 +235,6 @@ TEST(InteractiveRunnerTest, RunToCompletion)
   auto state = runner.state();
   EXPECT_TRUE(state.isFinished);
   EXPECT_EQ(state.eventCount, 10u);
-
-  t.join();
 }
 
 TEST(InteractiveRunnerTest, StepUntilTrade)
@@ -228,8 +264,8 @@ TEST(InteractiveRunnerTest, StepUntilTrade)
   MockReader reader(events);
   BacktestRunner runner;
 
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   ASSERT_TRUE(waitFor([&]()
                       { return runner.isPaused(); }));
@@ -242,9 +278,6 @@ TEST(InteractiveRunnerTest, StepUntilTrade)
   auto state = runner.state();
   EXPECT_EQ(state.tradeCount, 1u);
   EXPECT_EQ(state.bookUpdateCount, 5u);
-
-  runner.stop();
-  t.join();
 }
 
 TEST(InteractiveRunnerTest, BreakpointAtTime)
@@ -257,8 +290,8 @@ TEST(InteractiveRunnerTest, BreakpointAtTime)
   // Break at timestamp 50ms
   runner.addBreakpoint(Breakpoint::atTime(50000000));
 
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   ASSERT_TRUE(waitFor([&]()
                       { return runner.isPaused(); }));
@@ -269,9 +302,6 @@ TEST(InteractiveRunnerTest, BreakpointAtTime)
   auto state = runner.state();
   EXPECT_TRUE(state.isPaused);
   EXPECT_GE(state.currentTimeNs, 50000000u);
-
-  runner.stop();
-  t.join();
 }
 
 TEST(InteractiveRunnerTest, CustomBreakpoint)
@@ -285,8 +315,8 @@ TEST(InteractiveRunnerTest, CustomBreakpoint)
   runner.addBreakpoint(Breakpoint::when([](const replay::ReplayEvent& ev)
                                         { return ev.type == replay::EventType::Trade && ev.trade.price_raw > 10050; }));
 
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   ASSERT_TRUE(waitFor([&]()
                       { return runner.isPaused(); }));
@@ -298,9 +328,6 @@ TEST(InteractiveRunnerTest, CustomBreakpoint)
   EXPECT_TRUE(state.isPaused);
   // Should have processed roughly 51 events (0-50 have prices 10000-10050)
   EXPECT_GE(state.eventCount, 51u);
-
-  runner.stop();
-  t.join();
 }
 
 TEST(InteractiveRunnerTest, PauseCallback)
@@ -314,8 +341,8 @@ TEST(InteractiveRunnerTest, PauseCallback)
   runner.setPauseCallback([&](const BacktestState&)
                           { ++pauseCount; });
 
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   // Wait for initial pause callback
   ASSERT_TRUE(waitFor([&]()
@@ -329,9 +356,6 @@ TEST(InteractiveRunnerTest, PauseCallback)
   ASSERT_TRUE(waitFor([&]()
                       { return pauseCount.load() >= 2; }));
   EXPECT_GE(pauseCount.load(), 2);
-
-  runner.stop();
-  t.join();
 }
 
 TEST(InteractiveRunnerTest, StateInspection)
@@ -351,8 +375,8 @@ TEST(InteractiveRunnerTest, StateInspection)
         }
       });
 
-  std::thread t([&]()
-                { runner.start(reader); });
+  RunnerThread t(runner, [&]()
+                 { runner.start(reader); });
 
   // Wait for initial pause callback
   while (!initialPauseCalled.load())
@@ -368,7 +392,8 @@ TEST(InteractiveRunnerTest, StateInspection)
   runner.resume();
 
   // Wait for completion
-  t.join();
+  ASSERT_TRUE(waitFor([&]()
+                      { return runner.isFinished(); }));
 
   state = runner.state();
   EXPECT_EQ(state.eventCount, 5u);

--- a/tests/test_liquidation_engine.cpp
+++ b/tests/test_liquidation_engine.cpp
@@ -9,6 +9,7 @@
 
 #include "flox/backtest/liquidation_engine.h"
 
+#include "flox/backtest/account.h"
 #include "flox/backtest/simulated_clock.h"
 #include "flox/backtest/simulated_executor.h"
 
@@ -102,6 +103,60 @@ TEST(LiquidationEngine, AdlClosesProfitableOppositeWhenFundDepleted)
   // acct 3 alone covers 550. So just one closeout.
   EXPECT_EQ(out.adlCloseoutsCount, 1u);
   EXPECT_EQ(out.adlClosedOut.front(), 3u);
+}
+
+// Regression: ADL must close the winner at the bankruptcy price -- it forgoes
+// only the gain that absorbs the deficit and KEEPS the excess. Crediting the
+// full mark uPnl (the old behaviour) makes the winner whole AND zeroes the
+// deficit => money created. Here deficit=550, winner uPnl=600: it must forgo
+// 550 and retain 50, not pocket the full 600.
+TEST(LiquidationEngine, AdlConfiscatesForgoneGainNotFullUpnl)
+{
+  LiquidationEngine e;
+  e.addTier(0.0, 0.005);
+  e.setInsuranceFundCapital(0.0);  // fund can't absorb -> straight to ADL
+  e.setAdlEnabled(true);
+  e.setLiquidationSlippageBps(0.0);
+
+  // Bankrupt long (orphan): 10 @ 100, equity 50; at mark 40 loss 600 -> deficit 550.
+  e.openPosition(pos(/*acct=*/1, 10.0, 100.0, 50.0));
+  // Winner short account: -10 @ 100, equity 100; at mark 40 uPnl = +600.
+  Account w(/*id=*/2, /*equity=*/100.0);
+  w.setMarginMode(MarginMode::Cross);
+  w.openPosition(BTC, -10.0, 100.0);
+  e.attachAccount(&w);
+
+  const auto out = e.onMark(BTC, 40.0);
+  EXPECT_EQ(out.adlCloseoutsCount, 1u);
+  EXPECT_EQ(out.adlClosedOut.front(), 2u);
+  // absorbed = min(deficit 550, uPnl 600) = 550; retained = 50.
+  // Correct: 100 + 50 = 150. Old buggy behaviour credited full 600 -> 700.
+  EXPECT_DOUBLE_EQ(w.equity(), 150.0);
+  EXPECT_EQ(w.positionCount(), 0u);  // fully deleveraged
+}
+
+// Determinism: when several opposite-side winners share the same ADL score, the
+// closeout queue must be a stable total order (score, then accountId) so the
+// victim does not depend on std::sort's handling of equal keys across builds.
+// Two identical winners (equal PnL ratio) are inserted in DESCENDING id order;
+// the lower accountId must still be chosen first.
+TEST(LiquidationEngine, AdlTieBreaksOnAccountIdDeterministically)
+{
+  LiquidationEngine e;
+  e.addTier(0.0, 0.005);
+  e.setInsuranceFundCapital(0.0);
+  e.setAdlEnabled(true);
+  e.setLiquidationSlippageBps(0.0);
+
+  // Bankrupt long -> deficit 550 (< one winner's 600, so exactly one closeout).
+  e.openPosition(pos(/*acct=*/1, 10.0, 100.0, 50.0));
+  // Two identical winners, equal PnL ratio 6; inserted high id first.
+  e.openPosition(pos(/*acct=*/3, -10.0, 100.0, 100.0));
+  e.openPosition(pos(/*acct=*/2, -10.0, 100.0, 100.0));
+
+  const auto out = e.onMark(BTC, 40.0);
+  EXPECT_EQ(out.adlCloseoutsCount, 1u);
+  EXPECT_EQ(out.adlClosedOut.front(), 2u);  // lower accountId wins the tie
 }
 
 TEST(LiquidationEngine, AdlDisabledLeavesDeficitUnpaid)

--- a/tests/test_matching_book.cpp
+++ b/tests/test_matching_book.cpp
@@ -1,0 +1,111 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox/book/ladder_book.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+using namespace flox;
+
+namespace
+{
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+RestingOrder ord(OrderId id, Side s, double p, double q)
+{
+  return RestingOrder{.id = id, .accountId = 1, .price = px(p), .leaves = qty(q), .side = s};
+}
+
+LadderBook::Config ladderCfg()
+{
+  return LadderBook::Config{
+      .basePriceRaw = 0, .tickRaw = px(0.01).raw(), .numLevels = 20000, .maxOrders = 1024};
+}
+
+// Compare top-of-book + a crossing-depth probe between the two implementations.
+template <class A, class B>
+void expectAgree(const A& a, const B& b)
+{
+  ASSERT_EQ(a.bestBid().has_value(), b.bestBid().has_value());
+  ASSERT_EQ(a.bestAsk().has_value(), b.bestAsk().has_value());
+  if (a.bestBid().has_value())
+  {
+    EXPECT_EQ(a.bestBid().value().raw(), b.bestBid().value().raw());
+  }
+  if (a.bestAsk().has_value())
+  {
+    EXPECT_EQ(a.bestAsk().value().raw(), b.bestAsk().value().raw());
+  }
+  EXPECT_EQ(a.availableWithin(Side::BUY, px(200), false).raw(),
+            b.availableWithin(Side::BUY, px(200), false).raw());
+  EXPECT_EQ(a.availableWithin(Side::SELL, px(1), false).raw(),
+            b.availableWithin(Side::SELL, px(1), false).raw());
+}
+}  // namespace
+
+// The map-reference MatchingBook and the O(1) LadderBook must be observationally
+// identical across add / cancel / reduce / fillBest -- the property the venue
+// relies on and differentially fuzzes. This is the in-flox equivalence smoke.
+TEST(MatchingBook, LadderAndMapAgreeAcrossOps)
+{
+  MatchingBook m;
+  LadderBook l(ladderCfg());
+
+  // Build both sides across several levels.
+  for (auto& o : {ord(1, Side::SELL, 101, 5), ord(2, Side::SELL, 102, 3),
+                  ord(3, Side::SELL, 101, 2), ord(4, Side::BUY, 99, 4),
+                  ord(5, Side::BUY, 98, 6), ord(6, Side::BUY, 99, 1)})
+  {
+    m.addResting(o.side, o);
+    l.addResting(o.side, o);
+  }
+  EXPECT_TRUE(m.bestBid().has_value() && m.bestBid().value() == px(99));
+  EXPECT_TRUE(m.bestAsk().has_value() && m.bestAsk().value() == px(101));
+  expectAgree(m, l);
+
+  // Partial fill of the best ask (101 has 5+2=7 across ids 1,3 FIFO).
+  m.fillBest(Side::SELL, qty(6));
+  l.fillBest(Side::SELL, qty(6));
+  expectAgree(m, l);
+
+  // Cancel a bid at the top level.
+  m.cancel(4);
+  l.cancel(4);
+  expectAgree(m, l);
+
+  // Reduce a resting order in place.
+  m.reduce(5, qty(2));
+  l.reduce(5, qty(2));
+  expectAgree(m, l);
+
+  // Drain the remaining asks by cancelling them; the ask side empties in both.
+  for (OrderId id : {OrderId{1}, OrderId{2}, OrderId{3}})
+  {
+    m.cancel(id);
+    l.cancel(id);
+  }
+  EXPECT_FALSE(m.bestAsk().has_value());
+  EXPECT_FALSE(l.bestAsk().has_value());
+  expectAgree(m, l);
+}
+
+TEST(MatchingBook, IcebergHiddenReserveIsRealDepth)
+{
+  MatchingBook m;
+  LadderBook l(ladderCfg());
+  // Iceberg sell: display 2, hide 8 (total 10) at 100.
+  RestingOrder ice{.id = 1, .accountId = 1, .price = px(100), .leaves = qty(2), .side = Side::SELL, .hidden = qty(8), .peak = qty(2)};
+  m.addResting(Side::SELL, ice);
+  l.addResting(Side::SELL, ice);
+  // availableWithin counts hidden reserve as real crossing liquidity (10, not 2).
+  EXPECT_EQ(m.availableWithin(Side::BUY, px(100), false).raw(), qty(10).raw());
+  EXPECT_EQ(l.availableWithin(Side::BUY, px(100), false).raw(), qty(10).raw());
+}

--- a/tests/test_system_clock.cpp
+++ b/tests/test_system_clock.cpp
@@ -1,0 +1,44 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox/util/system_clock.h"
+
+#include <gtest/gtest.h>
+
+using namespace flox;
+
+namespace
+{
+// Bounds for a plausible wall-clock reading: after 2020-01-01 and before 2100.
+// This distinguishes a real live clock from a simulated/zero value.
+constexpr UnixNanos kAfter2020 = 1'577'836'800'000'000'000LL;
+constexpr UnixNanos kBefore2100 = 4'102'444'800'000'000'000LL;
+}  // namespace
+
+TEST(SystemClock, NowNsReturnsWallClockUnixNs)
+{
+  SystemClock c;
+  const UnixNanos t = c.nowNs();
+  EXPECT_GT(t, kAfter2020);
+  EXPECT_LT(t, kBefore2100);
+}
+
+TEST(SystemClock, AdvanceToIsNoOpDoesNotRewind)
+{
+  SystemClock c;
+  c.advanceTo(0);  // real time is not advanceable/rewindable
+  EXPECT_GT(c.nowNs(), kAfter2020);
+}
+
+TEST(SystemClock, UsableThroughIClockInterface)
+{
+  SystemClock c;
+  IClock& clk = c;  // drop-in wherever an IClock is expected (parity with SimulatedClock)
+  EXPECT_GT(clk.nowNs(), kAfter2020);
+}

--- a/venue/AUDIT-LOG.md
+++ b/venue/AUDIT-LOG.md
@@ -1,0 +1,105 @@
+# Venue module — Audit & Fix Log
+
+A durable catalogue of correctness defects found and fixed while hardening the
+spot + derivatives venue (now the flox `venue/` module), with the regression test that locks each one. Every
+fix listed here ships with a test proven to **fail before the fix and pass
+after** (negative proof), and the whole set is green in flox CI and under
+`venue/scripts/run_sanitizers.sh` (ASAN/UBSAN/TSAN).
+
+Method: independent adversarial audits, one subsystem at a time. Each finding
+was verified against the real code before fixing; anything that could not be
+fixed safely with a catching test was **documented as a follow-up (below), not
+shipped blind**.
+
+## Verification-theory progression
+
+Conservation-of-total is necessary but **not sufficient**. Each round exposed a
+new invariant the previous ones missed:
+
+1. total conservation → catches money created/destroyed in aggregate
+2. **reserved-invariant** (drain book → every `reserved == 0`) → catches
+   reservation leaks invisible to total conservation
+3. **per-order** reservation consistency → catches an over-release masked by
+   other orders' reservations in the same account's aggregate
+4. **per-account equity + insurance-payout** → catches mis-socialization
+   (right total, wrong recipient — e.g. ADL phantom credit)
+5. **insertion-order independence** → catches determinism/HA forks (unordered
+   iteration feeding an emitted event or a state-affecting decision)
+6. **made-whole on non-fill** → catches frozen funds (last-look reject)
+7. **compliance netting** → catches a debit balance masking a custody shortfall
+
+Several defects **compounded**: funding driving `available` negative while a
+position kept an account unliquidated (#14) made the states reachable that #20
+(ADL phantom mint) and #22 (segregation netting) then exploited — one finding
+opened the next.
+
+## Fixes (each with its regression test)
+
+| # | Class | Defect | Test |
+|---|-------|--------|------|
+| 1 | reservation | iceberg modify-shrink released against the displayed peak, not the full size → over-release + phantom resting liquidity | `test_iceberg_modify_shrink` |
+| 2 | liquidation | force-close didn't cancel the account's other resting orders first → insurance paid out to a total-equity-solvent account | `test_perp_liquidation_frees_resting_collateral` |
+| 3 | funding | funding to `available` couldn't trigger liquidation (equity check ignored wallet) → silent bad debt; added wallet-drag term | `test_funding_triggers_liquidation` |
+| 4 | MD fidelity | iceberg hidden reserve leaked to the public feed on a partial-peak fill (`OrderExecuted` now carries `displayLeaves`) | `test_iceberg_hidden_from_md` |
+| 5 | determinism/HA | ADL victim chosen by `unordered_map` layout on equal uPnl → replica event-hash fork; added total-order tie-break | `test_cross_margin_adl_deterministic_victim` |
+| 6 | hostile-input | WS 64-bit extended length overflowed the guard → `resize(~2^64)` → process crash; + 4 GiB amplification on binary/TLS prefix; caps + overflow-safe check + connLoop try/catch | `test_websocket` (overflow/oversized/partial + hostile u32) |
+| 7 | authorization | session never bound the account → any client could act as any account by writing a different id; `handle()` now stamps the session account | `test_session_account_binding` |
+| 8 | arithmetic-UB | LULD band `raw * bps` int64 multiply overflowed (UBSAN) → garbage band; 128-bit + clamp | `test_luld` (high-price/wide-band) |
+| 9 | money-creation | ADL claw-back credited the venue the full haircut while the all-or-nothing debit no-op'd on a negative-wallet winner → minted money | `test_cross_margin_adl_negative_available_conserves` |
+| 10 | order-lifecycle | FOK rested as a GTC limit when STP removed the self-liquidity its precheck counted on; STP-aware precheck + residual-kill | `test_matcher` (FOK+STP) |
+| 11 | compliance | segregation netted debit client balances → a real custody shortfall reported as fully-backed; sum of positive obligations | `test_segregation_no_debit_netting` |
+| 12 | map-reuse | OCO `ocoMembers_` not cleaned on cancel/expiry/reject → a reused OrderId wrongly canceled + unbounded leak; `unlinkOco` + scope-guard | `test_matcher` (OCO cancel/reject + id reuse) |
+| 13 | passive-mispricing | peg repriced off a book that still included its own order → creep to the opposite touch each submit; cancel-before-target | `test_matcher` (Mid-peg-no-creep) |
+| 14 | risk-gate-bypass | triggered stop re-entered outside onNew → reduce-only stop opened an uncollateralized position; `perpRiskGate` on the trigger path | `test_perp_reduce_only_stop_cannot_open` |
+| 15 | frozen-funds | last-look reject/timeout emitted only `FillRejected` → both parties' reservations stranded forever; `releaseHeldLeg` | `test_last_look_reject_releases_reservation` |
+| 16 | risk-gate-bypass | perp modify re-enter skipped `perpRiskGate` → size-increase grew position past the cap | `test_perp_modify_respects_position_cap` |
+| 17 | safety-flag | reduce-only dropped across a perp modify → could flip a position; `RestingOrder.reduceOnly` carried + re-capped | `test_perp_modify_preserves_reduce_only` |
+| 18 | recovery-completeness | auction uncross fills + emergency cancel-all bypassed the journal → replay divergence; sequenced `AdminCmd` | `test_auction_recovery` |
+| 19 | layout-independence | repeg/expire/cancel-all iterated `unordered_*` without the ADL sort standard (repeg is state-affecting) → cross-build HA fork; sort collected ids | `test_matcher` (mass-cancel ascending order) |
+
+Earlier in the session (pre-audit hardening), the same discipline fixed: an
+integer-overflow UB on hostile numeric JSON input; `reduceOnly` silently dropped
+on the wire in OUCH/FIX/REST (a reduce-only order would have opened a position);
+FIX CheckSum not validated; missing `LastPx` in exec reports; derivatives
+recovery divergence (mark/funding promoted to journaled commands); and four
+distinct reservation leaks on the residual-cancel / reject / stop-trigger paths.
+
+## Known limitations (documented, deliberately NOT rushed)
+
+These are real gaps whose correct fix is a cohesive design change in a
+critical/concurrent path. Rushing them risks a worse defect than they cure, so
+they are recorded here and in `README.md` as follow-ups rather than shipped
+blind:
+
+- **fill-time reduce-only re-check**: reduce-only is capped at submit / trigger /
+  modify against the position at that instant, but not re-checked at each *fill*.
+  If the position shrinks while a reduce-only order rests (or multiple reduce-only
+  orders sum beyond the position), the remainder can over-reduce. Correct fix:
+  cohesive per-account aggregate reduce-only accounting re-checked at fill time
+  (position-aware matching).
+- **async outbound bus + backpressure**: exec reports are delivered
+  fire-and-forget via a synchronous `writeAll` on the `submit()` path. A slow
+  client head-of-line-blocks the engine; a failed write silently drops a fill
+  (client diverges) with no recovery. `ResendBuffer` exists but is unwired.
+  Correct fix: per-connection async queue + wire `ResendBuffer` + teardown on
+  write failure.
+- **hardware clock in the live sequencer**: `now_` is a logical counter, so
+  ns-scale timed features (`Journal::loadTimed`, and volume-tiered fees'
+  30-day rolling window) need a real `steady_clock` feed.
+- **volume-tiered fees**: single shared `FeeSchedule`, `recordFill` uncalled →
+  flat (tier-0) only. Per-account VIP tiers need `bindAccount` + the real clock.
+- **HMAC logon replay-nonce**: logon checks signature + ±5s skew but no
+  single-use nonce → a captured logon is replayable within the window (needs a
+  shared, time-evicted nonce store).
+- **control-plane auth / value validation**: admin ops have no authentication
+  and don't validate tick/lot/band values (assumed to run on an internal admin
+  interface).
+
+## Running the gate
+
+```bash
+cmake -S . -B build -DFLOX_BUILD_TESTS=ON
+cmake --build build
+cd build && ctest
+../venue/scripts/run_sanitizers.sh
+```

--- a/venue/CMakeLists.txt
+++ b/venue/CMakeLists.txt
@@ -1,0 +1,73 @@
+# ── flox venue module ────────────────────────────────────────────────
+# The venue side of flox: build a market rather than trade on one. Kept as an
+# optional module (mirroring `connectors/`) so the core library stays free of
+# its weight, and so the server perimeter can carry its own dependencies
+# without pushing them onto every flox user.
+#
+# Namespace: flox::venue.  Include prefix: <flox-venue/...>.
+
+file(GLOB_RECURSE FLOX_VENUE_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
+
+add_library(flox-venue STATIC ${FLOX_VENUE_SRC})
+add_library(flox::venue ALIAS flox-venue)
+
+target_include_directories(flox-venue
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(flox-venue PUBLIC ${FLOX})
+target_compile_features(flox-venue PUBLIC cxx_std_23)
+
+# ── benchmarks ───────────────────────────────────────────────────────
+if(FLOX_BUILD_BENCHMARKS)
+  add_executable(bench_venue_book ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/bench_book.cpp)
+  target_link_libraries(bench_venue_book PRIVATE flox-venue)
+endif()
+
+# ── Install ──────────────────────────────────────────────────────────
+# Same posture as connectors/: the module is consumable via find_package so a
+# downstream project can link flox::venue without vendoring this tree.
+
+include(GNUInstallDirs)
+
+install(TARGETS flox-venue
+        EXPORT  flox-venueTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(EXPORT flox-venueTargets
+        NAMESPACE flox::
+        FILE flox-venue-config.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/flox-venue)
+
+# ── tests ────────────────────────────────────────────────────────────
+if(FLOX_BUILD_TESTS)
+  find_package(GTest REQUIRED)
+  find_package(Threads)
+  file(GLOB FLOX_VENUE_TESTS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp)
+  # The TLS gateway needs OpenSSL; the rest of the module does not. Keep the
+  # heavy dependency optional (same posture as connectors/) so a plain build of
+  # the venue stays dependency-free.
+  find_package(OpenSSL)
+  if(NOT OpenSSL_FOUND)
+    list(REMOVE_ITEM FLOX_VENUE_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_venue_tls.cpp)
+    message(STATUS "OpenSSL not found -- skipping venue TLS gateway test")
+  endif()
+  foreach(test_src ${FLOX_VENUE_TESTS})
+    get_filename_component(test_name ${test_src} NAME_WE)
+    add_executable(${test_name} ${test_src})
+    target_link_libraries(${test_name}
+      PRIVATE flox-venue GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
+    if(TARGET Threads::Threads)
+      target_link_libraries(${test_name} PRIVATE Threads::Threads)
+    endif()
+    if(test_name STREQUAL "test_venue_tls" AND OpenSSL_FOUND)
+      target_link_libraries(${test_name} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    endif()
+    add_test(NAME ${test_name} COMMAND ${test_name})
+  endforeach()
+endif()

--- a/venue/DESIGN.md
+++ b/venue/DESIGN.md
@@ -1,0 +1,540 @@
+# Venue module — design notes
+
+> Historical build plan, kept for the rationale behind the design. Paths were
+> rewritten when this became the flox `venue/` module; behaviour is documented
+> in `docs/venue/`.
+
+CLOB matching engine (ядро биржи/брокерского venue) поверх FLOX v0.6.8.
+C++23. Для операторов бирж и брокеров (crypto spot + derivatives).
+
+> Статус: design doc. Код ещё не писан. Базовый flox склонирован в этот же каталог
+> (`include/`, `src/`, `benchmarks/`, ...) как fork-point и источник примитивов.
+
+---
+
+## 0. Резюме решения (TL;DR)
+
+- **FLOX — это buy-side фреймворк** (стратегии подключаются к биржам через коннекторы).
+  Matching engine — это **sell-side** (само ядро venue). Поэтому: берём из flox
+  фундамент (fixed-point типы, order-модель, Disruptor-шину, L3-книгу, журнал floxlog,
+  lifecycle), а **сам матчинг строим новый** — в flox его нет (L3-книга только *учитывает*
+  ордера, но не *пересекает* их и не генерит сделки).
+- **Архитектура матчинг-ядра — single-writer sequenced core** (LMAX Disruptor):
+  один поток на symbol-shard владеет книгой, все мутации сериализованы через ring buffer,
+  детерминированно. Это одновременно даёт и производительность, и надёжность
+  (детерминированный replay журнала = recovery + аудит + state-machine replication для HA).
+- **Интерфейс — многоуровневый, не «REST или нет», а всё сразу через нормализующие шлюзы:**
+  - hot path — **бинарный OUCH-style order entry (SBE)** поверх TCP (+ опция kernel-bypass в colo);
+  - **FIX 4.4 / 5.0 (FIXT)** gateway — обязателен для институциональной адопции и drop-copy;
+  - **REST + WebSocket (JSON)** — онбординг, retail-брокеры, дашборды (высокая адопция, не hot path);
+  - market data — **ITCH-style бинарный incremental feed** (UDP multicast в colo / TCP)
+    + WebSocket-фан-аут для retail;
+  - gRPC — внутренний control-plane (админ, листинг инструментов, риск-лимиты).
+  Все шлюзы терминируют в **один внутренний бинарный InboundCommand**, который кормит sequencer.
+  Так закрываются оба требования: производительность (бинарный hot path) и адопция (FIX + REST).
+
+---
+
+## 1. Что FLOX уже даёт (инвентаризация переиспользуемого)
+
+| Блок | Файл(ы) в flox | Как используем в матчинг-движке |
+|---|---|---|
+| **Fixed-point типы** Price/Quantity/Volume, i128/i256, checked-narrow | `include/flox/common.h`, `util/base/decimal.h`, `util/int/` | Детерминированная арифметика без float. Основа всей цены/количества/notional. Готово к использованию как есть. |
+| **Order-модель** со всеми venue-полями | `execution/order.h` | TIF, ExecutionFlags (postOnly/reduceOnly/closePosition/holdSide), triggerPrice, trailing, iceberg (`visibleQuantity`), `clientOrderId`, `accountId`, `orderTag` (OCO). Практически готовая входная модель. |
+| **Venue-семантика в enum'ах** | `common.h` | `OrderType` (LIMIT/MARKET/STOP_*/TP_*/TRAILING/ICEBERG), `TimeInForce` (GTC/IOC/FOK/GTD/POST_ONLY), `STPMode` (None/CancelNewest/CancelOldest/CancelBoth/Decrement). Уже спроектировано под sell-side. |
+| **L3 order book** (order-by-order, time-price FIFO) | `book/l3/l3_order_book.h` | Фундамент структуры книги: intrusive linked-list уровней, open-addressing хэш id→slot, zero-alloc, fixed capacity. **Дорабатываем** (см. §4.3) — best-price в нём O(n) на cache-miss, а findOrCreateLevel имеет O(n) fallback; для hot-path нужен O(1) ladder. |
+| **Disruptor / EventBus** (multi-consumer, sequence barriers, CPU-affinity, busy-backoff) | `util/eventing/event_bus.h`, `util/concurrency/spsc_queue.h` | **Это backbone sequencer'а.** Один publisher (gateway ingress) → matching consumer + market-data consumer + journal consumer + risk consumer, каждый со своим sequence barrier. `FLOX_PROFILE_SCOPE("Disruptor::publish")` подтверждает LMAX-паттерн. |
+| **Журнал floxlog** (сегменты, индекс, сжатие, snapshot+delta, mmap/parallel reader, validator, manifest) | `replay/writers/binary_log_writer.h`, `replay/readers/`, `replay/ops/` | **Ключ к надёжности.** Пишем каждый принятый InboundCommand и каждый OutboundEvent в журнал → recovery через replay, регуляторный аудит-трейл, state-machine replication на standby. Сегментация+ротация+индекс уже есть. |
+| **Engine / lifecycle** | `engine/engine.h`, `engine/abstract_subsystem.h`, `engine/symbol_registry.h`, `engine/trading_calendar.h` | ISubsystem start/stop, реестр символов, торговый календарь (сессии, halts). |
+| **Risk / kill-switch абстракции** | `risk/abstract_risk_manager.h`, `risk/portfolio_risk.h`, `killswitch/abstract_killswitch.h` | Базис pre-trade risk и market-wide kill-switch (halt). |
+| **Low-latency логирование и метрики** | `log/atomic_logger.h`, `metrics/` | Async-логгер вне hot-path, метрики латентности/throughput. |
+| **CPU topology / affinity / core assignment** | `util/performance/{cpu_topology,cpu_affinity,core_assignment,thread_affinity,busy_backoff}.h` | Пиннинг matching-потока на изолированное ядро, NUMA-aware размещение. |
+| **SimulatedExecutor** (maker/taker fill, STP-группы, FOK-семантика, queue-модели, slippage/latency) | `backtest/simulated_executor.h` | **Не** матчинг-движок (симулирует venue против истории для одного участника), но **эталон корректной семантики** fill/STP/FOK и готовый **test-oracle** для проверки нашего матчера. |
+| **Net / transport / WS** | `net/abstract_transport.h`, `net/abstract_websocket_client.h`, `external/ixwebsocket` | Транспорт для WS market-data фан-аута и REST/WS шлюзов. |
+| **Replay-equivalence харнесс** | `tests/replay-equivalence/` | Готовая методология проверки детерминизма (тот же вход → тот же выход). |
+| **Бинды и C API** | `capi/`, `python/`, `node/`, `mcp/` | Для control-plane/адмики и MCP-доступа AI-агентов к venue (листинг, лимиты, наблюдение). Не для hot-path. |
+
+**Вывод:** flox покрывает ~50–60% нетривиального фундамента (типы, модель ордера, Disruptor,
+журнал, lifecycle, детерминизм-харнесс). Отсутствует ровно то, что делает *матчинг-движок
+матчинг-движком*: сам алгоритм пересечения, order gateway, market-data публикация, HA/recovery-оркестрация,
+sharding.
+
+---
+
+## 2. Что нужно построить (gap analysis)
+
+1. **Matching core** — пересечение incoming↔resting, генерация fills, price-time FIFO (+ pro-rata опция),
+   применение TIF/STP/post-only/iceberg/stop-триггеров. **Нет в flox.**
+2. **Оптимизированная книга** — O(1) best bid/ask и O(1) переход по уровням в пределах тик-диапазона
+   (ladder/radix), поверх/вместо `L3OrderBook`.
+3. **Sequencer / ingress** — приём команд со всех шлюзов, единая последовательность (gateway sequence number),
+   валидация, backpressure, идемпотентность (dedup по clientOrderId).
+4. **Pre-trade risk** — price bands (limit-up/down), fat-finger (max qty/notional), max open orders,
+   для брокеров: credit/margin/buying-power check, self-match scope.
+5. **Order gateways** — OUCH-бинарный, FIX, REST/WS (см. §5), каждый нормализует в InboundCommand.
+6. **Market-data publisher** — L1/L2/L3 incremental + периодические снапшоты + trade prints;
+   бинарный ITCH-style + WS фан-аут; conflation для медленных подписчиков.
+7. **Execution reports / drop-copy** — ExecReport назад участнику (ack/reject/fill/cancel), drop-copy поток.
+8. **HA / recovery** — журнал-replay для восстановления книги, primary/hot-standby через
+   state-machine replication, детерминированный failover.
+9. **Sharding** — маппинг symbol→shard, по потоку на shard; нет cross-symbol матчинга (упрощает).
+10. **Session / auth / rate-limit** на шлюзах.
+11. **Инструментный реестр** — tick size, lot size, min notional, price bands, торговые часы (частично `symbol_registry` + `trading_calendar`).
+
+---
+
+## 3. Сегменты и Jobs (это влияет на дизайн и на интерфейс)
+
+«Биржи и брокеры» — это **два разных сегмента** с разным приоритетом success criteria.
+Это не косметика — это прямо определяет, какой интерфейс лидирует и где точка адопции.
+
+**Сегмент A — операторы бирж (venue operators).**
+Core Job: *«I want to match client orders fairly, deterministically and at scale, with a
+verifiable audit trail»*. Приоритет критериев: **детерминизм/корректность → латентность →
+throughput → регуляторная аудируемость → честность матчинга (fair queue)**. Им нужен
+бинарный hot-path, multicast MD, HA, journaling-аудит. Латентность и throughput — первый экран.
+
+**Сегмент B — брокеры (internalizers / broker-dealers).**
+Core Job: *«I want to internalize client flow and run a crossing/matching book on my own
+inventory with risk controls»*. Приоритет: **лёгкость интеграции → pre-trade risk/credit →
+multi-account/отчётность → латентность**. Для них латентность вторична, а **FIX + REST + быстрый
+онбординг** — первичны. Точка адопции у брокеров — «я подключился за день по FIX/REST», а не «у меня 5 мкс».
+
+**Следствие для дизайна (subtractive move):** одно матчинг-ядро, но **разные шлюзы лидируют для
+разных сегментов**. Не строим два движка — строим одно ядро + tiered gateways. Риск-контроли
+(credit/margin) делаем опциональным слоем перед sequencer (нужен брокерам, часто выключен у чистой биржи).
+
+---
+
+## 4. Архитектура
+
+### 4.1 Общая схема потока
+
+```
+                         ┌─────────── gateways (нормализация в InboundCommand) ───────────┐
+ HFT/colo   ──OUCH/SBE──▶│ binary gw │                                                     │
+ институты  ──FIX 4.4───▶│  FIX gw   │──▶ [session/auth] ──▶ [rate-limit] ──▶ [pre-trade   │
+ retail/бро ──REST/WS───▶│ REST/WS gw│                                          risk?]     │
+                         └───────────────────────────────┬─────────────────────────────────┘
+                                                          │ InboundCommand (бинарный, fixed-layout)
+                                                          ▼
+                                              ┌───────────────────────┐
+                                              │   INGRESS SEQUENCER    │  единый gseq, dedup,
+                                              │  (Disruptor ring)      │  журналирование ДО матчинга
+                                              └───────────┬───────────┘
+                             ┌────────────────────────────┼───────────────────────────────┐
+                             ▼ (shard 0)                   ▼ (shard 1)             ...      │  routing по symbol→shard
+                   ┌──────────────────┐          ┌──────────────────┐
+                   │ MATCHING CORE    │          │ MATCHING CORE    │  single-writer поток,
+                   │ (1 thread/shard) │          │ (1 thread/shard) │  пиннинг на изол. ядро
+                   │  order book +    │          │  order book +    │
+                   │  matching algo   │          │  matching algo   │
+                   └───────┬──────────┘          └───────┬──────────┘
+                           │ OutboundEvent (fill / ack / reject / book-delta / trade)
+          ┌────────────────┼─────────────────────┬───────────────────┐  multi-consumer Disruptor
+          ▼                ▼                     ▼                   ▼
+   ┌─────────────┐  ┌──────────────┐    ┌────────────────┐   ┌──────────────┐
+   │ JOURNAL     │  │ EXEC REPORTS │    │ MARKET DATA    │   │ RISK/POSITION│
+   │ (floxlog)   │  │ + drop-copy  │    │ publisher      │   │ aggregator   │
+   │ recovery+   │  │ → участникам │    │ ITCH/WS + snap │   │ (post-trade) │
+   │ audit + HA  │  └──────────────┘    └────────────────┘   └──────────────┘
+   └──────┬──────┘
+          │ same input sequence replicated
+          ▼
+   ┌─────────────┐
+   │ HOT STANDBY │  state-machine replication: тот же gseq-поток → та же книга
+   └─────────────┘
+```
+
+Инварианты:
+- **Ровно один writer на shard.** Никаких локов в hot-path книги. Всё через Disruptor.
+- **Детерминизм:** результат = чистая функция от последовательности InboundCommand. Никакого
+  wall-clock/random внутри матчинга (время проставляется sequencer'ом и попадает в журнал как данные).
+- **Журналируем ВХОД до матчинга** (для recovery достаточно входа + детерминизма) **и ВЫХОД**
+  (для аудита/drop-copy/сверки).
+
+### 4.2 Matching core (single-writer sequenced)
+
+- Один поток на shard владеет: order book, реестром активных ордеров, stop-book (условные),
+  счётчиками. Читает из своего Disruptor-барьера, обрабатывает команды строго последовательно.
+- Обработка `NewOrder`:
+  1. валидация против инструмента (tick/lot/min-notional/price-band) — часть в gateway, финальная тут;
+  2. проверка STP-scope против resting того же account/группы;
+  3. **matching loop** — пока incoming агрессивен и есть встречная ликвидность на пересекающемся уровне:
+     берём head очереди (FIFO), matched = min(remaining, restingQty), эмитим `TradeEvent`
+     (maker price), уменьшаем/снимаем resting, уменьшаем incoming;
+  4. остаток по TIF: GTC → в книгу; IOC → отменить остаток; FOK → предчек полной ликвидности,
+     иначе reject целиком (семантику брать из `SimulatedExecutor` FOK AnyPrice/BookVWAP);
+     POST_ONLY → reject если бы пересёкся; iceberg → показать `visibleQuantity`, пополнять из скрытого.
+  5. эмитим `ExecReport` (ack/partial/filled) и book-delta.
+- `Cancel` / `Replace(Modify)` — O(1) по id-хэшу (уже есть в L3-книге); replace = cancel+add с
+  потерей приоритета при росте qty/смене цены (или сохранение при уменьшении qty — конфигурируемо, как на реальных venue).
+- **Stop / trigger orders** — отдельный stop-book; триггерятся при пересечении last/mark price,
+  затем инжектятся в матчинг как market/limit. Триггер-цену (last vs mark vs index) делаем настройкой инструмента.
+
+### 4.3 Структура книги (доработка L3OrderBook)
+
+`L3OrderBook` берём как основу очередей уровня (intrusive FIFO, zero-alloc, id-хэш), но заменяем
+ценовую индексацию на структуру с **O(1) best и O(1) шагом по уровням**:
+
+- **Спот/узкий тик-диапазон:** прямой массив-ladder, индекс = `(price - refPrice)/tickSize`,
+  плюс битовая карта занятых уровней (`find_next` через `__builtin_ctzll`) для быстрого поиска
+  следующего непустого уровня. Best bid/ask — O(1).
+- **Широкий диапазон / derivatives:** двухуровневый radix (bucket → ladder) или bounded flat map
+  с курсором best. Fallback O(n)-скан из текущего `findOrCreateLevel` в hot-path недопустим — убираем.
+- Уровень — `PriceLevel{ totalQty, head, tail, orderCount }` (order-count нужен для pro-rata и метрик).
+- Всё аллоцируется заранее (fixed capacity на shard), zero-alloc в hot-path — инвариант flox сохраняем.
+
+### 4.4 Алгоритмы матчинга
+
+- **Price-time priority (FIFO)** — дефолт. Честно, просто, ожидаемо участниками. Уже согласуется с
+  «Time Price FIFO» инвариантом L3-книги.
+- **Pro-rata / size-time** — опция для инструментов с толстыми уровнями (часто на деривативах):
+  распределение пропорционально размеру resting на топ-уровне, с min-fill и time-остатком.
+  Выбор алгоритма — свойство инструмента, а не глобальный флаг.
+- Алгоритм за интерфейсом `IMatchPolicy` (одна виртуалка на *инструмент*, не на *ордер* — вне hot-loop),
+  чтобы не платить за виртуальный вызов на каждый fill.
+
+### 4.5 Детерминизм и sequencing
+
+- Каждый принятый InboundCommand получает **global sequence number (gseq)** и **timestamp**, проставленные
+  ingress-sequencer'ом *до* журналирования. Внутри матчинга — никакого чтения часов/random.
+- Trade id / order id — из детерминированных монотонных счётчиков на shard (seedятся из журнала при recovery).
+- Это даёт три вещи бесплатно: **recovery** (replay журнала входов), **HA** (тот же вход на standby = та же книга),
+  **аудит/спор-резолюшн** (побитово воспроизводимая история). Переиспользуем `tests/replay-equivalence`.
+
+### 4.6 Pre-trade risk (слой перед sequencer, опциональный)
+
+- Дешёвые проверки (price band, max qty/notional, max open orders per account, kill-switch/halt) — в
+  gateway/ingress, чтобы мусор не доходил до матчинга. **[СДЕЛАНО]** в движке: tick/lot/min-qty,
+  fat-finger `maxOrderQty`/`maxOrderNotional`, LULD-band, для перпов **position limit** `maxPositionQty`
+  (реджект `PositionLimitExceeded`, если полный филл увёл бы |позицию| за лимит; reduce-only не блокируется),
+  и **max open orders** `maxOpenOrders` per-account (реджект `TooManyOpenOrders` — DoS/риск-гейт на живые
+  resting-ордера; слот освобождается отменой). Rate-limit сессий — `flox::RateLimitPolicy` (см. §5).
+- Для брокеров: **credit/buying-power/margin** предчек против позиции аккаунта — использует
+  `risk/abstract_risk_manager.h` + `portfolio_risk.h`. Может быть выключен для чистой биржи.
+- Market-wide halt / kill-switch — через `killswitch/abstract_killswitch.h` + `trading_calendar` (сессии).
+
+---
+
+## 5. Интерфейсы — главный вопрос («REST или как-то ещё»)
+
+**Короткий ответ: не выбирать одно. Hot-path НЕ должен быть REST/JSON.** Стандарт индустрии для
+бирж/брокеров — многоуровневый набор протоколов, все терминируют в один внутренний бинарный
+InboundCommand. Это единственный способ закрыть *и* производительность, *и* адопцию.
+
+| Уровень | Протокол | Транспорт | Сегмент / назначение | Латентность | Усилие реализации |
+|---|---|---|---|---|---|
+| **T0 hot path** | **OUCH-style бинарный, SBE (Simple Binary Encoding)** | TCP (colo); опц. kernel-bypass (io_uring / DPDK / OpenOnload) | HFT, маркет-мейкеры, сегмент A | единицы–десятки мкс | высокое |
+| **T1 институты** | **FIX 4.4 / FIXT 1.1 (FIX 5.0 SP2)** + drop-copy | TCP (FIX session) | институциональные клиенты, брокеры-агрегаторы, adoption | сотни мкс–мс | среднее (готовые парсеры: QuickFIX, но лучше кастом SBE-FIX для скорости) |
+| **T2 адопция/retail** | **REST (JSON) + WebSocket** | HTTP/1.1 + WS | онбординг, retail-брокеры, дашборды, боты | мс+ | низкое |
+| **MD hot** | **ITCH-style бинарный incremental** (add/exec/cancel/trade) + периодич. snapshot | UDP multicast (colo) / TCP unicast | data-подписчики сегмента A | десятки мкс | высокое |
+| **MD retail** | **WebSocket JSON** (L2 depth, trades, ticker), conflated | WS | retail, дашборды | десятки мс | низкое |
+| **Control plane** | **gRPC** (+ существующий FLOX C API / MCP) | HTTP/2 | админ: листинг инструментов, tick/lot, риск-лимиты, halt, наблюдение | — | низкое |
+
+**Порядок реализации (с учётом выбора HFT-colo, см. §13):** OUCH/SBE + multicast MD — **first-class с самого
+начала**, параллельно с REST/WS для демо/онбординга; FIX — вторым, для институтов/брокеров. То есть
+латентный бинарный стек не откладываем на потом (как было бы при «fast enough»), а ведём его как основную
+ветку сегмента A; REST/WS остаётся дешёвым онбординг-каналом сегмента B.
+Внимание к риску: спрос на суб-10-мкс — это riskiest assumption #2 (§12); валидируем интервью **параллельно**
+со стройкой hot-path, а не «после».
+
+Принципы шлюзов:
+- Каждый gateway — отдельный процесс/пул потоков, **вне** matching-потока. Он только парсит,
+  аутентифицирует, rate-лимитит, нормализует в InboundCommand и публикует в ingress Disruptor.
+- **Backpressure:** Disruptor `tryPublish` с таймаутом уже есть в `event_bus.h`; при переполнении —
+  reject с явным кодом, не блокировка матчинга.
+- **Идемпотентность:** dedup по `(session, clientOrderId)` на ingress — защита от ретраев/реконнектов.
+- FLOX C API / MCP (`flox_capi.h`, `mcp/`) переиспользуем для control-plane и для того, чтобы
+  AI-агенты могли наблюдать/управлять venue (листинг, лимиты, halt) — это уникальный «AI-native» козырь flox.
+
+---
+
+## 6. Надёжность / HA / recovery
+
+- **Журналирование (floxlog):** ingress пишет каждый InboundCommand (с gseq+ts) в `BinaryLogWriter`
+  *до* передачи в матчинг; матчинг-выход (trades/exec-reports) — во второй журнал для аудита/сверки.
+  Сегментация, ротация, индекс, сжатие, snapshot+delta — уже реализованы. **Mark-price и funding —
+  тоже sequenced-команды** (`SetMark`/`ApplyFunding` в `InboundCommand`), т.е. журналируются наравне с
+  ордерами. Иначе derivatives-recovery разъехалась бы: mark-driven ликвидации и funding-выплаты не
+  воспроизвелись бы при replay. Проверено `test_perp_recovery` (крах mark → ликвидация → replay
+  восстанавливает позиции И балансы точно).
+- **Recovery:** при рестарте — reader (`mmap_reader`/`parallel_reader`) проигрывает журнал входов
+  через тот же матчинг → книга восстановлена побитово. Периодические book-снапшоты (`writeBook`)
+  ускоряют recovery (replay только с последнего снапшота). **Проверено на уровне денег** (`test_venue`):
+  восстановленный ledger совпадает с живым ТОЧНО — per account + venue, base + quote, available + reserved
+  (не только поток событий; recovery с верными событиями, но неверными балансами была бы катастрофой).
+- **HA (hot standby):** state-machine replication — тот же gseq-поток входов реплицируется на standby,
+  standby гоняет тот же детерминированный матчинг → идентичная книга. Failover = standby становится
+  primary с последнего подтверждённого gseq. Реплика подтверждает запись в журнал перед ack клиенту
+  (настраиваемо: sync/async, trade-off латентность↔durability). **Проверено на уровне денег** (`test_ha`,
+  200k команд с settlement): standby, WAL-recovered реплика и post-failover движок реконструируют ledger
+  ТОЧНО — per account + venue, base + quote, available + reserved (не только книга/поток событий).
+- **Идемпотентный failover:** клиенты после реконнекта запрашивают состояние своих ордеров
+  (order/exec-report resend по gseq), dedup по clientOrderId предотвращает дубли.
+- **Validator** (`replay/ops/validator.h`) — проверка целостности журнала; **manifest** — метаданные сегментов.
+
+---
+
+## 7. Масштабирование
+
+- **Sharding по символам:** `symbol → shardId` (consistent/статический маппинг). Каждый shard —
+  один матчинг-поток на выделенном ядре. Cross-symbol матчинга в CLOB нет → shards полностью независимы,
+  масштаб линейный по ядрам/узлам. `multi_symbol_benchmark.cpp` в flox — стартовая точка для замеров.
+- **Горизонталь между узлами:** shard-группы на разных машинах; ingress-роутер направляет команду на узел
+  владельца символа. Market-data агрегируется на edge-публикаторах.
+- **Что НЕ шардим:** аккаунт-риск, где ордера аккаунта идут по разным символам, —
+  post-trade позиция агрегируется отдельным risk-consumer'ом (eventual), а pre-trade credit-чек
+  на ingress использует кэш buying-power с периодической сверкой (иначе cross-shard consensus в hot-path — дорого).
+- **Кросс-маржа (портфельный риск) [СДЕЛАНО]:** `flox-venue/cross_margin.h::CrossMarginManager` —
+  ровно этот cross-shard risk-consumer. Один кошелёк залога держит весь перп-портфель аккаунта:
+  `equity = wallet + Σ uPnL_s`, `IM = Σ |q_s|·mark_s·imBps_s`, `MM = Σ |q_s|·mark_s·mmBps_s` по всем символам.
+  Pre-trade гейт (`canOpen`) допускает ордер только если post-trade IM ≤ equity; вывод залога — гейт
+  `canWithdraw`/`withdrawable` (нельзя вывести обеспечение под открытыми позициями: `equity − amount ≥ IM`);
+  ликвидация — по
+  **агрегатному** equity < MM (прибыль по одному символу фондирует убыток по другому — в этом суть cross
+  против isolated в движке). Расчёт PnL/ликвидации/страх-фонда — тот же клиринг-пул, что и в движке
+  (value conserved: каждый realize кредитует аккаунт и дебетует venue-пул). Драйвится с risk-потока,
+  не с матчинг-потоков. Проверено: `tests/test_cross_margin.cpp` (IM-гейт, cross-offset, агрегатная
+  ликвидация, банкротство+страховка, conservation, **funding** — longs pay shorts по портфельным
+  позициям, пул в ноль на сбалансированной книге) + фаззы `test_cross_margin_conservation` (100k опов,
+  2 символа, 0 breaches).
+- **Mark/index price feed (anti-манипуляция) [СДЕЛАНО]:** `flox-venue/index_feed.h`. Mark-цена гонит
+  PnL, funding и **ликвидацию**, поэтому её нельзя брать из last trade перпа — на тонкой книге один принт
+  дёргает mark и вызывает каскад ликвидаций. Два слоя: `IndexAggregator` — медиана нескольких внешних
+  spot-источников с отбросом устаревших (staleness TTL) и грубых выбросов (deviation-фильтр: один
+  взломанный/лагающий источник не двигает индекс, но синхронный широкий сдвиг — трекается); `MarkPrice` —
+  медиана из {index, last, book-mid}, зажатая в band вокруг индекса. **Book-mid — это impact-mid**
+  (`impactPriceRaw`/`impactMidRaw`): VWAP на заполнение фиксированного impact-нотионала вглубь книги, а не
+  сырой top-of-book, — dust/спуф на вершине не двигает mark (проверено `test_impact_price`: спуф 90 при
+  реальной глубине на 100 → impact ≈ 100). Адаптер `bookImpactMidRaw(book, impactQty)` считает impact-mid
+  прямо с живой движковой книги (`levels()` best-first, работает с MatchingBook/LadderBook) — проверено
+  `test_book_impact_mid` на реальном движке. Детерминизм: staleness через явный
+  `nowNs`, wall-clock не читается. Проверено `tests/test_mark_price.cpp`, включая e2e-кейс
+  `test_clamp_prevents_liquidation`: манипулятивный принт 80 при индексе 100 клампится в 98 → аккаунт
+  остаётся платёжеспособным, ложной ликвидации нет.
+- **Circuit breaker ликвидаций [СДЕЛАНО]:** `CrossMarginManager::setLiquidationsPaused` — при сбое/устаревании
+  фида оператор паузит ликвидации, чтобы плохая цена не выкосила книгу массовой ликвидацией. Mark всё равно
+  обновляется (PnL/equity живые), но sweep пропускается; после восстановления фида — возобновляется.
+  Проверено `test_cross_margin_liquidations_paused` (краш-mark при паузе не ликвидирует; unpause → sweep).
+  **Авто-пауза [СДЕЛАНО]:** `MarkFeedDriver` (`flox-venue/mark_feed_driver.h`) связывает `IndexAggregator::hasIndex`
+  с circuit breaker'ом: на каждом тике при свежем индексе публикует mark и снимает паузу, при устаревшем
+  (feed outage) — сам ставит `setLiquidationsPaused(true)`. Оператору не надо дёргать флаг вручную. Проверено
+  `test_mark_feed_driver`: свежий фид → mark+ликвидация, устаревший → авто-пауза (краш не ликвидирует),
+  восстановление → sweep.
+- **Funding по premium-TWAP [СДЕЛАНО]:** `flox-venue/funding_rate.h::FundingCalculator` расширен интервальным
+  путём: `sample(mark,index)` копит премию по всему интервалу, `intervalRate()` считает ставку от
+  усреднённой премии (Binance-формула: `premium + clamp(interest − premium, ±band)`, cap). Одиночный
+  манипулятивный принт разбавляется усреднением и не двигает выплату (в отличие от снапшот-`rate()`).
+  Проверено в `tests/test_funding.cpp` (снапшот vs TWAP при спайке, устойчивая премия, reset).
+  **Планировщик** `flox-venue/funding_scheduler.h` замыкает жизненный цикл: семплит премию по интервалу
+  и на границе вызывает `engine.applyFunding(rate, mark)` + reset (детерминизм через явный `nowNs`).
+  E2E-проверка `tests/test_funding_scheduler.cpp`: long/short пара, положительная премия → лонг платит
+  шорту, пул в ноль, аккумулятор сброшен между интервалами.
+- **ADL (auto-deleveraging) [СДЕЛАНО]:** бэкстоп после страх-фонда в **обоих** маржин-режимах —
+  портфельном `CrossMarginManager` (флаг `autoDeleverage`) и isolated-margin движке (`SymbolConfig::autoDeleverage`,
+  `MatchingEngine::autoDeleverageEngine`). Когда банкротство пробивает залог и дефицит ушёл бы в страх-фонд,
+  дефицит вместо этого забирается у самых прибыльных контрагентов на противоположной стороне: их выигрышная
+  позиция закрывается по mark, а выигрыш подрезается (haircut) — ранжирование по uPnL desc, до покрытия
+  дефицита. Событие `Liquidation{adl=true}`. Conservation держится по построению (каждая проводка
+  сбалансирована). Проверено `test_cross_margin_adl` (портфель) и `test_perp_engine_adl` (isolated):
+  дефицит забран у шорта, страх-фонд не тронут, socialized loss не размазан на всех.
+- **Capacity:** цель — сотни тысяч–миллионы ордеров/сек на shard (single-writer, zero-alloc, cache-resident book).
+  Реальные числа фиксируем бенчмарками до заявлений (см. §10).
+
+---
+
+## 8. Производительность (инженерные решения)
+
+- **CPU pinning + изоляция ядер:** матчинг-поток на isolated core (`isolcpus`/`nohz_full`), NUMA-local
+  память — через `util/performance/{cpu_affinity,core_assignment,cpu_topology}.h`.
+- **Zero-alloc hot-path:** вся память книги/очередей — преаллоцированные пулы (`util/memory/pool.h`),
+  никаких `new`/`malloc`/exceptions в матчинге. Инвариант L3-книги сохраняем и распространяем на весь core.
+- **Busy-poll vs backoff:** Disruptor уже поддерживает busy-backoff; для colo — busy-spin, для эконом-режима — backoff.
+- **Cache alignment:** `alignas(64)` на горячих структурах (в L3-книге уже так), false-sharing исключаем.
+- **Бинарные fixed-layout сообщения** (SBE) → zero-copy парсинг, без аллокаций/reflection.
+- **Логи/метрики вне hot-path:** `atomic_logger` async, метрики — lock-free counters, экспорт отдельным потоком.
+- **Целевые метрики (гипотезы, подтвердить бенчами):** tick-to-trade p50 < 5 мкс / p99 < 20 мкс (без сети,
+  colo TCP); throughput > 1M orders/s/shard; jitter p99.9 ограничен (важнее среднего для venue).
+
+---
+
+## 9. Наблюдаемость (метрики, мониторинг, обсервабилити)
+
+Venue без наблюдаемости в прод не выходит. Три уровня: **метрики** (числовые ряды),
+**трейсинг/аудит** (событийный лог), **алертинг** (пороги → дежурный). Всё вне hot-path:
+матчинг-поток только инкрементит lock-free счётчики и пишет в гистограмму, экспорт — отдельным потоком.
+
+- **Latency-гистограмма (`flox-venue/metrics.h::LatencyHistogram`).** Реализована: log2-бакеты
+  (`__builtin_clzll`), запись O(1) без аллокаций, чтение перцентилей (p50/p99/p99.9), mean/max.
+  Снимается на submit (tick-to-trade внутри core) и на gateway (end-to-end с сетью). Один писатель
+  на матчинг-потоке, монитор-поток снапшотит.
+- **Событийные счётчики (`Metrics`).** Реализовано: derived из outbound-потока — `accepted`, `trades`,
+  `cancels`, `rejects`, `modifies`, `liquidations`, `holds`, кумулятивный `volumeRaw` (traded notional).
+  `observe(OutboundEvent)` вызывается на каждом исходящем событии.
+- **Gauges (point-in-time состояние) [СДЕЛАНО]:** `Gauges` в `metrics.h` + `prom::render(Metrics, Gauges)` —
+  экспорт того, что НЕ выводится из потока событий: баланс страх-фонда (`fme_insurance_fund_raw`), текущая
+  funding-ставка (`fme_funding_rate`), open interest (`fme_open_interest_raw`), число открытых позиций и
+  живых ордеров, **возраст mark-цены** (`fme_mark_price_age_ns` — алерт на лаг фида) и **состояние
+  circuit breaker'а** (`fme_liquidations_paused` — 0/1). Семплируется мониторинг-потоком из
+  ledger/risk-manager/feed. Проверено `test_prometheus_gauges`.
+  **Сэмплер замкнут на живое состояние [СДЕЛАНО]:** `CrossMarginManager::openInterestRaw/openPositionCount`,
+  `MatchingEngine::restingOrderCount`, insurance = `ledger.total(venue)` → заполняют `Gauges` для реального
+  `/metrics`. E2E-проверка `tests/test_gauge_sampler.cpp` (перп-OI + spot resting → отрендеренная страница).
+- **Reject-rate по причинам [СДЕЛАНО]:** `Metrics::rejectsByReason` (индекс по `RejectReason`) →
+  labeled-серия `fme_rejects_by_reason_total{reason="..."}` в Prometheus. Спайк реджектов виден с разбивкой
+  по причине (fat-finger / position-limit / LULD / too-many-orders / ...). Проверено в `test_metrics.cpp`.
+- **Что ещё экспортировать (venue-KPI):** глубина/спред книги (bestBid/bestAsk, суммарный notional по
+  уровням), fill-rate по MM (вход в MMP), возраст самого старого resting-ордера, лаг журнала
+  (ingress→durable), лаг standby-реплики (gseq primary − gseq standby), размер очереди Disruptor
+  (backpressure), funding/mark-price age, число ликвидаций и покрытие ими.
+- **Экспозиция [СДЕЛАНО]:** pull-модель — HTTP `/metrics` в Prometheus-формате
+  (`flox-venue/prometheus.h` — текстовый рендер снапшота `Metrics`: counter-блоки + latency-`summary`
+  с квантилями p50/p99/p99.9, `_sum`, `_count`; i128 traded-notional). HTTP-сервер
+  (`flox-venue/metrics_server.h`) на своём потоке через `SocketAcceptor`, никогда не трогает hot-path:
+  `/metrics`, `/healthz` (процесс жив), `/readyz` (журнал durable, реплика в синхроне, книга загружена —
+  через инъектируемый readiness-callback, 200/503). Snapshot/ready — колбэки, чтобы вызывающий сам
+  выбирал синхронизацию чтения матчинг-thread'ового `Metrics`. Push-альтернатива (statsd/OTLP) — при
+  необходимости для окружений без Prometheus. Проверено сквозным скрейпом в `tests/test_metrics.cpp`.
+- **Структурный аудит-лог:** каждый матчинг-выход уже журналируется (floxlog, §6) — это же источник
+  для аудита/форензики и для дифф-сверки primary↔standby. Трейсинг: сквозной `clientOrderId`/`gseq`
+  связывает вход → fills → settlement через все слои (gateway, core, ledger).
+- **Алертинг (пороги → дежурный):** p99 tick-to-trade выше SLO, reject-rate spike, лаг журнала/реплики
+  выше порога, insurance ниже минимума, рост очереди Disruptor (перегрузка), «зависший» resting-ордер,
+  расхождение money-conservation (немедленный critical — см. `test_conservation`), gap в gseq.
+  Алерты на симптомы деградации *до* отказа, а не постфактум.
+- **Дашборды:** latency (перцентили tick-to-trade и end-to-end), throughput (orders/s, trades/s по shard),
+  состояние книги (спред/глубина), риск (open interest, ликвидации, insurance), надёжность (лаг журнала/реплики,
+  uptime, failover-события).
+- **Вне hot-path — жёсткий инвариант.** Метрики: lock-free counters + гистограмма на стеке потока; логи:
+  async (`atomic_logger`); экспорт/скрейп/рендер — отдельным потоком. Матчинг никогда не блокируется на I/O
+  наблюдаемости.
+
+**Проверка:** `tests/test_venue.cpp` снимает реальную submit-latency (p50/p99) и сверяет счётчики
+(trades/volume) с фактическим потоком событий сквозь весь путь (OUCH → core+ledger+fees → md+journal+resend+metrics).
+
+---
+
+## 10. Тестирование и корректность
+
+- **Детерминизм:** харнесс `tests/replay-equivalence` — один вход, прогон N раз (и на primary+standby) →
+  побитово идентичный выход.
+- **Test-oracle:** `SimulatedExecutor` как эталон семантики fill/STP/FOK/post-only — прогоняем те же
+  последовательности через наш core и сверяем fills.
+- **Property-based / conformance:** инварианты книги (sum(level.qty)=Σorders, best bid < best ask всегда,
+  FIFO-приоритет не нарушается, notional-consistency через checked i128), STP-модусы, TIF-семантика.
+- **Fuzzing сетевых парсеров [СДЕЛАНО]:** `tests/test_parser_fuzz.cpp` — truncation + bit-flip corruption
+  + случайные буферы (сотни тысяч итераций на кодек) для **всех wire-парсеров, принимающих сетевой ввод**:
+  OUCH, FIX, REST/JSON, **WebSocket frame parser** (`ws::parseFrame` — 64-битные length-заголовки,
+  маскирование), **WS handshake** (HTTP-заголовки), **ITCH-декодер** (big-endian поля). Под ASAN+UBSAN.
+  **Нашёл и починил реальный UB:** враждебное числовое поле (`"price":5e52`) переполняло
+  `Decimal::fromDouble` (double→int64 out-of-range); добавлен saturating `safeDecimal<D>()` на границе
+  REST/FIX-парсеров (flox read-only, фикс на нашей стороне). Всё чисто под ASAN+UBSAN.
+- **Replay реальных нагрузок** через floxlog: записали продовый вход → гоняем регресс на каждом релизе.
+- **Соответствие протоколам:** FIX conformance (session-level: resend, seq-reset, heartbeat, logon/logout);
+  OUCH/ITCH — golden-vector тесты.
+- **Money-conservation фаззы [СДЕЛАНО]:** после КАЖДОЙ операции сверяем сумму по каждому активу
+  (accounts + venue) — spot (200k опов, **весь спектр типов/TIF под ledger: limit/market/cancel/modify/GTD/
+  OCO/peg/IOC/FOK/post-only — каждый корректно освобождает/переоформляет/сеттлит reservation**),
+  linear-perp без и с ADL (по 100k, + **reserved-инвариант: после осушения книги Σ reserved == Σ
+  position-margin — IM-резерв не течёт**), cross-margin 2 символа
+  (100k), мультиколлатерал 2 актива с revaluation + collateral-liquidation (100k, сохранение quote И coin),
+  0 breaches. ADL и collateral-конвертация фаззятся отдельно — это самая тонкая денежная логика.
+- **Sanitizer-прогон [СДЕЛАНО]:** весь верификационный корпус прогнан под санитайзерами. **ASAN+UBSAN:**
+  все сетевые парсеры + 2M differential (обе книги, ladder dense-arrays/bitmap) + ~600k conservation
+  (ledger/cross-margin/ADL/collateral-conversion) + ~210k integration (perp-venue + multi-symbol soak) —
+  ~2.8M движковых опов, чисто (один UB-баг найден и починен, см. выше). **TSAN:** sequenced Disruptor-shard
+  (500k команд ingress→matching→journal) и многопоточные шлюзы (TCP/WS/control/UDP) — data races не найдены.
+- **Multi-symbol soak [СДЕЛАНО]:** `tests/test_multi_symbol_soak.cpp` — 3 spot-символа как независимые
+  шарды за `SymbolRouter`, общий ledger, per-symbol market-data + общие метрики, 150k случайных опов
+  (~92k сделок). Проверяет композицию: conservation по каждому активу на каждом шаге, MD-топ-книги ==
+  движковой книге, well-formed книги (best bid < best ask). Здесь всплывают баги композиции, которые
+  покомпонентные тесты не ловят.
+- **Perp-venue harness [СДЕЛАНО]:** `tests/test_perp_venue.cpp` — весь деривативный путь в одном прогоне:
+  движок-матчер → Trade-поток → `CrossMarginManager` (расчёт + портфельный риск), index-агрегатор +
+  impact-mid с живой книги → `MarkPrice` → `setMark` (ликвидации) + `FundingScheduler` (фандинг), pre-trade
+  `canOpen`-гейт, ADL, gauge-сэмплер. 60k опов (~26k сделок, ~59 фандинг-расчётов): collateral conserved на
+  каждом шаге (0 breaches), страх-фонд почти цел (ADL поглощает банкротов). Деривативный аналог spot-soak.
+
+---
+
+## 11. Дорожная карта (MVP-как-probe → продукт)
+
+Каждый этап — проверка риск-гипотезы, а не «фича». Дешевле убить/развернуть рано.
+Секвенс отражает выбор §13: **HFT-colo + spot & derivatives + обе модели поставки** → hot-path и
+деривативы не откладываем.
+
+- **Этап 0 — Matching core (spot, FIFO, single-shard), сразу под латентность. [СДЕЛАНО]**
+  Book-ladder O(1) (`ladder_book.h`, zero-alloc), matching loop, TIF (GTC/IOC/FOK)/STP/post-only,
+  cancel/replace, **iceberg**, **стопы** (STOP/TAKE_PROFIT market+limit, TRAILING_STOP, каскад по last price),
+  детерминизм + журнал (`journal.h`) + replay-recovery, sharded-роутер, бенчмарк (`bench_book`) и
+  дифференциальный fuzz (2M ops, ladder == reference). Текущий `engine.submit` со всей venue-логикой:
+  ladder ~255 ns/op (~3.9M ops/s), ~1.5× map-reference (раннее ~1.9× было на голом stage-0 матчинге —
+  ratio сжался, т.к. фиксированная per-submit venue-стоимость растёт одинаково для обеих книг).
+  Осталось в рамках этапа: пиннинг/isolated-cores на реальном железе.
+  *Проверено на dev: корректность (94+ проверок, 2M differential); латентность colo — впереди (риск #3).*
+- **Этап 1a — Sequenced ingress на настоящем Disruptor. [СДЕЛАНО]** `sequenced_shard.h` на
+  `flox::EventBus`: ingress (один consumer = single-writer матчинг) + outbound fan-out + WAL на потоке
+  матчинга; тест `sequenced` подтверждает побитовое совпадение с прямым прогоном (~3.1M cmd/s end-to-end).
+  Outbound MD-лента через floxlog `BinaryLogWriter` (`tape_recorder.h`, `test_tape`). Осталось: backpressure-политики.
+- **Этап 1 — Hot-path стек (сегмент A) + онбординг. [СДЕЛАНО на уровне кодеков]** Бинарный **OUCH/SBE
+  order-entry** (`ouch_codec.h`), **ITCH-style MD** (`market_data.h`+`itch_codec.h`, L2 на флоксовом
+  `NLevelOrderBook`), **FIX 4.4** (`fix_codec.h`), **REST/JSON** (`rest_json.h`). Осталось: сетевой транспорт
+  (TCP/WS-серверы, session/auth/rate-limit), UDP-multicast, busy-poll/isolated cores на железе (риск #2).
+- **Этап 2 — Derivatives. [СДЕЛАНО]** Mark-price триггеры стопов (`setMarkPrice`); margin/liquidation через
+  **`flox::LiquidationEngine`** (`liquidation_monitor.h`, `test_derivatives`) с маршрутизацией закрывающих
+  ордеров в движок; pro-rata как опция инструмента (`test_prorata`). Осталось: funding-feed для перпетуалов,
+  pre-trade credit/margin для брокеров.
+- **Этап 3 — HA + sharding + kernel-bypass. [СДЕЛАНО (кроме kernel-bypass)]** Hot standby (state-machine
+  replication) + failover + recovery — `test_ha`; symbol-sharding — `symbol_router.h`. Осталось: kernel-bypass
+  (io_uring/DPDK/OpenOnload) для T0, capacity-бенчи на железе.
+- **Этап 4 — Операционка + упаковка поставки. [control-plane СДЕЛАН]** `control_plane.h` (`InstrumentRegistry`):
+  листинг, tick/lot/bands, halts, trigger-ref — `test_control_plane`. Осталось: gRPC/MCP-обёртка,
+  наблюдаемость, две упаковки (on-prem / managed SaaS).
+
+---
+
+## 12. Riskiest assumptions (проверить до крупных вложений)
+
+Ранжировано по `(вероятность ошибки × цена ошибки) / цена проверки`:
+
+1. **Сегмент+Job:** реально ли брокеры/малые биржи *покупают отдельный matching-движок*, а не берут готовую
+   биржевую платформу «под ключ» / white-label CEX? Самый дорогой риск. Проверка: 5–7 интервью с
+   операторами/брокерами по AJTBD (не про фичи — про то, за что уже платят и где ломается цепочка).
+   Дёшево, до кода.
+2. **Латентность как критерий покупки:** нужен ли целевому сегменту суб-10-мкс, или «надёжно и по FIX за день»
+   выигрывает? Определяет, T0 (OUCH/kernel-bypass) или T1/T2 (FIX/REST) — первый билд. Проверка: те же интервью + анализ,
+   на чём сегодня торгуют.
+3. **Correctness/детерминизм под нагрузкой:** держит ли single-writer + журнал заявленный throughput с
+   ограниченным p99.9 jitter. Проверка: бенчмарк ядра на этапе 0 (дёшево, рано).
+4. **Regulatory/аудит:** достаточно ли floxlog-трейла для требований к venue (аудируемость, спор-резолюшн,
+   retention). Проверка: свериться с требованиями целевой юрисдикции до этапа 4.
+
+Дефолт по каждому «кастомному» риску: **снять допущение, а не строить под него** — напр. первую когорту
+брокеров подключить по REST/FIX (низкий риск, быстрая адопция), а OUCH/kernel-bypass строить только
+если интервью подтвердят спрос на латентность.
+
+---
+
+## 13. Решения (зафиксированы) и оставшиеся вопросы
+
+**Зафиксировано (2026-07-26):**
+
+1. **Класс латентности — HFT-colo (единицы мкс).** OUCH/SBE + multicast MD + kernel-bypass — first-class.
+   Zero-alloc/pinning/cache-layout закладываем с этапа 0. Спрос на суб-10-мкс держим как riskiest
+   assumption #2 и валидируем интервью **параллельно** со стройкой (не «после»).
+2. **Инструменты — spot + derivatives.** Спот в этапах 0–1, деривативы (mark/index, funding, margin,
+   liquidation, pro-rata) — этап 2. `backtest/liquidation_engine.h` как база маржи/ликвидаций.
+3. **Поставка — обе модели, ядро одно.** On-prem (лицензия + deploy-артефакт + HA-runbook) и managed SaaS
+   (мы хостим, клиент по API). Различие только в деплое/конфиге/control-plane — этап 4.
+
+**Осталось решить:**
+
+4. **Матчинг по умолчанию.** FIFO (рекомендую дефолт) с pro-rata как опция инструмента — подтвердить.
+5. **Форк vs зависимость от flox.** Рекомендую: flox как upstream-submodule в `external/` (тянуть апдейты
+   типов/журнала/Disruptor), новый код — отдельным слоем в `src/matching/`, `src/gateway/`, `src/marketdata/`,
+   `src/risk/`. Сейчас flox склонирован в корень как fork-point — надо переоформить (либо submodule, либо
+   вычистить лишнее и оставить как vendored base). Подтвердить подход.
+6. **Kernel-bypass стек.** io_uring (проще, Linux-native) vs DPDK vs OpenOnload (Solarflare NIC) — зависит от
+   целевого железа colo клиентов. Решаем ближе к этапу 3, но железо стоит уточнить у первых клиентов заранее.
+```

--- a/venue/README.md
+++ b/venue/README.md
@@ -1,0 +1,88 @@
+# `flox/venue` — the venue-side layer
+
+Everything under `flox/venue/` is for building **a market**, not for trading on
+one. The rest of flox is strategy-side (you send orders to an exchange);
+this layer is the exchange: it matches other participants' orders against each
+other, clears the money, and manages the risk of doing so.
+
+Built as an optional module (same shape as `connectors/`): its own
+`CMakeLists.txt`, include prefix `<flox-venue/...>`, target `flox::venue`, gated
+by `FLOX_BUILD_VENUE`. That keeps the core library free of its weight and lets
+the server perimeter carry its own dependencies (OpenSSL for the TLS gateway is
+optional and detected here, not forced on core).
+
+Namespace: `flox::venue` (nested so venue vocabulary can reuse names the
+strategy side already owns — `Trade` and `SymbolConfig` exist in both). Core
+scalar types (`Price`, `Quantity`, `Side`, `OrderId`) come from
+`flox/common.h` as usual. Because the two sets overlap, do not pull both in
+unqualified: prefer `namespace venue = flox::venue;` and qualify.
+
+What stayed in core, deliberately: the order-level books (`flox/book/*`, they sit
+next to the aggregate `NLevelOrderBook` and are useful on their own) and the
+general utilities this layer needed (`flox/util/{crypto,wire,transport,websocket,
+system_clock}.h`).
+
+## What it unlocks
+
+Strategy backtests replay a recorded tape: the market never reacts to your
+orders. With this layer many participants (or agents) can trade against a
+single live book, so the market responds — impact, queue position, and
+counterparty behaviour are emergent instead of assumed.
+
+## Map
+
+| Area | Headers |
+|---|---|
+| Order-level books | `flox/book/{resting_order,matching_book,ladder_book}.h` — per-order FIFO + O(1) ladder (distinct from the aggregate `NLevelOrderBook`, which is market-data depth) |
+| Matching | `matcher.h` (price-time FIFO, pro-rata, STP, last-look), `matching_engine.h` (order lifecycle, TIF, stops, OCO, peg, iceberg, auctions, LULD, perp clearing), `stop_book.h`, `symbol_router.h` |
+| Money | `ledger.h` — double-entry, `__int128`, `available`/`reserved`, conservation-exact |
+| Derivatives risk | `cross_margin.h` (portfolio margin), `collateral.h` (haircut basket), `funding_rate.h` + `funding_scheduler.h`, `index_feed.h` (manipulation-resistant mark), `mark_feed_driver.h` (stale-feed circuit breaker) |
+| Runtime | `sequenced_shard.h` — single-writer core on the flox `EventBus`, journalled |
+| Recovery | `journal.h` (WAL + replay), `event_hash.h` (bit-identical determinism check) |
+| Market data out | `market_data.h` + `itch_codec.h` — turns venue events into an L2 feed |
+| Protocol / ops | `fix_codec.h`, `resend_buffer.h`, `messages.h`, `reject_reason.h`, `metrics.h`, `prometheus.h` |
+| Perimeter | `socket_acceptor.h`, `session.h` (API-key HMAC logon, rate limits), `cancel_on_disconnect.h`, `tcp_gateway.h`, `ws_gateway.h`, `tls_gateway.h` (OpenSSL, optional), `udp_multicast.h`, `control_plane.h` / `control_api.h` / `control_server.h`, `metrics_server.h`, `tape_recorder.h` |
+| Wire protocols | `fix_codec.h`, `ouch_codec.h`, `rest_json.h`, `itch_codec.h` |
+
+## Two margin models, on purpose
+
+`flox::venue::CrossMarginManager` and `flox::LiquidationEngine`
+(`flox/backtest/`) both liquidate, and that is deliberate — they answer
+different questions:
+
+- **`LiquidationEngine` (backtest).** Positions and equity in `double`, driven
+  by a mark tape. Right for simulation: fast, tolerant, models cascades,
+  slippage, ADL ranking, and mark impact.
+- **`CrossMarginManager` (venue).** Portfolio margin backed by the `Ledger`
+  (`__int128`), conservation-exact per asset, with multi-asset collateral
+  haircuts and segregation. Right for a venue moving real balances, where a
+  rounding drift is a money bug rather than a modelling artefact.
+
+Collapsing them into one would either put `double` money into the venue path or
+force ledger machinery into backtests. This is the same split flox already makes
+between `SimulatedClock` and `SystemClock`: one concept, two drivers. Pick by
+what you are building; do not mix them for the same account.
+
+## Verification
+
+The venue core is fuzz-proven in flox's own CI:
+
+- `test_venue_differential_fuzz` — the map-reference book and the O(1) ladder are
+  driven in lockstep and must emit an identical event stream (rolling hash) with
+  no crossed book. 200k commands in CI; set `FLOX_FUZZ_OPS` for a deep run
+  (2M verified).
+- `test_venue_conservation_fuzz` — money is neither created nor destroyed across
+  a random command stream (spot, perp, perp+ADL), and after the book is drained
+  every account's `reserved` must return to zero. A stuck reservation is
+  invisible to conservation-of-total but shows up in that second check.
+
+Plus focused suites: matcher (FIFO/pro-rata/STP), ledger, mark price, mark-feed
+circuit breaker, market data, cross margin, collateral, segregation, funding
+scheduler, sequenced shard, pro-rata, multi-symbol soak, perp venue.
+
+
+## What is deliberately not here
+
+Broker- or instrument-specific policy: MT4/5 semantics (netting vs hedging,
+swap/rollover), CFD contract specifications, LP aggregation and A/B-book
+routing. Those belong to the deployment that runs a venue, not to the framework.

--- a/venue/README.md
+++ b/venue/README.md
@@ -22,6 +22,9 @@ next to the aggregate `NLevelOrderBook` and are useful on their own) and the
 general utilities this layer needed (`flox/util/{crypto,wire,transport,websocket,
 system_clock}.h`).
 
+Platform: Linux and macOS. Skipped on MSVC/clang-cl, which have no `__int128`
+— the type the ledger keeps money in.
+
 ## What it unlocks
 
 Strategy backtests replay a recorded tape: the market never reacts to your

--- a/venue/benchmarks/bench_book.cpp
+++ b/venue/benchmarks/bench_book.cpp
@@ -1,0 +1,110 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Order-level book microbenchmark: the O(1) ladder against the map reference,
+ * driven through the full engine.submit path (validation, risk gates, matching)
+ * rather than a bare book call.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/workload.h"
+#include "flox/book/ladder_book.h"
+#include "flox/book/matching_book.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+constexpr SymbolId SYM = 1;
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = Price::fromDouble(0.01);
+  c.minPrice = Price::fromDouble(50.0);
+  c.maxPrice = Price::fromDouble(150.0);
+  return c;
+}
+
+LadderBook::Config ladderCfg()
+{
+  return LadderBook::Config{/*base*/ 0, /*tick*/ Price::fromDouble(0.01).raw(),
+                            /*levels*/ 16000, /*maxOrders*/ 1 << 20};
+}
+
+struct Result
+{
+  double nsPerOp{};
+  double opsPerSec{};
+  uint64_t trades{};
+  uint64_t hash{};
+};
+
+template <class Book>
+Result run(const std::vector<InboundCommand>& cmds, Book book)
+{
+  uint64_t trades = 0;
+  uint64_t hash = 1469598103934665603ULL;
+  auto sink = [&](const OutboundEvent& e)
+  {
+    if (std::get_if<Trade>(&e))
+    {
+      ++trades;
+    }
+    hash = hashEvent(hash, e);
+  };
+  MatchingEngine<Book> eng(cfg(), sink, std::move(book));
+
+  const auto t0 = std::chrono::steady_clock::now();
+  for (const auto& c : cmds)
+  {
+    eng.submit(c);
+  }
+  const auto t1 = std::chrono::steady_clock::now();
+
+  const double ns = std::chrono::duration<double, std::nano>(t1 - t0).count();
+  Result r;
+  r.nsPerOp = ns / static_cast<double>(cmds.size());
+  r.opsPerSec = static_cast<double>(cmds.size()) / (ns / 1e9);
+  r.trades = trades;
+  r.hash = hash;
+  return r;
+}
+}  // namespace
+
+int main()
+{
+  workload::Params p;
+  p.symbol = SYM;
+  p.count = 2'000'000;
+  const auto cmds = workload::symmetricLimits(p);
+
+  std::printf("workload: %zu commands, symmetric limits around %.2f (+/-%d ticks)\n\n", cmds.size(),
+              p.mid, p.spreadTicks);
+
+  const Result mapR = run<MatchingBook>(cmds, MatchingBook{});
+  const Result ladR = run<LadderBook>(cmds, LadderBook{ladderCfg()});
+
+  std::printf("%-16s  %10s  %14s  %10s\n", "book", "ns/op", "ops/s", "trades");
+  std::printf("%-16s  %10.1f  %14.0f  %10llu\n", "map-reference", mapR.nsPerOp, mapR.opsPerSec,
+              static_cast<unsigned long long>(mapR.trades));
+  std::printf("%-16s  %10.1f  %14.0f  %10llu\n", "ladder-o1", ladR.nsPerOp, ladR.opsPerSec,
+              static_cast<unsigned long long>(ladR.trades));
+
+  const bool equal = (mapR.trades == ladR.trades) && (mapR.hash == ladR.hash);
+  std::printf("\ndeterminism cross-check (map == ladder): %s\n", equal ? "PASS" : "FAIL");
+  std::printf("ladder speedup: %.2fx\n", mapR.nsPerOp / ladR.nsPerOp);
+  return equal ? 0 : 1;
+}

--- a/venue/include/flox-venue/cancel_on_disconnect.h
+++ b/venue/include/flox-venue/cancel_on_disconnect.h
@@ -1,0 +1,66 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace flox::venue
+{
+
+class DisconnectCanceller
+{
+ public:
+  using Responder = std::function<void(const uint8_t*, size_t)>;
+  using Handler = std::function<void(const InboundCommand&, const Responder&)>;
+
+  explicit DisconnectCanceller(bool enabled) noexcept : enabled_(enabled) {}
+
+  // Record a command placed on this session (only NewOrders are cancellable).
+  void track(const InboundCommand& cmd)
+  {
+    if (!enabled_)
+    {
+      return;
+    }
+    if (const auto* n = std::get_if<NewOrder>(&cmd))
+    {
+      placed_.push_back(CancelOrder{n->id, n->symbol, n->accountId});
+    }
+  }
+
+  // On disconnect, cancel everything this session left resting.
+  void flush(const Handler& handler)
+  {
+    if (!enabled_)
+    {
+      return;
+    }
+    const Responder noop = [](const uint8_t*, size_t) {};
+    for (const auto& c : placed_)
+    {
+      handler(InboundCommand{c}, noop);
+    }
+    placed_.clear();
+  }
+
+  bool enabled() const noexcept { return enabled_; }
+
+ private:
+  bool enabled_;
+  std::vector<CancelOrder> placed_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/collateral.h
+++ b/venue/include/flox-venue/collateral.h
@@ -1,0 +1,86 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/ledger.h"
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace flox::venue
+{
+
+class CollateralSchedule
+{
+ public:
+  // `priceRaw` = quote value of one unit of `asset` (Price-scaled); `haircutBps`
+  // discounts that value (2000 = 20% haircut -> 80% credit).
+  void configure(AssetId asset, int64_t priceRaw, int32_t haircutBps)
+  {
+    cfg_[asset] = {priceRaw, haircutBps};
+  }
+
+  void setPrice(AssetId asset, int64_t priceRaw)
+  {
+    auto it = cfg_.find(asset);
+    if (it != cfg_.end())
+    {
+      it->second.priceRaw = priceRaw;
+    }
+  }
+
+  bool accepts(AssetId asset) const { return cfg_.count(asset) != 0; }
+
+  // Enumerate accepted collateral assets (for liquidation-time conversion).
+  template <class Fn>
+  void forEachAsset(Fn&& fn) const
+  {
+    for (const auto& [asset, c] : cfg_)
+    {
+      (void)c;
+      fn(asset);
+    }
+  }
+
+  // Haircut-adjusted quote value of `balanceRaw` units of `asset` (0 if the
+  // asset is not accepted as collateral).
+  Amount value(AssetId asset, Amount balanceRaw) const
+  {
+    auto it = cfg_.find(asset);
+    if (it == cfg_.end())
+    {
+      return 0;
+    }
+    const __int128 gross =
+        static_cast<__int128>(balanceRaw) * it->second.priceRaw / static_cast<__int128>(Price::Scale);
+    return static_cast<Amount>(gross * (10000 - it->second.haircutBps) / 10000);
+  }
+
+  // Total haircut-adjusted collateral value of an account's whole basket.
+  Amount portfolioValue(const Ledger& led, uint64_t account) const
+  {
+    Amount t = 0;
+    for (const auto& [asset, c] : cfg_)
+    {
+      (void)c;
+      t += value(asset, led.total(account, asset));
+    }
+    return t;
+  }
+
+ private:
+  struct Cfg
+  {
+    int64_t priceRaw;
+    int32_t haircutBps;
+  };
+  std::unordered_map<AssetId, Cfg> cfg_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/control_api.h
+++ b/venue/include/flox-venue/control_api.h
@@ -1,0 +1,196 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/control_plane.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <string>
+#include <unordered_map>
+
+namespace flox::venue
+{
+
+class ControlApi
+{
+ public:
+  explicit ControlApi(InstrumentRegistry& reg) : reg_(reg) {}
+
+  std::string handle(const std::string& request)
+  {
+    std::unordered_map<std::string, std::string> f;
+    if (!parse(request, f))
+    {
+      return err("bad_json");
+    }
+    const std::string method = get(f, "method");
+
+    if (method == "listInstrument")
+    {
+      SymbolConfig c;
+      c.id = symOf(f, "symbol");
+      c.tickSize = priceOf(f, "tick");
+      c.minPrice = priceOf(f, "minPrice");
+      c.maxPrice = priceOf(f, "maxPrice");
+      return reg_.listInstrument(c) ? ok() : err("exists");
+    }
+    if (method == "halt")
+    {
+      return reg_.halt(symOf(f, "symbol"), get(f, "halted") == "true") ? ok() : err("unknown_symbol");
+    }
+    if (method == "setBand")
+    {
+      return reg_.setPriceBand(symOf(f, "symbol"), priceOf(f, "minPrice"), priceOf(f, "maxPrice"))
+                 ? ok()
+                 : err("unknown_symbol");
+    }
+    if (method == "setTriggerRef")
+    {
+      const TriggerRef ref = (get(f, "ref") == "mark") ? TriggerRef::Mark : TriggerRef::Last;
+      return reg_.setTriggerRef(symOf(f, "symbol"), ref) ? ok() : err("unknown_symbol");
+    }
+    if (method == "get")
+    {
+      const SymbolConfig* c = reg_.get(symOf(f, "symbol"));
+      return c ? instrumentJson(*c) : err("unknown_symbol");
+    }
+    if (method == "list")
+    {
+      std::string a = "{\"ok\":true,\"instruments\":[";
+      bool first = true;
+      for (SymbolId id : reg_.list())
+      {
+        if (!first)
+        {
+          a += ",";
+        }
+        a += std::to_string(id);
+        first = false;
+      }
+      a += "]}";
+      return a;
+    }
+    return err("unknown_method");
+  }
+
+ private:
+  static std::string ok() { return "{\"ok\":true}"; }
+  static std::string err(const char* e) { return std::string("{\"ok\":false,\"error\":\"") + e + "\"}"; }
+
+  static std::string instrumentJson(const SymbolConfig& c)
+  {
+    return std::string("{\"ok\":true,\"symbol\":") + std::to_string(c.id) +
+           ",\"tick\":" + std::to_string(c.tickSize.toDouble()) +
+           ",\"minPrice\":" + std::to_string(c.minPrice.toDouble()) +
+           ",\"maxPrice\":" + std::to_string(c.maxPrice.toDouble()) +
+           ",\"halted\":" + (c.halted ? "true" : "false") +
+           ",\"triggerRef\":\"" + (c.triggerRef == TriggerRef::Mark ? "mark" : "last") + "\"}";
+  }
+
+  static std::string get(const std::unordered_map<std::string, std::string>& f, const char* k)
+  {
+    auto it = f.find(k);
+    return it == f.end() ? std::string{} : it->second;
+  }
+  static SymbolId symOf(const std::unordered_map<std::string, std::string>& f, const char* k)
+  {
+    return static_cast<SymbolId>(std::strtoul(get(f, k).c_str(), nullptr, 10));
+  }
+  static Price priceOf(const std::unordered_map<std::string, std::string>& f, const char* k)
+  {
+    return Price::fromDouble(std::strtod(get(f, k).c_str(), nullptr));
+  }
+
+  static std::string parseString(const std::string& s, size_t& i)
+  {
+    std::string out;
+    ++i;
+    while (i < s.size() && s[i] != '"')
+    {
+      if (s[i] == '\\' && i + 1 < s.size())
+      {
+        ++i;
+      }
+      out += s[i++];
+    }
+    if (i < s.size())
+    {
+      ++i;
+    }
+    return out;
+  }
+
+  static bool parse(const std::string& s, std::unordered_map<std::string, std::string>& out)
+  {
+    size_t i = 0;
+    auto ws = [&]
+    { while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i]))){ ++i;
+} };
+    ws();
+    if (i >= s.size() || s[i] != '{')
+    {
+      return false;
+    }
+    ++i;
+    ws();
+    if (i < s.size() && s[i] == '}')
+    {
+      return true;
+    }
+    while (i < s.size())
+    {
+      ws();
+      if (i >= s.size() || s[i] != '"')
+      {
+        return false;
+      }
+      const std::string key = parseString(s, i);
+      ws();
+      if (i >= s.size() || s[i] != ':')
+      {
+        return false;
+      }
+      ++i;
+      ws();
+      std::string val;
+      if (i < s.size() && s[i] == '"')
+      {
+        val = parseString(s, i);
+      }
+      else
+      {
+        const size_t st = i;
+        while (i < s.size() && s[i] != ',' && s[i] != '}' &&
+               !std::isspace(static_cast<unsigned char>(s[i])))
+        {
+          ++i;
+        }
+        val = s.substr(st, i - st);
+      }
+      out[key] = val;
+      ws();
+      if (i < s.size() && s[i] == ',')
+      {
+        ++i;
+        continue;
+      }
+      if (i < s.size() && s[i] == '}')
+      {
+        return true;
+      }
+      return false;
+    }
+    return false;
+  }
+
+  InstrumentRegistry& reg_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/control_plane.h
+++ b/venue/include/flox-venue/control_plane.h
@@ -1,0 +1,93 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/matching_engine.h"
+
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace flox::venue
+{
+
+class InstrumentRegistry
+{
+ public:
+  // List a new tradable instrument. Returns false if the id already exists.
+  bool listInstrument(const SymbolConfig& cfg)
+  {
+    if (instruments_.count(cfg.id))
+    {
+      return false;
+    }
+    instruments_[cfg.id] = cfg;
+    return true;
+  }
+
+  bool has(SymbolId id) const noexcept { return instruments_.count(id) != 0; }
+
+  const SymbolConfig* get(SymbolId id) const
+  {
+    auto it = instruments_.find(id);
+    return it == instruments_.end() ? nullptr : &it->second;
+  }
+
+  bool halt(SymbolId id, bool halted)
+  {
+    auto it = instruments_.find(id);
+    if (it == instruments_.end())
+    {
+      return false;
+    }
+    it->second.halted = halted;
+    return true;
+  }
+
+  bool setPriceBand(SymbolId id, Price minPrice, Price maxPrice)
+  {
+    auto it = instruments_.find(id);
+    if (it == instruments_.end())
+    {
+      return false;
+    }
+    it->second.minPrice = minPrice;
+    it->second.maxPrice = maxPrice;
+    return true;
+  }
+
+  bool setTriggerRef(SymbolId id, TriggerRef ref)
+  {
+    auto it = instruments_.find(id);
+    if (it == instruments_.end())
+    {
+      return false;
+    }
+    it->second.triggerRef = ref;
+    return true;
+  }
+
+  std::vector<SymbolId> list() const
+  {
+    std::vector<SymbolId> out;
+    out.reserve(instruments_.size());
+    for (const auto& [id, _] : instruments_)
+    {
+      out.push_back(id);
+    }
+    return out;
+  }
+
+  size_t size() const noexcept { return instruments_.size(); }
+
+ private:
+  std::unordered_map<SymbolId, SymbolConfig> instruments_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/control_server.h
+++ b/venue/include/flox-venue/control_server.h
@@ -1,0 +1,97 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/control_api.h"
+#include "flox-venue/socket_acceptor.h"
+#include "flox/util/transport.h"
+
+#include <unistd.h>
+#include <cstdint>
+#include <istream>
+#include <ostream>
+#include <string>
+
+namespace flox::venue
+{
+
+class ControlServer
+{
+ public:
+  explicit ControlServer(ControlApi& api) : api_(api) {}
+
+  // Process every request line from `in`, writing one response line to `out`.
+  void serve(std::istream& in, std::ostream& out)
+  {
+    std::string line;
+    while (std::getline(in, line))
+    {
+      if (line.empty())
+      {
+        continue;
+      }
+      out << api_.handle(line) << "\n";
+    }
+  }
+
+ private:
+  ControlApi& api_;
+};
+
+// Network-exposed control plane: a loopback TCP admin server that serves the
+// same line-delimited JSON request/response surface. A gRPC gateway or an MCP
+// bridge fronts this in production; here it is directly reachable for admin
+// tooling and tests.
+class TcpControlServer
+{
+ public:
+  explicit TcpControlServer(ControlApi& api) : api_(api) {}
+
+  int start(uint16_t port)
+  {
+    return acceptor_.start(port, [this](int fd)
+                           { connLoop(fd); });
+  }
+  void stop() { acceptor_.stop(); }
+  int port() const noexcept { return acceptor_.port(); }
+
+ private:
+  void connLoop(int fd)
+  {
+    std::string buf;
+    uint8_t tmp[1024];
+    while (acceptor_.running())
+    {
+      const ssize_t r = ::read(fd, tmp, sizeof tmp);
+      if (r <= 0)
+      {
+        break;
+      }
+      buf.append(reinterpret_cast<char*>(tmp), static_cast<size_t>(r));
+      size_t nl;
+      while ((nl = buf.find('\n')) != std::string::npos)
+      {
+        const std::string line = buf.substr(0, nl);
+        buf.erase(0, nl + 1);
+        if (line.empty())
+        {
+          continue;
+        }
+        const std::string resp = api_.handle(line) + "\n";
+        net::writeAll(fd, reinterpret_cast<const uint8_t*>(resp.data()), resp.size());
+      }
+    }
+    ::close(fd);
+  }
+
+  ControlApi& api_;
+  SocketAcceptor acceptor_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/cross_margin.h
+++ b/venue/include/flox-venue/cross_margin.h
@@ -33,8 +33,7 @@ class CrossMarginManager
 
   using OnLiquidation = std::function<void(const Liquidation&)>;
 
-  CrossMarginManager(Ledger& led, AssetId collateral, uint64_t venueAccount, OnLiquidation onLiq = [](const Liquidation&) {}, bool autoDeleverage = false)
-      : led_(led), collateral_(collateral), venue_(venueAccount), onLiq_(std::move(onLiq)), adl_(autoDeleverage)
+  CrossMarginManager(Ledger& led, AssetId collateral, uint64_t venueAccount, OnLiquidation onLiq = [](const Liquidation&) {}, bool autoDeleverage = false) : led_(led), collateral_(collateral), venue_(venueAccount), onLiq_(std::move(onLiq)), adl_(autoDeleverage)
   {
   }
 

--- a/venue/include/flox-venue/cross_margin.h
+++ b/venue/include/flox-venue/cross_margin.h
@@ -1,0 +1,546 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/collateral.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/messages.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+class CrossMarginManager
+{
+ public:
+  struct SymCfg
+  {
+    int32_t imBps{0};
+    int32_t mmBps{0};
+  };
+
+  using OnLiquidation = std::function<void(const Liquidation&)>;
+
+  CrossMarginManager(Ledger& led, AssetId collateral, uint64_t venueAccount, OnLiquidation onLiq = [](const Liquidation&) {}, bool autoDeleverage = false)
+      : led_(led), collateral_(collateral), venue_(venueAccount), onLiq_(std::move(onLiq)), adl_(autoDeleverage)
+  {
+  }
+
+  void configureSymbol(SymbolId s, int32_t imBps, int32_t mmBps) { cfg_[s] = {imBps, mmBps}; }
+
+  // Optional multi-asset collateral: when set, equity uses the haircut-adjusted
+  // basket value (BTC/ETH/... posted as margin) instead of the single quote
+  // balance. Null -> quote-only wallet (default).
+  void setCollateralSchedule(const CollateralSchedule* sched) noexcept { collat_ = sched; }
+
+  // Circuit breaker: when the mark/index feed is stale or disorderly, the
+  // operator pauses liquidations so a bad price can't mass-liquidate the book.
+  // Marks still update (for PnL/equity); only the liquidation sweep is skipped.
+  void setLiquidationsPaused(bool paused) noexcept { liqPaused_ = paused; }
+  bool liquidationsPaused() const noexcept { return liqPaused_; }
+
+  // Mark update for one symbol; liquidates any account now below maintenance
+  // (unless liquidations are paused).
+  void setMark(SymbolId s, Price mark)
+  {
+    marks_[s] = mark.raw();
+    if (!liqPaused_)
+    {
+      checkLiquidations();
+    }
+  }
+
+  // Funding for the portfolio book: each open position in `s` transfers
+  // rate*notional to/from the clearing pool -- longs pay shorts when rate > 0.
+  // Zero-sum across a balanced perp book (Σ long OI == Σ short OI); every move
+  // is mirrored on the venue pool, so value is conserved regardless.
+  void applyFunding(SymbolId s, double rate, Price mark)
+  {
+    const int64_t markRaw = mark.raw();
+    for (auto& [acct, legs] : pos_)
+    {
+      auto l = legs.find(s);
+      if (l == legs.end())
+      {
+        continue;
+      }
+      const __int128 notionalSigned =
+          static_cast<__int128>(markRaw) * l->second.qtyRaw / static_cast<__int128>(Price::Scale);
+      const Amount pay = -static_cast<Amount>(static_cast<double>(notionalSigned) * rate);
+      if (pay == 0)
+      {
+        continue;
+      }
+      led_.credit(acct, collateral_, pay);  // long pays (rate>0), short receives
+      led_.credit(venue_, collateral_, -pay);
+    }
+    if (!liqPaused_)
+    {
+      checkLiquidations();  // funding can push a payer below maintenance
+    }
+  }
+
+  int64_t positionQty(uint64_t acct, SymbolId s) const
+  {
+    auto a = pos_.find(acct);
+    if (a == pos_.end())
+    {
+      return 0;
+    }
+    auto l = a->second.find(s);
+    return l == a->second.end() ? 0 : l->second.qtyRaw;
+  }
+
+  Price positionEntry(uint64_t acct, SymbolId s) const
+  {
+    auto a = pos_.find(acct);
+    if (a == pos_.end())
+    {
+      return Price{};
+    }
+    auto l = a->second.find(s);
+    return l == a->second.end() ? Price{} : Price::fromRaw(l->second.entryRaw);
+  }
+
+  // Portfolio equity = collateral value + unrealized PnL across all symbols.
+  // With a collateral schedule, the wallet is the haircut-adjusted basket;
+  // otherwise it is the single quote balance.
+  Amount equity(uint64_t acct) const
+  {
+    const Amount wallet =
+        collat_ ? collat_->portfolioValue(led_, acct) : led_.available(acct, collateral_);
+    return wallet + unrealizedPnl(acct);
+  }
+
+  Amount initialMargin(uint64_t acct) const { return marginReq(acct, /*maintenance*/ false); }
+  Amount maintenanceMargin(uint64_t acct) const { return marginReq(acct, /*maintenance*/ true); }
+
+  // Aggregate open interest across all accounts (position notional at mark) --
+  // a venue-wide risk gauge for observability.
+  Amount openInterestRaw() const
+  {
+    __int128 t = 0;
+    for (const auto& [acct, legs] : pos_)
+    {
+      for (const auto& [s, leg] : legs)
+      {
+        t += static_cast<__int128>(markOf(s, leg.entryRaw)) * iabs64(leg.qtyRaw) /
+             static_cast<__int128>(Price::Scale);
+      }
+    }
+    return static_cast<Amount>(t);
+  }
+
+  // Total number of open position legs across all accounts.
+  uint64_t openPositionCount() const
+  {
+    uint64_t n = 0;
+    for (const auto& [acct, legs] : pos_)
+    {
+      n += legs.size();
+    }
+    return n;
+  }
+
+  // The largest amount that may be withdrawn while leaving the portfolio fully
+  // initial-margined (equity - amount >= IM). Never negative.
+  Amount withdrawable(uint64_t acct) const
+  {
+    const Amount free = equity(acct) - initialMargin(acct);
+    return free > 0 ? free : 0;
+  }
+
+  // Gate a withdrawal: a trader must not pull collateral that backs open
+  // positions. Allowed only if the post-withdrawal equity still covers IM.
+  bool canWithdraw(uint64_t acct, Amount amount) const
+  {
+    return amount >= 0 && amount <= withdrawable(acct);
+  }
+
+  // Pre-trade portfolio buying-power gate. A fill that reduces net exposure is
+  // always allowed (it can only lower IM); an increasing fill is admitted only
+  // if the resulting portfolio IM still fits inside current equity.
+  bool canOpen(uint64_t acct, SymbolId s, Side side, int64_t qtyRaw, int64_t priceRaw) const
+  {
+    const int64_t signedFill = (side == Side::BUY ? 1 : -1) * qtyRaw;
+    const int64_t cur = positionQty(acct, s);
+    const int64_t next = cur + signedFill;
+    // Not increasing exposure on this symbol -> always allowed.
+    if (iabs64(next) <= iabs64(cur))
+    {
+      return true;
+    }
+
+    const Amount imAfter = marginReqWith(acct, s, next, priceRaw, /*maintenance*/ false);
+    return imAfter <= equity(acct);
+  }
+
+  // Apply a fill (post-trade). Realizes PnL on the reducing portion into the
+  // ledger through the clearing pool; updates the average entry on the opening
+  // portion. Mirrors the engine's netting, without per-position margin locks.
+  void applyFill(uint64_t acct, SymbolId s, Side side, int64_t qtyRaw, int64_t priceRaw)
+  {
+    Leg& p = pos_[acct][s];
+    const int64_t fillSign = (side == Side::BUY) ? 1 : -1;
+    int64_t remaining = qtyRaw;
+
+    const int64_t posSign = (p.qtyRaw > 0) ? 1 : (p.qtyRaw < 0 ? -1 : 0);
+    if (posSign != 0 && posSign != fillSign)
+    {
+      const int64_t reduceQty = std::min<int64_t>(remaining, iabs64(p.qtyRaw));
+      const __int128 pnl = static_cast<__int128>(priceRaw - p.entryRaw) * reduceQty /
+                           static_cast<__int128>(Price::Scale) * posSign;
+      led_.credit(acct, collateral_, static_cast<Amount>(pnl));
+      led_.credit(venue_, collateral_, -static_cast<Amount>(pnl));
+      p.qtyRaw += fillSign * reduceQty;
+      remaining -= reduceQty;
+      if (p.qtyRaw == 0)
+      {
+        p.entryRaw = 0;
+      }
+    }
+
+    if (remaining > 0)
+    {
+      const int64_t absOld = iabs64(p.qtyRaw);
+      const __int128 num = static_cast<__int128>(absOld) * p.entryRaw +
+                           static_cast<__int128>(remaining) * priceRaw;
+      p.entryRaw = static_cast<int64_t>(num / (absOld + remaining));
+      p.qtyRaw += fillSign * remaining;
+    }
+
+    if (p.qtyRaw == 0)
+    {
+      erasePos(acct, s);
+    }
+  }
+
+ private:
+  struct Leg
+  {
+    int64_t qtyRaw{0};
+    int64_t entryRaw{0};
+  };
+
+  static int64_t iabs64(int64_t v) { return v < 0 ? -v : v; }
+
+  int64_t markOf(SymbolId s, int64_t fallbackRaw) const
+  {
+    auto it = marks_.find(s);
+    return it == marks_.end() ? fallbackRaw : it->second;
+  }
+
+  Amount unrealizedPnl(uint64_t acct) const
+  {
+    auto a = pos_.find(acct);
+    if (a == pos_.end())
+    {
+      return 0;
+    }
+    __int128 total = 0;
+    for (const auto& [s, leg] : a->second)
+    {
+      const int64_t mark = markOf(s, leg.entryRaw);
+      total += static_cast<__int128>(mark - leg.entryRaw) * leg.qtyRaw / static_cast<__int128>(Price::Scale);
+    }
+    return static_cast<Amount>(total);
+  }
+
+  Amount marginReq(uint64_t acct, bool maintenance) const
+  {
+    auto a = pos_.find(acct);
+    if (a == pos_.end())
+    {
+      return 0;
+    }
+    __int128 total = 0;
+    for (const auto& [s, leg] : a->second)
+    {
+      total += legMargin(s, leg.qtyRaw, markOf(s, leg.entryRaw), maintenance);
+    }
+    return static_cast<Amount>(total);
+  }
+
+  // Portfolio margin requirement if symbol `s` position were `newQty` at mark
+  // `refPriceRaw` (used for the pre-trade check on the incoming symbol).
+  Amount marginReqWith(uint64_t acct, SymbolId s, int64_t newQty, int64_t refPriceRaw,
+                       bool maintenance) const
+  {
+    __int128 total = legMargin(s, newQty, markOf(s, refPriceRaw), maintenance);
+    auto a = pos_.find(acct);
+    if (a != pos_.end())
+    {
+      for (const auto& [os, leg] : a->second)
+      {
+        if (os == s)
+        {
+          continue;
+        }
+        total += legMargin(os, leg.qtyRaw, markOf(os, leg.entryRaw), maintenance);
+      }
+    }
+    return static_cast<Amount>(total);
+  }
+
+  __int128 legMargin(SymbolId s, int64_t qtyRaw, int64_t markRaw, bool maintenance) const
+  {
+    auto c = cfg_.find(s);
+    if (c == cfg_.end())
+    {
+      return 0;
+    }
+    const int32_t bps = maintenance ? c->second.mmBps : c->second.imBps;
+    const __int128 notional =
+        static_cast<__int128>(markRaw) * iabs64(qtyRaw) / static_cast<__int128>(Price::Scale);
+    return notional * bps / 10000;
+  }
+
+  void checkLiquidations()
+  {
+    std::vector<uint64_t> toLiq;
+    for (const auto& [acct, legs] : pos_)
+    {
+      if (legs.empty())
+      {
+        continue;
+      }
+      if (equity(acct) < maintenanceMargin(acct))
+      {
+        toLiq.push_back(acct);
+      }
+    }
+    // Deterministic order: when several accounts breach at once and share ADL
+    // counterparties, the liquidation order decides which winner absorbs which
+    // deficit vs. which hits insurance -- must not depend on pos_ iteration.
+    std::sort(toLiq.begin(), toLiq.end());
+    for (uint64_t a : toLiq)
+    {
+      liquidate(a);
+    }
+  }
+
+  // Close every position at its mark, realize all PnL into the wallet, and let
+  // the insurance fund cover any residual negative equity (bankruptcy). When
+  // auto-deleverage is on, a bankruptcy deficit is clawed back from the most
+  // profitable opposite-side traders (ADL) before it touches the insurance fund.
+  void liquidate(uint64_t acct)
+  {
+    auto a = pos_.find(acct);
+    if (a == pos_.end())
+    {
+      return;
+    }
+    std::vector<std::pair<SymbolId, int64_t>> bankruptSides;  // (symbol, signed qty) closed
+    for (const auto& [s, leg] : a->second)
+    {
+      const int64_t mark = markOf(s, leg.entryRaw);
+      const __int128 pnl =
+          static_cast<__int128>(mark - leg.entryRaw) * leg.qtyRaw / static_cast<__int128>(Price::Scale);
+      led_.credit(acct, collateral_, static_cast<Amount>(pnl));
+      led_.credit(venue_, collateral_, -static_cast<Amount>(pnl));
+      bankruptSides.emplace_back(s, leg.qtyRaw);
+    }
+    pos_.erase(a);
+
+    // Before touching insurance, sell any non-quote collateral (BTC/ETH) the
+    // account posted to cover the quote deficit -- the venue takes the coin at
+    // its haircut value and pays quote. Value stays conserved per asset.
+    Amount avail = led_.available(acct, collateral_);
+    if (avail < 0 && collat_)
+    {
+      convertCollateral(acct, -avail);
+      avail = led_.available(acct, collateral_);
+    }
+    const bool bankrupt = avail < 0;
+    for (const auto& [s, q] : bankruptSides)
+    {
+      onLiq_(Liquidation{acct, s, Quantity::fromRaw(iabs64(q)), Price::fromRaw(markOf(s, 0)), bankrupt,
+                         /*adl*/ false});
+    }
+    if (!bankrupt)
+    {
+      return;
+    }
+
+    Amount deficit = -avail;
+    led_.credit(acct, collateral_, deficit);  // insurance tops the wallet up to zero
+    led_.credit(venue_, collateral_, -deficit);
+    if (adl_)
+    {
+      autoDeleverage(bankruptSides, deficit);  // recover the deficit from winners
+    }
+  }
+
+  // Claw the bankruptcy deficit back from the most profitable traders on the
+  // opposite side of the bankrupt's positions: close each at the mark and haircut
+  // their realized gain into the insurance fund, until the deficit is recovered.
+  void autoDeleverage(const std::vector<std::pair<SymbolId, int64_t>>& bankruptSides, Amount deficit)
+  {
+    // Rank candidate winners: opposite side, positive unrealized profit.
+    struct Cand
+    {
+      uint64_t acct;
+      SymbolId sym;
+      Amount uPnl;
+    };
+    std::vector<Cand> cands;
+    for (const auto& [sym, bqty] : bankruptSides)
+    {
+      const int64_t bankruptSign = bqty > 0 ? 1 : -1;
+      const int64_t mark = markOf(sym, 0);
+      for (const auto& [oa, legs] : pos_)
+      {
+        auto l = legs.find(sym);
+        if (l == legs.end())
+        {
+          continue;
+        }
+        const int64_t sign = l->second.qtyRaw > 0 ? 1 : (l->second.qtyRaw < 0 ? -1 : 0);
+        if (sign == 0 || sign == bankruptSign)
+        {
+          continue;  // must be the opposite side
+        }
+        const Amount up = static_cast<Amount>(static_cast<__int128>(mark - l->second.entryRaw) *
+                                              l->second.qtyRaw / static_cast<__int128>(Price::Scale));
+        if (up > 0)
+        {
+          cands.push_back({oa, sym, up});
+        }
+      }
+    }
+    // Total order: most profitable first, then (acct, sym) as a deterministic
+    // tie-break. Without it, equal-uPnl winners resolve on unordered_map layout
+    // and std::sort's instability -- so which winner is deleveraged (an emitted
+    // Liquidation folded into the determinism hash) would differ across a replica
+    // rebuilt with a different insertion history, forking HA state.
+    std::sort(cands.begin(), cands.end(),
+              [](const Cand& x, const Cand& y)
+              {
+                if (x.uPnl != y.uPnl)
+                {
+                  return x.uPnl > y.uPnl;
+                }
+                if (x.acct != y.acct)
+                {
+                  return x.acct < y.acct;
+                }
+                return x.sym < y.sym;
+              });
+
+    Amount remaining = deficit;
+    for (const auto& c : cands)
+    {
+      if (remaining <= 0)
+      {
+        break;
+      }
+      auto pa = pos_.find(c.acct);
+      if (pa == pos_.end())
+      {
+        continue;
+      }
+      auto l = pa->second.find(c.sym);
+      if (l == pa->second.end())
+      {
+        continue;
+      }
+      const int64_t mark = markOf(c.sym, 0);
+      const Leg leg = l->second;
+      // Close the winner at the mark (realize their gain), then haircut it.
+      const Amount pnl = static_cast<Amount>(static_cast<__int128>(mark - leg.entryRaw) * leg.qtyRaw /
+                                             static_cast<__int128>(Price::Scale));
+      led_.credit(c.acct, collateral_, pnl);
+      led_.credit(venue_, collateral_, -pnl);
+      const Amount haircut = remaining < c.uPnl ? remaining : c.uPnl;
+      // Confiscate the forgone profit to insurance -- but debit is all-or-nothing
+      // and the winner's `available` may be below the haircut (funding can drive
+      // it negative). Crediting the venue the full haircut while the debit
+      // no-ops would MINT money. Take only what is actually there and credit the
+      // venue exactly that; any uncovered remainder stays in `remaining` and is
+      // borne by the insurance fund (the normal ADL waterfall), never conjured.
+      const Amount avail = led_.available(c.acct, collateral_);
+      const Amount taken = std::min<Amount>(haircut, avail > 0 ? avail : 0);
+      if (taken > 0)
+      {
+        led_.debit(c.acct, collateral_, taken);
+        led_.credit(venue_, collateral_, taken);
+      }
+      remaining -= taken;
+      erasePos(c.acct, c.sym);
+      onLiq_(Liquidation{c.acct, c.sym, Quantity::fromRaw(iabs64(leg.qtyRaw)), Price::fromRaw(mark),
+                         /*bankrupt*/ false, /*adl*/ true});
+    }
+  }
+
+  // Liquidate an account's non-quote collateral to cover a quote `deficit`:
+  // move coin from the account to the venue (which will offload it externally)
+  // and credit the account the haircut value in quote. Balanced per asset.
+  void convertCollateral(uint64_t acct, Amount deficit)
+  {
+    Amount remaining = deficit;
+    collat_->forEachAsset(
+        [&](AssetId asset)
+        {
+          if (asset == collateral_ || remaining <= 0)
+          {
+            return;
+          }
+          const Amount bal = led_.available(acct, asset);
+          if (bal <= 0)
+          {
+            return;
+          }
+          const Amount val = collat_->value(asset, bal);
+          if (val <= 0)
+          {
+            return;
+          }
+          const Amount take = remaining < val ? remaining : val;
+          const Amount units = static_cast<Amount>(static_cast<__int128>(bal) * take / val);
+          led_.debit(acct, asset, units);  // sell coin to the venue
+          led_.credit(venue_, asset, units);
+          led_.credit(acct, collateral_, take);  // proceeds in quote
+          led_.credit(venue_, collateral_, -take);
+          remaining -= take;
+        });
+  }
+
+  void erasePos(uint64_t acct, SymbolId s)
+  {
+    auto a = pos_.find(acct);
+    if (a == pos_.end())
+    {
+      return;
+    }
+    a->second.erase(s);
+    if (a->second.empty())
+    {
+      pos_.erase(a);
+    }
+  }
+
+  Ledger& led_;
+  AssetId collateral_;
+  uint64_t venue_;
+  OnLiquidation onLiq_;
+  const CollateralSchedule* collat_{nullptr};
+  bool adl_{false};
+  bool liqPaused_{false};
+  std::unordered_map<SymbolId, SymCfg> cfg_;
+  std::unordered_map<SymbolId, int64_t> marks_;
+  std::unordered_map<uint64_t, std::unordered_map<SymbolId, Leg>> pos_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/cross_margin.h
+++ b/venue/include/flox-venue/cross_margin.h
@@ -13,6 +13,7 @@
 #include "flox-venue/messages.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <functional>
 #include <unordered_map>
@@ -29,6 +30,8 @@ class CrossMarginManager
   {
     int32_t imBps{0};
     int32_t mmBps{0};
+    int64_t priceScale{Price::Scale};
+    int64_t qtyScale{Quantity::Scale};
   };
 
   using OnLiquidation = std::function<void(const Liquidation&)>;
@@ -37,7 +40,20 @@ class CrossMarginManager
   {
   }
 
-  void configureSymbol(SymbolId s, int32_t imBps, int32_t mmBps) { cfg_[s] = {imBps, mmBps}; }
+  void configureSymbol(SymbolId s, int32_t imBps, int32_t mmBps,
+                       int64_t priceScale = Price::Scale, int64_t qtyScale = Quantity::Scale)
+  {
+    assert(scalesValid(priceScale, qtyScale));
+    cfg_[s] = {imBps, mmBps, priceScale, qtyScale};
+  }
+
+  // Scales of a configured symbol; defaults for one traded before configureSymbol.
+  std::pair<int64_t, int64_t> scalesOf(SymbolId s) const
+  {
+    auto c = cfg_.find(s);
+    return c == cfg_.end() ? std::pair<int64_t, int64_t>{Price::Scale, Quantity::Scale}
+                           : std::pair<int64_t, int64_t>{c->second.priceScale, c->second.qtyScale};
+  }
 
   // Optional multi-asset collateral: when set, equity uses the haircut-adjusted
   // basket value (BTC/ETH/... posted as margin) instead of the single quote
@@ -75,8 +91,8 @@ class CrossMarginManager
       {
         continue;
       }
-      const __int128 notionalSigned =
-          static_cast<__int128>(markRaw) * l->second.qtyRaw / static_cast<__int128>(Price::Scale);
+      const auto [pS, qS] = scalesOf(s);
+      const Amount notionalSigned = notionalRaw(markRaw, l->second.qtyRaw, pS, qS);
       const Amount pay = -static_cast<Amount>(static_cast<double>(notionalSigned) * rate);
       if (pay == 0)
       {
@@ -135,8 +151,8 @@ class CrossMarginManager
     {
       for (const auto& [s, leg] : legs)
       {
-        t += static_cast<__int128>(markOf(s, leg.entryRaw)) * iabs64(leg.qtyRaw) /
-             static_cast<__int128>(Price::Scale);
+        const auto [pS, qS] = scalesOf(s);
+        t += notionalRaw(markOf(s, leg.entryRaw), iabs64(leg.qtyRaw), pS, qS);
       }
     }
     return static_cast<Amount>(t);
@@ -199,10 +215,10 @@ class CrossMarginManager
     if (posSign != 0 && posSign != fillSign)
     {
       const int64_t reduceQty = std::min<int64_t>(remaining, iabs64(p.qtyRaw));
-      const __int128 pnl = static_cast<__int128>(priceRaw - p.entryRaw) * reduceQty /
-                           static_cast<__int128>(Price::Scale) * posSign;
-      led_.credit(acct, collateral_, static_cast<Amount>(pnl));
-      led_.credit(venue_, collateral_, -static_cast<Amount>(pnl));
+      const auto [pS, qS] = scalesOf(s);
+      const Amount pnl = notionalRaw(priceRaw - p.entryRaw, reduceQty, pS, qS) * posSign;
+      led_.credit(acct, collateral_, pnl);
+      led_.credit(venue_, collateral_, -pnl);
       p.qtyRaw += fillSign * reduceQty;
       remaining -= reduceQty;
       if (p.qtyRaw == 0)
@@ -252,7 +268,8 @@ class CrossMarginManager
     for (const auto& [s, leg] : a->second)
     {
       const int64_t mark = markOf(s, leg.entryRaw);
-      total += static_cast<__int128>(mark - leg.entryRaw) * leg.qtyRaw / static_cast<__int128>(Price::Scale);
+      const auto [pS, qS] = scalesOf(s);
+      total += notionalRaw(mark - leg.entryRaw, leg.qtyRaw, pS, qS);
     }
     return static_cast<Amount>(total);
   }
@@ -301,8 +318,8 @@ class CrossMarginManager
       return 0;
     }
     const int32_t bps = maintenance ? c->second.mmBps : c->second.imBps;
-    const __int128 notional =
-        static_cast<__int128>(markRaw) * iabs64(qtyRaw) / static_cast<__int128>(Price::Scale);
+    const Amount notional =
+        notionalRaw(markRaw, iabs64(qtyRaw), c->second.priceScale, c->second.qtyScale);
     return notional * bps / 10000;
   }
 
@@ -345,10 +362,10 @@ class CrossMarginManager
     for (const auto& [s, leg] : a->second)
     {
       const int64_t mark = markOf(s, leg.entryRaw);
-      const __int128 pnl =
-          static_cast<__int128>(mark - leg.entryRaw) * leg.qtyRaw / static_cast<__int128>(Price::Scale);
-      led_.credit(acct, collateral_, static_cast<Amount>(pnl));
-      led_.credit(venue_, collateral_, -static_cast<Amount>(pnl));
+      const auto [pS, qS] = scalesOf(s);
+      const Amount pnl = notionalRaw(mark - leg.entryRaw, leg.qtyRaw, pS, qS);
+      led_.credit(acct, collateral_, pnl);
+      led_.credit(venue_, collateral_, -pnl);
       bankruptSides.emplace_back(s, leg.qtyRaw);
     }
     pos_.erase(a);
@@ -411,8 +428,8 @@ class CrossMarginManager
         {
           continue;  // must be the opposite side
         }
-        const Amount up = static_cast<Amount>(static_cast<__int128>(mark - l->second.entryRaw) *
-                                              l->second.qtyRaw / static_cast<__int128>(Price::Scale));
+        const auto [pS, qS] = scalesOf(sym);
+        const Amount up = notionalRaw(mark - l->second.entryRaw, l->second.qtyRaw, pS, qS);
         if (up > 0)
         {
           cands.push_back({oa, sym, up});
@@ -458,8 +475,8 @@ class CrossMarginManager
       const int64_t mark = markOf(c.sym, 0);
       const Leg leg = l->second;
       // Close the winner at the mark (realize their gain), then haircut it.
-      const Amount pnl = static_cast<Amount>(static_cast<__int128>(mark - leg.entryRaw) * leg.qtyRaw /
-                                             static_cast<__int128>(Price::Scale));
+      const auto [pS, qS] = scalesOf(c.sym);
+      const Amount pnl = notionalRaw(mark - leg.entryRaw, leg.qtyRaw, pS, qS);
       led_.credit(c.acct, collateral_, pnl);
       led_.credit(venue_, collateral_, -pnl);
       const Amount haircut = remaining < c.uPnl ? remaining : c.uPnl;

--- a/venue/include/flox-venue/event_hash.h
+++ b/venue/include/flox-venue/event_hash.h
@@ -1,0 +1,118 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cstdint>
+
+namespace flox::venue
+{
+
+inline uint64_t mix(uint64_t h, uint64_t v) noexcept
+{
+  h ^= v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+  return h;
+}
+
+inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
+{
+  if (const auto* x = std::get_if<OrderAccepted>(&e))
+  {
+    h = mix(h, 1);
+    h = mix(h, x->id);
+    h = mix(h, x->symbol);
+    h = mix(h, static_cast<uint64_t>(x->side));
+    h = mix(h, static_cast<uint64_t>(x->price.raw()));
+    h = mix(h, static_cast<uint64_t>(x->leavesQty.raw()));
+    h = mix(h, x->restingOnBook ? 1U : 0U);
+  }
+  else if (const auto* x = std::get_if<OrderRejected>(&e))
+  {
+    h = mix(h, 2);
+    h = mix(h, x->id);
+    h = mix(h, static_cast<uint64_t>(x->reason));
+  }
+  else if (const auto* x = std::get_if<Trade>(&e))
+  {
+    h = mix(h, 3);
+    h = mix(h, x->tradeId);
+    h = mix(h, static_cast<uint64_t>(x->price.raw()));
+    h = mix(h, static_cast<uint64_t>(x->quantity.raw()));
+    h = mix(h, x->makerId);
+    h = mix(h, x->takerId);
+  }
+  else if (const auto* x = std::get_if<OrderExecuted>(&e))
+  {
+    h = mix(h, 4);
+    h = mix(h, x->id);
+    h = mix(h, static_cast<uint64_t>(x->lastQty.raw()));
+    h = mix(h, static_cast<uint64_t>(x->leavesQty.raw()));
+    h = mix(h, x->complete ? 1U : 0U);
+  }
+  else if (const auto* x = std::get_if<OrderCanceled>(&e))
+  {
+    h = mix(h, 5);
+    h = mix(h, x->id);
+    h = mix(h, static_cast<uint64_t>(x->reason));
+  }
+  else if (const auto* x = std::get_if<OrderModified>(&e))
+  {
+    h = mix(h, 6);
+    h = mix(h, x->id);
+    h = mix(h, static_cast<uint64_t>(x->price.raw()));
+    h = mix(h, static_cast<uint64_t>(x->leavesQty.raw()));
+    h = mix(h, x->priorityKept ? 1U : 0U);
+  }
+  else if (const auto* x = std::get_if<OrderTriggered>(&e))
+  {
+    h = mix(h, 7);
+    h = mix(h, x->id);
+    h = mix(h, static_cast<uint64_t>(x->refPrice.raw()));
+  }
+  else if (const auto* x = std::get_if<FillHeld>(&e))
+  {
+    h = mix(h, 8);
+    h = mix(h, x->heldId);
+    h = mix(h, x->makerId);
+    h = mix(h, x->takerId);
+    h = mix(h, static_cast<uint64_t>(x->price.raw()));
+    h = mix(h, static_cast<uint64_t>(x->qty.raw()));
+  }
+  else if (const auto* x = std::get_if<FillRejected>(&e))
+  {
+    h = mix(h, 9);
+    h = mix(h, x->heldId);
+    h = mix(h, x->takerId);
+  }
+  else if (const auto* x = std::get_if<MmpTriggered>(&e))
+  {
+    h = mix(h, 10);
+    h = mix(h, x->accountId);
+    h = mix(h, x->symbol);
+  }
+  else if (const auto* x = std::get_if<FeeCharged>(&e))
+  {
+    h = mix(h, 11);
+    h = mix(h, x->id);
+    h = mix(h, static_cast<uint64_t>(x->fee.raw()));
+    h = mix(h, x->maker ? 1U : 0U);
+  }
+  else if (const auto* x = std::get_if<Liquidation>(&e))
+  {
+    h = mix(h, 12);
+    h = mix(h, x->account);
+    h = mix(h, static_cast<uint64_t>(x->qty.raw()));
+    h = mix(h, static_cast<uint64_t>(x->price.raw()));
+    h = mix(h, x->bankrupt ? 1U : 0U);
+  }
+  return h;
+}
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/event_sink.h
+++ b/venue/include/flox-venue/event_sink.h
@@ -1,0 +1,18 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <functional>
+
+namespace flox::venue
+{
+using EventSink = std::function<void(const OutboundEvent&)>;
+}  // namespace flox::venue

--- a/venue/include/flox-venue/fix_codec.h
+++ b/venue/include/flox-venue/fix_codec.h
@@ -1,0 +1,250 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace flox::venue
+{
+
+class FixCodec
+{
+ public:
+  static constexpr char SOH = '\x01';
+
+  // ---- inbound: FIX message -> InboundCommand ----
+  static std::optional<InboundCommand> decode(const std::string& msg)
+  {
+    std::unordered_map<int, std::string> f;
+    size_t i = 0;
+    while (i < msg.size())
+    {
+      size_t eq = msg.find('=', i);
+      if (eq == std::string::npos)
+      {
+        break;
+      }
+      size_t soh = msg.find(SOH, eq + 1);
+      if (soh == std::string::npos)
+      {
+        soh = msg.size();
+      }
+      const int tag = std::atoi(msg.substr(i, eq - i).c_str());
+      f[tag] = msg.substr(eq + 1, soh - eq - 1);
+      i = soh + 1;
+    }
+
+    auto has = [&](int t)
+    { return f.count(t) != 0; };
+    auto s = [&](int t)
+    { return has(t) ? f[t] : std::string{}; };
+
+    // FIX integrity: if a CheckSum (tag 10) is present it MUST be correct --
+    // sum of every byte up to and including the SOH before "10=", mod 256. A
+    // corrupted message with a bad checksum is rejected. (Lenient when absent,
+    // for internal/test callers that don't append one.)
+    if (has(10))
+    {
+      const std::string marker = std::string(1, SOH) + "10=";
+      const size_t p = msg.rfind(marker);
+      if (p != std::string::npos)
+      {
+        unsigned sum = 0;
+        for (size_t k = 0; k <= p; ++k)
+        {
+          sum += static_cast<unsigned char>(msg[k]);
+        }
+        if ((sum % 256) != static_cast<unsigned>(std::atoi(f[10].c_str())))
+        {
+          return std::nullopt;  // checksum mismatch -> reject
+        }
+      }
+    }
+    auto u64 = [&](int t)
+    { return static_cast<uint64_t>(std::strtoull(s(t).c_str(), nullptr, 10)); };
+    auto sym = [&](int t)
+    { return static_cast<SymbolId>(std::strtoul(s(t).c_str(), nullptr, 10)); };
+    auto price = [&](int t)
+    { return safeDecimal<Price>(std::strtod(s(t).c_str(), nullptr)); };
+    auto qtyf = [&](int t)
+    { return safeDecimal<Quantity>(std::strtod(s(t).c_str(), nullptr)); };
+
+    const std::string type = s(35);
+    if (type == "D")  // NewOrderSingle
+    {
+      NewOrder o;
+      o.id = u64(11);
+      o.clientOrderId = u64(11);
+      o.symbol = sym(55);
+      o.side = (s(54) == "2") ? Side::SELL : Side::BUY;
+      o.quantity = qtyf(38);
+      o.accountId = u64(1);
+      switch (std::atoi(s(40).c_str()))  // OrdType
+      {
+        case 1:
+          o.type = OrderType::MARKET;
+          break;
+        case 3:
+          o.type = OrderType::STOP_MARKET;
+          break;
+        case 4:
+          o.type = OrderType::STOP_LIMIT;
+          break;
+        default:
+          o.type = OrderType::LIMIT;
+          break;
+      }
+      if (has(44))
+      {
+        o.price = price(44);
+      }
+      if (has(99))
+      {
+        o.triggerPrice = price(99);
+      }
+      if (has(111))
+      {
+        o.visibleQuantity = qtyf(111);  // MaxFloor -> iceberg peak
+      }
+      switch (std::atoi(s(59).c_str()))  // TimeInForce
+      {
+        case 3:
+          o.tif = TimeInForce::IOC;
+          break;
+        case 4:
+          o.tif = TimeInForce::FOK;
+          break;
+        default:
+          o.tif = TimeInForce::GTC;
+          break;
+      }
+      const std::string execInst = s(18);
+      if (execInst.find('6') != std::string::npos)  // ParticipateDoNotInitiate
+      {
+        o.postOnly = true;
+      }
+      if (execInst.find('E') != std::string::npos)  // DoNotIncrease -> reduce-only
+      {
+        o.reduceOnly = true;
+      }
+      return InboundCommand{o};
+    }
+    if (type == "F")  // OrderCancelRequest
+    {
+      CancelOrder c;
+      c.id = u64(41);  // OrigClOrdID
+      c.symbol = sym(55);
+      c.accountId = u64(1);
+      return InboundCommand{c};
+    }
+    if (type == "G")  // OrderCancelReplaceRequest
+    {
+      ModifyOrder m;
+      m.id = u64(41);
+      m.symbol = sym(55);
+      if (has(44))
+      {
+        m.newPrice = price(44);
+      }
+      m.newQty = qtyf(38);
+      m.accountId = u64(1);
+      return InboundCommand{m};
+    }
+    return std::nullopt;
+  }
+
+  // ---- outbound: OutboundEvent -> ExecutionReport (35=8) ----
+  static std::string encode(const OutboundEvent& ev)
+  {
+    std::string b;  // body after 35
+    auto add = [&](int tag, const std::string& val)
+    { b += std::to_string(tag) + "=" + val + SOH; };
+    auto num = [](Price p)
+    { return std::to_string(p.toDouble()); };
+    auto qnum = [](Quantity q)
+    { return std::to_string(q.toDouble()); };
+
+    add(35, "8");  // ExecutionReport
+    if (const auto* a = std::get_if<OrderAccepted>(&ev))
+    {
+      add(37, std::to_string(a->id));
+      add(11, std::to_string(a->id));
+      add(55, std::to_string(a->symbol));
+      add(54, a->side == Side::SELL ? "2" : "1");
+      add(150, "0");  // ExecType New
+      add(39, "0");   // OrdStatus New
+      add(151, qnum(a->leavesQty));
+      add(44, num(a->price));
+    }
+    else if (const auto* x = std::get_if<OrderExecuted>(&ev))
+    {
+      add(37, std::to_string(x->id));
+      add(55, std::to_string(x->symbol));
+      add(150, "F");                     // ExecType Trade
+      add(39, x->complete ? "2" : "1");  // Filled / Partially filled
+      add(32, qnum(x->lastQty));         // LastQty
+      add(31, num(x->lastPx));           // LastPx -- price of this fill
+      add(6, num(x->lastPx));            // AvgPx (single-fill report)
+      add(151, qnum(x->leavesQty));      // LeavesQty
+    }
+    else if (const auto* c = std::get_if<OrderCanceled>(&ev))
+    {
+      add(37, std::to_string(c->id));
+      add(150, "4");  // Canceled
+      add(39, "4");
+    }
+    else if (const auto* j = std::get_if<OrderRejected>(&ev))
+    {
+      add(37, std::to_string(j->id));
+      add(150, "8");  // Rejected
+      add(39, "8");
+      add(58, std::string(toString(j->reason)));
+    }
+    else if (const auto* m = std::get_if<OrderModified>(&ev))
+    {
+      add(37, std::to_string(m->id));
+      add(150, "5");  // Replaced
+      add(39, "5");
+      add(151, qnum(m->leavesQty));
+      add(44, num(m->price));
+    }
+    else
+    {
+      return {};  // Trade/Triggered are market-data, not exec reports
+    }
+
+    return frame(b);
+  }
+
+ private:
+  // Prepend 8/9, append 10 with correct BodyLength and CheckSum.
+  static std::string frame(const std::string& body)
+  {
+    const std::string prefix = std::string("8=FIX.4.4") + SOH;
+    const std::string lenField = std::string("9=") + std::to_string(body.size()) + SOH;
+    std::string msg = prefix + lenField + body;
+    uint32_t sum = 0;
+    for (unsigned char ch : msg)
+    {
+      sum += ch;
+    }
+    char cs[4];
+    std::snprintf(cs, sizeof(cs), "%03u", sum % 256);
+    msg += std::string("10=") + cs + SOH;
+    return msg;
+  }
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/funding_rate.h
+++ b/venue/include/flox-venue/funding_rate.h
@@ -1,0 +1,134 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Perpetual funding RATE computation (live side). Complements
+ * backtest/funding_schedule.h, which REPLAYS a recorded rate tape: this
+ * computes the rate from live mark/index. The funding
+ * rate is the premium index (mark vs index) plus a clamped interest component,
+ * capped; at each funding interval longs pay shorts (or vice-versa) in
+ * proportion to position notional. Zero-sum across the book.
+ *
+ * Two paths: rate(mark,index) is a single snapshot; the interval TWAP path
+ * (sample() across the interval, settle on intervalRate()) is manipulation-
+ * resistant -- a momentary dislocation cannot swing the payment. Pair sample()
+ * with the mark/index feed (index_feed.h).
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace flox::venue
+{
+
+struct FundingParams
+{
+  double interestRate{0.0001};  // baseline interest component per interval (1bp)
+  double clampBand{0.0005};     // clamp on (interest - premium) (5bp)
+  double cap{0.0075};           // max |funding rate| per interval (0.75%)
+};
+
+struct PerpPosition
+{
+  uint64_t account{};
+  double signedQty{};  // + long, - short
+};
+
+struct FundingCharge
+{
+  uint64_t account{};
+  double amount{};  // signed: negative = account pays, positive = account receives
+};
+
+class FundingCalculator
+{
+ public:
+  explicit FundingCalculator(FundingParams p = {}) : p_(p) {}
+
+  // funding = premium + clamp(interest - premium, ±band), capped at ±cap.
+  double rate(double mark, double index) const
+  {
+    if (index <= 0.0)
+    {
+      return 0.0;
+    }
+    return rateFromPremium(premiumOf(mark, index));
+  }
+
+  // --- interval TWAP path (manipulation-resistant) ---
+  // Real venues do not funding off a single snapshot: a momentary dislocation
+  // would swing the payment. Sample the premium repeatedly across the interval,
+  // then settle on the average. Feed each sample from the mark/index feed.
+  void sample(double mark, double index)
+  {
+    if (index <= 0.0)
+    {
+      return;
+    }
+    premiumSum_ += premiumOf(mark, index);
+    ++samples_;
+  }
+
+  // Rate from the time-averaged premium accumulated via sample(). Falls back to
+  // the interest rate when no samples were taken.
+  double intervalRate() const
+  {
+    if (samples_ == 0)
+    {
+      return rateFromPremium(0.0);
+    }
+    return rateFromPremium(premiumSum_ / static_cast<double>(samples_));
+  }
+
+  void resetSamples()
+  {
+    premiumSum_ = 0.0;
+    samples_ = 0;
+  }
+
+  std::size_t sampleCount() const noexcept { return samples_; }
+
+  // Settle funding at `mark`. Longs pay when the rate is positive; the total
+  // across a balanced book nets to zero.
+  std::vector<FundingCharge> settle(const std::vector<PerpPosition>& pos, double mark,
+                                    double index) const
+  {
+    const double r = rate(mark, index);
+    std::vector<FundingCharge> out;
+    out.reserve(pos.size());
+    for (const auto& p : pos)
+    {
+      out.push_back(FundingCharge{p.account, -p.signedQty * mark * r});
+    }
+    return out;
+  }
+
+  FundingParams params() const noexcept { return p_; }
+
+ private:
+  static double premiumOf(double mark, double index)
+  {
+    return index <= 0.0 ? 0.0 : (mark - index) / index;
+  }
+
+  double rateFromPremium(double premium) const
+  {
+    double c = p_.interestRate - premium;
+    c = std::max(-p_.clampBand, std::min(p_.clampBand, c));
+    const double f = premium + c;
+    return std::max(-p_.cap, std::min(p_.cap, f));
+  }
+
+  FundingParams p_;
+  double premiumSum_{0.0};
+  std::size_t samples_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/funding_scheduler.h
+++ b/venue/include/flox-venue/funding_scheduler.h
@@ -1,0 +1,66 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/funding_rate.h"
+#include "flox-venue/messages.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace flox::venue
+{
+
+template <class Engine>
+class FundingScheduler
+{
+ public:
+  FundingScheduler(Engine& eng, int64_t fundingIntervalNs, FundingCalculator calc = FundingCalculator{})
+      : eng_(eng), interval_(fundingIntervalNs), calc_(calc)
+  {
+  }
+
+  // Feed the current mark/index at time nowNs. Samples the premium; when a
+  // funding boundary is crossed, settles funding on the engine at the sampled
+  // TWAP rate, resets the accumulator, and returns the settled rate.
+  std::optional<double> onTick(int64_t nowNs, Price mark, Price index)
+  {
+    if (nextSettle_ < 0)
+    {
+      nextSettle_ = nowNs + interval_;  // first tick anchors the interval
+    }
+    calc_.sample(mark.toDouble(), index.toDouble());
+
+    if (nowNs >= nextSettle_)
+    {
+      const double rate = calc_.intervalRate();
+      eng_.applyFunding(rate, mark);
+      calc_.resetSamples();
+      nextSettle_ += interval_;
+      ++settlements_;
+      lastRate_ = rate;
+      return rate;
+    }
+    return std::nullopt;
+  }
+
+  int64_t nextSettleNs() const noexcept { return nextSettle_; }
+  uint64_t settlements() const noexcept { return settlements_; }
+  double lastRate() const noexcept { return lastRate_; }
+
+ private:
+  Engine& eng_;
+  int64_t interval_;
+  FundingCalculator calc_;
+  int64_t nextSettle_{-1};
+  uint64_t settlements_{0};
+  double lastRate_{0.0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/index_feed.h
+++ b/venue/include/flox-venue/index_feed.h
@@ -1,0 +1,231 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace flox::venue
+{
+
+class IndexAggregator
+{
+ public:
+  IndexAggregator(int64_t stalenessNs, int32_t maxDeviationBps, size_t minSources)
+      : stalenessNs_(stalenessNs), maxDeviationBps_(maxDeviationBps), minSources_(minSources)
+  {
+  }
+
+  void update(uint32_t sourceId, Price p, int64_t tsNs) { sources_[sourceId] = {p.raw(), tsNs}; }
+
+  bool hasIndex(int64_t nowNs) const { return freshPrices(nowNs).size() >= minSources_; }
+
+  // Median of the fresh, outlier-filtered source set. Returns an invalid Price
+  // (raw 0) if fewer than minSources fresh feeds are available.
+  Price index(int64_t nowNs) const
+  {
+    std::vector<int64_t> fresh = freshPrices(nowNs);
+    if (fresh.size() < minSources_)
+    {
+      return Price{};
+    }
+    const int64_t m0 = median(fresh);
+    // Drop sources deviating more than maxDeviationBps from the rough median.
+    std::vector<int64_t> kept;
+    kept.reserve(fresh.size());
+    for (int64_t v : fresh)
+    {
+      const int64_t dev = (v > m0 ? v - m0 : m0 - v);
+      if (m0 == 0 || dev * 10000 / m0 <= maxDeviationBps_)
+      {
+        kept.push_back(v);
+      }
+    }
+    if (kept.size() < minSources_)
+    {
+      kept = std::move(fresh);  // all deviate similarly (real move) -> keep them
+    }
+    return Price::fromRaw(median(kept));
+  }
+
+ private:
+  struct Src
+  {
+    int64_t priceRaw;
+    int64_t tsNs;
+  };
+
+  std::vector<int64_t> freshPrices(int64_t nowNs) const
+  {
+    std::vector<int64_t> out;
+    out.reserve(sources_.size());
+    for (const auto& [id, s] : sources_)
+    {
+      if (nowNs - s.tsNs <= stalenessNs_)
+      {
+        out.push_back(s.priceRaw);
+      }
+    }
+    return out;
+  }
+
+  static int64_t median(std::vector<int64_t>& v)
+  {
+    std::sort(v.begin(), v.end());
+    const size_t n = v.size();
+    if (n == 0)
+    {
+      return 0;
+    }
+    return (n & 1) ? v[n / 2] : (v[n / 2 - 1] + v[n / 2]) / 2;
+  }
+
+  int64_t stalenessNs_;
+  int32_t maxDeviationBps_;
+  size_t minSources_;
+  std::unordered_map<uint32_t, Src> sources_;
+};
+
+// One book level for impact-price computation (price + resting size).
+struct DepthLevel
+{
+  int64_t priceRaw;
+  int64_t qtyRaw;
+};
+
+// Impact price: the volume-weighted price to fill `targetQtyRaw` walking the
+// levels best-first. A thin top-of-book cannot swing it -- you must consume real
+// depth to move the impact price. If depth is insufficient, returns the VWAP of
+// what is available; 0 if there is no depth at all.
+inline int64_t impactPriceRaw(const std::vector<DepthLevel>& levels, int64_t targetQtyRaw)
+{
+  if (targetQtyRaw <= 0)
+  {
+    return levels.empty() ? 0 : levels.front().priceRaw;
+  }
+  __int128 notional = 0;
+  int64_t filled = 0;
+  for (const auto& lv : levels)
+  {
+    const int64_t take = std::min<int64_t>(lv.qtyRaw, targetQtyRaw - filled);
+    if (take <= 0)
+    {
+      break;
+    }
+    notional += static_cast<__int128>(lv.priceRaw) * take;
+    filled += take;
+    if (filled >= targetQtyRaw)
+    {
+      break;
+    }
+  }
+  if (filled == 0)
+  {
+    return 0;
+  }
+  return static_cast<int64_t>(notional / filled);
+}
+
+// Impact mid = midpoint of the impact bid (VWAP into asks) and impact ask
+// (VWAP into bids) for a given impact size. Feed this into MarkPrice::setMid.
+inline int64_t impactMidRaw(const std::vector<DepthLevel>& bids, const std::vector<DepthLevel>& asks,
+                            int64_t impactQtyRaw)
+{
+  const int64_t ib = impactPriceRaw(bids, impactQtyRaw);
+  const int64_t ia = impactPriceRaw(asks, impactQtyRaw);
+  if (ib == 0)
+  {
+    return ia;
+  }
+  if (ia == 0)
+  {
+    return ib;
+  }
+  return (ib + ia) / 2;
+}
+
+// Compute the impact mid directly from a live order book. Works with any book
+// exposing `levels(Side, std::vector<std::pair<Price, Quantity>>&)` best-first
+// (MatchingBook / LadderBook). Feed the result into MarkPrice::setMid.
+template <class Book>
+int64_t bookImpactMidRaw(const Book& book, int64_t impactQtyRaw)
+{
+  std::vector<std::pair<Price, Quantity>> bl, al;
+  book.levels(Side::BUY, bl);
+  book.levels(Side::SELL, al);
+  std::vector<DepthLevel> bids, asks;
+  bids.reserve(bl.size());
+  asks.reserve(al.size());
+  for (const auto& [p, q] : bl)
+  {
+    bids.push_back({p.raw(), q.raw()});
+  }
+  for (const auto& [p, q] : al)
+  {
+    asks.push_back({p.raw(), q.raw()});
+  }
+  return impactMidRaw(bids, asks, impactQtyRaw);
+}
+
+class MarkPrice
+{
+ public:
+  explicit MarkPrice(int32_t clampBps) : clampBps_(clampBps) {}
+
+  void setIndex(Price p) { indexRaw_ = p.raw(); }
+  void setLast(Price p) { lastRaw_ = p.raw(); }
+  void setMid(Price p) { midRaw_ = p.raw(); }
+
+  bool valid() const { return indexRaw_ > 0; }
+
+  // Median of {index, last, mid} (whichever are set), clamped to the index band.
+  Price value() const
+  {
+    if (indexRaw_ <= 0)
+    {
+      return Price{};
+    }
+    std::vector<int64_t> pts{indexRaw_};
+    if (lastRaw_ > 0)
+    {
+      pts.push_back(lastRaw_);
+    }
+    if (midRaw_ > 0)
+    {
+      pts.push_back(midRaw_);
+    }
+    std::sort(pts.begin(), pts.end());
+    int64_t mark = pts[pts.size() / 2];
+
+    const int64_t band = indexRaw_ * clampBps_ / 10000;
+    const int64_t lo = indexRaw_ - band;
+    const int64_t hi = indexRaw_ + band;
+    if (mark < lo)
+    {
+      mark = lo;
+    }
+    if (mark > hi)
+    {
+      mark = hi;
+    }
+    return Price::fromRaw(mark);
+  }
+
+ private:
+  int32_t clampBps_;
+  int64_t indexRaw_{0};
+  int64_t lastRaw_{0};
+  int64_t midRaw_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/itch_codec.h
+++ b/venue/include/flox-venue/itch_codec.h
@@ -1,0 +1,82 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/market_data.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace flox::venue
+{
+
+class ItchCodec
+{
+ public:
+  static constexpr size_t kSize = 1 + 8 + 4 + 8 + 1 + 8 + 8 + 8;  // 46 bytes
+
+  static void encode(const MdMessage& m, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    out.reserve(kSize);
+    put(out, static_cast<uint8_t>(m.type), 1);
+    put(out, m.seq, 8);
+    put(out, m.symbol, 4);
+    put(out, m.id, 8);
+    put(out, static_cast<uint8_t>(m.side), 1);
+    put(out, static_cast<uint64_t>(m.price.raw()), 8);
+    put(out, static_cast<uint64_t>(m.qty.raw()), 8);
+    put(out, m.makerId, 8);
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdMessage& m)
+  {
+    if (n < kSize)
+    {
+      return false;
+    }
+    size_t o = 0;
+    m.type = static_cast<MdType>(p[o]);
+    o += 1;
+    m.seq = get(p + o, 8);
+    o += 8;
+    m.symbol = static_cast<SymbolId>(get(p + o, 4));
+    o += 4;
+    m.id = get(p + o, 8);
+    o += 8;
+    m.side = static_cast<Side>(p[o]);
+    o += 1;
+    m.price = Price::fromRaw(static_cast<int64_t>(get(p + o, 8)));
+    o += 8;
+    m.qty = Quantity::fromRaw(static_cast<int64_t>(get(p + o, 8)));
+    o += 8;
+    m.makerId = get(p + o, 8);
+    return true;
+  }
+
+ private:
+  static void put(std::vector<uint8_t>& o, uint64_t v, int bytes)
+  {
+    for (int i = bytes - 1; i >= 0; --i)
+    {
+      o.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xFF));
+    }
+  }
+  static uint64_t get(const uint8_t* p, int bytes)
+  {
+    uint64_t v = 0;
+    for (int i = 0; i < bytes; ++i)
+    {
+      v = (v << 8) | p[i];
+    }
+    return v;
+  }
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/journal.h
+++ b/venue/include/flox-venue/journal.h
@@ -1,0 +1,125 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace flox::venue
+{
+
+static_assert(std::is_trivially_copyable_v<NewOrder>, "NewOrder must be blittable");
+static_assert(std::is_trivially_copyable_v<CancelOrder>, "CancelOrder must be blittable");
+static_assert(std::is_trivially_copyable_v<ModifyOrder>, "ModifyOrder must be blittable");
+static_assert(std::is_trivially_copyable_v<MassCancel>, "MassCancel must be blittable");
+static_assert(std::is_trivially_copyable_v<Quote>, "Quote must be blittable");
+static_assert(std::is_trivially_copyable_v<LastLookDecision>, "LastLookDecision must be blittable");
+static_assert(std::is_trivially_copyable_v<SetMark>, "SetMark must be blittable");
+static_assert(std::is_trivially_copyable_v<ApplyFunding>, "ApplyFunding must be blittable");
+static_assert(std::is_trivially_copyable_v<AdminCmd>, "AdminCmd must be blittable");
+
+class Journal
+{
+ public:
+  explicit Journal(const std::string& path)
+      : out_(path, std::ios::binary | std::ios::trunc)
+  {
+  }
+
+  void append(const InboundCommand& c) { append(c, 0); }
+
+  // Write-ahead record: [ts:8][tag:1][command bytes]. The sequencer timestamp is
+  // journaled so replay reproduces last-look / MMP / LULD timing exactly.
+  void append(const InboundCommand& c, int64_t tsNs)
+  {
+    out_.write(reinterpret_cast<const char*>(&tsNs), 8);
+    const uint8_t tag = static_cast<uint8_t>(c.index());  // variant alternative index
+    out_.write(reinterpret_cast<const char*>(&tag), 1);
+    std::visit([&](const auto& v)
+               { out_.write(reinterpret_cast<const char*>(&v), sizeof(v)); }, c);
+    ++count_;
+  }
+
+  void flush() { out_.flush(); }
+  uint64_t count() const noexcept { return count_; }
+
+  static std::vector<InboundCommand> load(const std::string& path)
+  {
+    std::vector<InboundCommand> v;
+    for (auto& [ts, cmd] : loadTimed(path))
+    {
+      (void)ts;
+      v.push_back(cmd);
+    }
+    return v;
+  }
+
+  // Replay records with their sequencer timestamps (for exact timing replay).
+  static std::vector<std::pair<int64_t, InboundCommand>> loadTimed(const std::string& path)
+  {
+    std::ifstream in(path, std::ios::binary);
+    std::vector<std::pair<int64_t, InboundCommand>> v;
+    int64_t ts;
+    uint8_t tag;
+    auto readInto = [&](auto proto)
+    {
+      in.read(reinterpret_cast<char*>(&proto), sizeof(proto));
+      v.emplace_back(ts, InboundCommand{proto});
+    };
+    while (in.read(reinterpret_cast<char*>(&ts), 8) && in.read(reinterpret_cast<char*>(&tag), 1))
+    {
+      switch (tag)
+      {
+        case 0:
+          readInto(NewOrder{});
+          break;
+        case 1:
+          readInto(CancelOrder{});
+          break;
+        case 2:
+          readInto(ModifyOrder{});
+          break;
+        case 3:
+          readInto(MassCancel{});
+          break;
+        case 4:
+          readInto(Quote{});
+          break;
+        case 5:
+          readInto(LastLookDecision{});
+          break;
+        case 6:
+          readInto(SetMark{});
+          break;
+        case 7:
+          readInto(ApplyFunding{});
+          break;
+        case 8:
+          readInto(AdminCmd{});
+          break;
+        default:
+          return v;  // unknown tag -> stop
+      }
+    }
+    return v;
+  }
+
+ private:
+  std::ofstream out_;
+  uint64_t count_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/ledger.h
+++ b/venue/include/flox-venue/ledger.h
@@ -32,6 +32,45 @@ using Amount = __int128;  // raw 1e-8 units
 inline Amount amountOf(Volume v) { return static_cast<Amount>(v.raw()); }
 inline Amount amountOf(Quantity q) { return static_cast<Amount>(q.raw()); }
 
+// Money is always at this scale (1e-8 units of the asset), regardless of any
+// symbol's price/qty scale. A base-asset balance is the symbol's qty raw, so
+// every symbol sharing a base asset must use one qtyScale.
+inline constexpr int64_t kMoneyScale = 100'000'000;
+
+inline constexpr Amount kAmountMax = static_cast<Amount>(~static_cast<unsigned __int128>(0) >> 1);
+inline constexpr Amount kAmountMin = -kAmountMax - 1;
+
+// kMoneyScale and qtyScale must divide one another exactly (any power-of-ten
+// scale qualifies); priceScale only needs to be positive.
+inline constexpr bool scalesValid(int64_t priceScale, int64_t qtyScale)
+{
+  return priceScale > 0 && qtyScale > 0 &&
+         (qtyScale <= kMoneyScale ? kMoneyScale % qtyScale == 0 : qtyScale % kMoneyScale == 0);
+}
+
+// price x quantity, each raw in the symbol's own scale, -> Amount raw at
+// kMoneyScale. Generalizes the fixed-scale `praw * qraw / Price::Scale`
+// (bit-identical to it at the default 1e8/1e8, so determinism hashes are
+// unchanged). Signed; truncates toward zero exactly like the expression it
+// replaces. Multiply-before-divide keeps sub-quote-unit precision when
+// qtyScale is coarser than money (a meme-coin at qtyScale 1); the overflow
+// guard falls back to divide-first for magnitudes past ~1e22 quote units,
+// where the lost remainder is meaningless but signed overflow would be UB.
+inline Amount notionalRaw(int64_t priceRaw, int64_t qtyRaw, int64_t priceScale, int64_t qtyScale)
+{
+  const Amount prod = static_cast<Amount>(priceRaw) * qtyRaw;
+  if (qtyScale <= kMoneyScale)
+  {
+    const Amount mul = kMoneyScale / qtyScale;
+    if (prod > kAmountMax / mul || prod < kAmountMin / mul)
+    {
+      return prod / priceScale * mul;
+    }
+    return prod * mul / priceScale;
+  }
+  return prod / (static_cast<Amount>(priceScale) * (qtyScale / kMoneyScale));
+}
+
 class Ledger
 {
  public:

--- a/venue/include/flox-venue/ledger.h
+++ b/venue/include/flox-venue/ledger.h
@@ -1,0 +1,130 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Account ledger / settlement (real money). A double-entry, multi-asset balance
+ * store: every account holds, per asset, an `available` and a `reserved`
+ * balance (raw fixed-point, 1e-8 units, 128-bit to avoid notional overflow).
+ *
+ * Order entry reserves buying power (quote for a bid, base for an ask); a fill
+ * settles it -- base and quote change hands, fees are debited; a cancel releases
+ * the remainder. Value is conserved: sum of all balances only changes by
+ * deposits/withdrawals and fee capture. This is what makes it a venue that
+ * moves real money rather than a matching toy.
+ */
+#pragma once
+
+#include "flox/common.h"
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace flox::venue
+{
+
+using AssetId = uint16_t;
+using Amount = __int128;  // raw 1e-8 units
+
+inline Amount amountOf(Volume v) { return static_cast<Amount>(v.raw()); }
+inline Amount amountOf(Quantity q) { return static_cast<Amount>(q.raw()); }
+
+class Ledger
+{
+ public:
+  void deposit(uint64_t account, AssetId asset, Amount raw) { bal(account, asset).avail += raw; }
+
+  Amount available(uint64_t account, AssetId asset) const
+  {
+    const Bal* b = find(account, asset);
+    return b ? b->avail : 0;
+  }
+  Amount reserved(uint64_t account, AssetId asset) const
+  {
+    const Bal* b = find(account, asset);
+    return b ? b->rsvd : 0;
+  }
+  Amount total(uint64_t account, AssetId asset) const
+  {
+    const Bal* b = find(account, asset);
+    return b ? b->avail + b->rsvd : 0;
+  }
+
+  // available -> reserved; fails (no change) if insufficient available.
+  bool reserve(uint64_t account, AssetId asset, Amount raw)
+  {
+    Bal& b = bal(account, asset);
+    if (b.avail < raw)
+    {
+      return false;
+    }
+    b.avail -= raw;
+    b.rsvd += raw;
+    return true;
+  }
+
+  // reserved -> available (e.g. on cancel of the unfilled remainder).
+  void release(uint64_t account, AssetId asset, Amount raw)
+  {
+    Bal& b = bal(account, asset);
+    const Amount m = raw < b.rsvd ? raw : b.rsvd;
+    b.rsvd -= m;
+    b.avail += m;
+  }
+
+  // Remove `raw` from reserved (it was paid out on a fill).
+  void spendReserved(uint64_t account, AssetId asset, Amount raw)
+  {
+    Bal& b = bal(account, asset);
+    b.rsvd -= raw;
+  }
+
+  void credit(uint64_t account, AssetId asset, Amount raw) { bal(account, asset).avail += raw; }
+
+  // Enumerate every (account, asset, total) balance -- for reconciliation and
+  // segregation reporting (compliance). Not on the hot path.
+  template <class Fn>
+  void forEachBalance(Fn&& fn) const
+  {
+    for (const auto& [k, b] : bal_)
+    {
+      fn(k >> 16, static_cast<AssetId>(k & 0xFFFF), b.avail + b.rsvd);
+    }
+  }
+
+  // Debit available directly (market taker leg / fee with no prior reservation).
+  bool debit(uint64_t account, AssetId asset, Amount raw)
+  {
+    Bal& b = bal(account, asset);
+    if (b.avail < raw)
+    {
+      return false;
+    }
+    b.avail -= raw;
+    return true;
+  }
+
+ private:
+  struct Bal
+  {
+    Amount avail{0};
+    Amount rsvd{0};
+  };
+  static uint64_t key(uint64_t account, AssetId asset)
+  {
+    return (account << 16) | asset;  // account uses low 48 bits in practice
+  }
+  Bal& bal(uint64_t account, AssetId asset) { return bal_[key(account, asset)]; }
+  const Bal* find(uint64_t account, AssetId asset) const
+  {
+    auto it = bal_.find(key(account, asset));
+    return it == bal_.end() ? nullptr : &it->second;
+  }
+
+  std::unordered_map<uint64_t, Bal> bal_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/liquidation_monitor.h
+++ b/venue/include/flox-venue/liquidation_monitor.h
@@ -1,0 +1,87 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include "flox/backtest/liquidation_engine.h"
+
+#include <cmath>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace flox::venue
+{
+
+class LiquidationMonitor
+{
+ public:
+  LiquidationMonitor(SymbolId symbol, double mmFraction, double insuranceCapital = 0.0)
+      : symbol_(symbol)
+  {
+    engine_.addTier(0.0, mmFraction);
+    engine_.setInsuranceFundCapital(insuranceCapital);
+  }
+
+  void openPosition(uint64_t account, double signedQty, double entry, double equity,
+                    double multiplier = 1.0)
+  {
+    flox::LeveragedPosition p;
+    p.accountId = account;
+    p.symbol = symbol_;
+    p.quantity = signedQty;  // + long, - short
+    p.entryPrice = entry;
+    p.equity = equity;
+    p.contractMultiplier = multiplier;
+    engine_.openPosition(p);
+    pos_[account] = p;
+  }
+
+  // Feed a new mark price; returns closing MARKET orders for every account the
+  // flox engine liquidated (already removed from the monitor's book).
+  std::vector<NewOrder> onMark(double mark)
+  {
+    const flox::LiquidationOutcome outcome = engine_.onMark(symbol_, mark);
+    std::vector<NewOrder> orders;
+    for (uint64_t acct : outcome.liquidated)
+    {
+      auto it = pos_.find(acct);
+      if (it == pos_.end())
+      {
+        continue;
+      }
+      const flox::LeveragedPosition p = it->second;
+      NewOrder o;
+      o.id = (++liqSeq_) | kLiqBit;  // synthetic liquidation order id
+      o.symbol = symbol_;
+      o.side = p.quantity > 0 ? Side::SELL : Side::BUY;  // close long -> sell
+      o.type = OrderType::MARKET;
+      o.quantity = Quantity::fromDouble(std::abs(p.quantity));
+      o.accountId = acct;
+      orders.push_back(o);
+      engine_.closePosition(acct, symbol_);
+      pos_.erase(it);
+    }
+    return orders;
+  }
+
+  double insuranceFundBalance() const { return engine_.insuranceFundBalance(); }
+  size_t openPositions() const { return pos_.size(); }
+
+ private:
+  static constexpr OrderId kLiqBit = 0x8000000000000000ULL;
+
+  SymbolId symbol_;
+  flox::LiquidationEngine engine_;
+  std::unordered_map<uint64_t, flox::LeveragedPosition> pos_;
+  uint64_t liqSeq_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/mark_feed_driver.h
+++ b/venue/include/flox-venue/mark_feed_driver.h
@@ -1,0 +1,78 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/index_feed.h"
+#include "flox-venue/messages.h"
+
+#include <cstdint>
+
+namespace flox::venue
+{
+
+template <class Risk>
+class MarkFeedDriver
+{
+ public:
+  MarkFeedDriver(IndexAggregator& idx, MarkPrice& mark, Risk& risk, SymbolId sym, int32_t clampBps)
+      : idx_(idx), mark_(mark), risk_(risk), sym_(sym), clampBps_(clampBps)
+  {
+    (void)clampBps_;  // MarkPrice already holds its clamp; kept for symmetry/config
+  }
+
+  // Update the mark from the current feed. `lastTradeRaw`/`impactMidRaw` are the
+  // perp's own signals (0 = unavailable). Returns true if a fresh mark was
+  // published; false if the feed was stale and liquidations were paused.
+  bool onTick(int64_t nowNs, int64_t lastTradeRaw, int64_t impactMidRaw)
+  {
+    if (!idx_.hasIndex(nowNs))
+    {
+      risk_.setLiquidationsPaused(true);  // feed outage -> freeze liquidations
+      paused_ = true;
+      return false;
+    }
+    if (paused_)
+    {
+      risk_.setLiquidationsPaused(false);  // feed recovered
+      paused_ = false;
+    }
+    mark_.setIndex(idx_.index(nowNs));
+    if (impactMidRaw > 0)
+    {
+      mark_.setMid(Price::fromRaw(impactMidRaw));
+    }
+    if (lastTradeRaw > 0)
+    {
+      mark_.setLast(Price::fromRaw(lastTradeRaw));
+    }
+    risk_.setMark(sym_, mark_.value());
+    lastPublishNs_ = nowNs;
+    return true;
+  }
+
+  bool paused() const noexcept { return paused_; }
+
+  // Age of the last published mark (ns); -1 before the first publish. Feed this
+  // into Gauges::markPriceAgeNs for the feed-lag alert.
+  int64_t markAgeNs(int64_t nowNs) const noexcept
+  {
+    return lastPublishNs_ < 0 ? -1 : nowNs - lastPublishNs_;
+  }
+
+ private:
+  IndexAggregator& idx_;
+  MarkPrice& mark_;
+  Risk& risk_;
+  SymbolId sym_;
+  int32_t clampBps_;
+  bool paused_{false};
+  int64_t lastPublishNs_{-1};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/market_data.h
+++ b/venue/include/flox-venue/market_data.h
@@ -1,0 +1,233 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include "flox/book/book_update.h"
+#include "flox/book/events/book_update_event.h"
+#include "flox/book/nlevel_order_book.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory_resource>
+#include <unordered_map>
+#include <utility>
+
+namespace flox::venue
+{
+
+enum class MdType : uint8_t
+{
+  AddOrder,
+  Trade,
+  Executed,
+  Cancel,
+  Replace,
+  Triggered,
+};
+
+struct MdMessage
+{
+  MdType type{};
+  uint64_t seq{};
+  SymbolId symbol{};
+  OrderId id{};  // subject order; for Trade this is the taker
+  Side side{};
+  Price price{};
+  Quantity qty{};     // AddOrder: shown qty; Trade: exec qty; Executed/Replace: leaves
+  OrderId makerId{};  // Trade only
+};
+
+template <size_t Levels = (1u << 16)>
+class MarketDataPublisher
+{
+ public:
+  using MdSink = std::function<void(const MdMessage&)>;
+
+  MarketDataPublisher(MdSink sink, Price tickSize, SymbolId symbol)
+      : sink_(std::move(sink)), symbol_(symbol), book_(tickSize)
+  {
+  }
+
+  void onEvent(const OutboundEvent& e)
+  {
+    if (const auto* x = std::get_if<OrderAccepted>(&e))
+    {
+      onAccepted(*x);
+    }
+    else if (const auto* x = std::get_if<Trade>(&e))
+    {
+      onTrade(*x);
+    }
+    else if (const auto* x = std::get_if<OrderExecuted>(&e))
+    {
+      onExecuted(*x);
+    }
+    else if (const auto* x = std::get_if<OrderCanceled>(&e))
+    {
+      onCanceled(*x);
+    }
+    else if (const auto* x = std::get_if<OrderModified>(&e))
+    {
+      onModified(*x);
+    }
+    else if (const auto* x = std::get_if<OrderTriggered>(&e))
+    {
+      onTriggered(*x);
+    }
+    // OrderRejected: no market impact
+  }
+
+  // flox NLevelOrderBook: bestBid/bestAsk, bidAtPrice/askAtPrice, consumeAsks/
+  // consumeBids (VWAP sweep), isCrossed, spread, mid.
+  const flox::NLevelOrderBook<Levels>& book() const noexcept { return book_; }
+  uint64_t seq() const noexcept { return seq_; }
+
+  // Full book snapshot as AddOrder messages -- a late-joining subscriber applies
+  // these, then resumes the incremental feed from `seq()`.
+  std::vector<MdMessage> snapshot() const
+  {
+    std::vector<MdMessage> out;
+    out.reserve(orders_.size());
+    for (const auto& [id, r] : orders_)
+    {
+      out.push_back(MdMessage{MdType::AddOrder, 0, r.symbol, id, r.side, r.price, r.leaves, 0});
+    }
+    return out;
+  }
+
+ private:
+  struct Resting
+  {
+    SymbolId symbol{};
+    Side side{};
+    Price price{};
+    Quantity leaves{};
+  };
+
+  Quantity atPrice(Side s, Price p) const
+  {
+    return s == Side::BUY ? book_.bidAtPrice(p) : book_.askAtPrice(p);
+  }
+
+  // Apply a single absolute-qty level delta to the flox depth book.
+  void applyLevel(Side s, Price p, Quantity newAggregate)
+  {
+    ev_.clear();
+    ev_.update.type = flox::BookUpdateType::DELTA;
+    ev_.update.symbol = symbol_;
+    if (s == Side::BUY)
+    {
+      ev_.update.bids.emplace_back(p, newAggregate);
+    }
+    else
+    {
+      ev_.update.asks.emplace_back(p, newAggregate);
+    }
+    book_.applyBookUpdate(ev_);
+  }
+
+  void emit(MdMessage m)
+  {
+    m.seq = ++seq_;
+    sink_(m);
+  }
+
+  void onAccepted(const OrderAccepted& a)
+  {
+    if (!a.restingOnBook)
+    {
+      return;  // pending stop: not on the visible book
+    }
+    // Public depth shows only the displayed size; an iceberg's hidden reserve is
+    // never leaked (displayQty carries the peak, 0 -> non-iceberg, use leavesQty).
+    const Quantity shown = a.displayQty.raw() > 0 ? a.displayQty : a.leavesQty;
+    orders_[a.id] = Resting{a.symbol, a.side, a.price, shown};
+    applyLevel(a.side, a.price, atPrice(a.side, a.price) + shown);
+    emit(MdMessage{MdType::AddOrder, 0, a.symbol, a.id, a.side, a.price, shown, 0});
+  }
+
+  void onTrade(const Trade& t)
+  {
+    // Depth reduction is done via the maker's OrderExecuted; the print itself
+    // does not touch depth (avoids double counting).
+    emit(MdMessage{MdType::Trade, 0, t.symbol, t.takerId, t.takerSide, t.price, t.quantity,
+                   t.makerId});
+  }
+
+  void onExecuted(const OrderExecuted& x)
+  {
+    auto it = orders_.find(x.id);
+    if (it == orders_.end())
+    {
+      return;  // taker leg (not resting) -- ignore
+    }
+    Resting& r = it->second;
+    // Use the DISPLAYED remaining, never the whole (peak+hidden) leavesQty -- else
+    // an iceberg's hidden reserve leaks onto the public feed and a partial peak
+    // fill (leavesQty > displayed) would fail to reduce depth / underflow the
+    // level. r.leaves tracks the shown size; drive it from displayLeaves.
+    const Quantity shownAfter = x.displayLeaves;
+    const int64_t levelDelta = shownAfter.raw() - r.leaves.raw();
+    if (levelDelta != 0)
+    {
+      applyLevel(r.side, r.price, Quantity::fromRaw(atPrice(r.side, r.price).raw() + levelDelta));
+    }
+    r.leaves = shownAfter;
+    emit(MdMessage{MdType::Executed, 0, r.symbol, x.id, r.side, r.price, shownAfter, 0});
+    if (x.complete)
+    {
+      orders_.erase(it);
+    }
+  }
+
+  void onCanceled(const OrderCanceled& c)
+  {
+    auto it = orders_.find(c.id);
+    if (it == orders_.end())
+    {
+      return;  // pending stop / unknown
+    }
+    const Resting r = it->second;
+    applyLevel(r.side, r.price, atPrice(r.side, r.price) - r.leaves);
+    orders_.erase(it);
+    emit(MdMessage{MdType::Cancel, 0, r.symbol, c.id, r.side, r.price, r.leaves, 0});
+  }
+
+  void onModified(const OrderModified& m)
+  {
+    auto it = orders_.find(m.id);
+    if (it == orders_.end())
+    {
+      return;
+    }
+    Resting& r = it->second;
+    applyLevel(r.side, r.price, atPrice(r.side, r.price) - r.leaves);  // remove old
+    r.price = m.price;
+    r.leaves = m.leavesQty;
+    applyLevel(r.side, r.price, atPrice(r.side, r.price) + m.leavesQty);  // add new
+    emit(MdMessage{MdType::Replace, 0, r.symbol, m.id, r.side, m.price, m.leavesQty, 0});
+  }
+
+  void onTriggered(const OrderTriggered& t)
+  {
+    emit(MdMessage{MdType::Triggered, 0, t.symbol, t.id, Side::BUY, t.refPrice, Quantity{}, 0});
+  }
+
+  MdSink sink_;
+  SymbolId symbol_{};
+  flox::NLevelOrderBook<Levels> book_;
+  std::pmr::memory_resource* res_ = std::pmr::new_delete_resource();
+  flox::BookUpdateEvent ev_{res_};
+  std::unordered_map<OrderId, Resting> orders_;
+  uint64_t seq_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/matcher.h
+++ b/venue/include/flox-venue/matcher.h
@@ -1,0 +1,392 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/event_sink.h"
+#include "flox-venue/messages.h"
+#include "flox/book/resting_order.h"
+
+#include <algorithm>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace flox::venue
+{
+
+enum class MatchPolicy : uint8_t
+{
+  PriceTimeFifo = 0,
+  ProRata = 1,  // TODO: thick-level distribution for derivatives
+};
+
+struct MatchOutcome
+{
+  Quantity filled{};
+  Quantity leaves{};
+  bool takerComplete{false};
+  RejectReason reject{RejectReason::None};  // nothing filled when set
+  bool residualRests{false};                // GTC limit remainder should rest
+  bool residualCanceled{false};             // IOC / MARKET / STP remainder killed
+  CancelReason residualCancelReason{CancelReason::UserRequested};
+};
+
+namespace detail
+{
+inline Quantity qmin(Quantity a, Quantity b) noexcept { return (a < b) ? a : b; }
+inline Side opposite(Side s) noexcept { return s == Side::BUY ? Side::SELL : Side::BUY; }
+
+// Self-trade-prevention scope is resolved per Matcher via account->firm-group
+// membership (Matcher::stpScope); account-level STP is the default when no group
+// is registered.
+
+inline bool crosses(Side takerSide, Price takerPrice, OrderType type, Price restingPrice) noexcept
+{
+  if (type == OrderType::MARKET)
+  {
+    return true;
+  }
+  return takerSide == Side::BUY ? takerPrice >= restingPrice : takerPrice <= restingPrice;
+}
+}  // namespace detail
+
+template <class Book>
+class Matcher
+{
+ public:
+  explicit Matcher(MatchPolicy policy = MatchPolicy::PriceTimeFifo) noexcept : policy_(policy) {}
+
+  using LastLookHook = std::function<void(const RestingOrder& maker, Quantity fill,
+                                          const NewOrder& taker)>;
+  void setLastLookHook(LastLookHook hook) { onLastLook_ = std::move(hook); }
+
+  // Firm-group STP: map an account to a firm/group id so self-trade prevention
+  // fires across all accounts of the same firm, not just the same account.
+  void setStpGroup(uint64_t account, uint64_t group) { stpGroup_[account] = group; }
+
+  MatchOutcome cross(const NewOrder& order, Book& book,
+                     const std::function<uint64_t()>& nextTradeId, const EventSink& sink) const
+  {
+    if (policy_ == MatchPolicy::ProRata)
+    {
+      return crossProRata(order, book, nextTradeId, sink);
+    }
+    using namespace detail;
+    MatchOutcome out;
+    const Side restingSide = opposite(order.side);
+    const bool isMarket = order.type == OrderType::MARKET;
+
+    // POST_ONLY: must never take. Reject outright if the opposite top crosses.
+    if (order.postOnly)
+    {
+      if (RestingOrder* top = book.peekBest(restingSide);
+          top && crosses(order.side, order.price, order.type, top->price))
+      {
+        out.reject = RejectReason::PostOnlyWouldCross;
+        return out;
+      }
+    }
+
+    // FOK: all-or-none. Precheck crossable liquidity before touching the book.
+    // With STP on, exclude same-scope liquidity: it will be canceled/decremented
+    // rather than traded, so it cannot fill the FOK -- counting it would let the
+    // FOK pass the precheck and then rest with 0 fills after STP removes it.
+    if (order.tif == TimeInForce::FOK)
+    {
+      const Quantity avail =
+          (order.stp == STPMode::None)
+              ? book.availableWithin(order.side, order.price, isMarket)
+              : book.availableWithinExcl(order.side, order.price, isMarket, [&](uint64_t maker)
+                                         { return stpScope(maker) == stpScope(order.accountId); });
+      if (avail < order.quantity)
+      {
+        out.reject = RejectReason::FillOrKillUnfulfillable;
+        return out;
+      }
+    }
+
+    Quantity leaves = order.quantity;
+    bool takerCanceledBySTP = false;
+
+    while (!leaves.isZero())
+    {
+      RestingOrder* m = book.peekBest(restingSide);
+      if (m == nullptr || !crosses(order.side, order.price, order.type, m->price))
+      {
+        break;
+      }
+
+      if (order.stp != STPMode::None && stpScope(m->accountId) == stpScope(order.accountId))
+      {
+        switch (order.stp)
+        {
+          case STPMode::CancelOldest:
+            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention});
+            book.cancel(m->id);
+            continue;
+          case STPMode::CancelNewest:
+            takerCanceledBySTP = true;
+            break;
+          case STPMode::CancelBoth:
+            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention});
+            book.cancel(m->id);
+            takerCanceledBySTP = true;
+            break;
+          case STPMode::Decrement:
+          {
+            // Cancel the smaller leg fully; reduce the larger by the smaller qty.
+            // No trade occurs. (Iceberg reserve is ignored for STP.)
+            const Quantity restTotal = m->leaves;
+            const Quantity dec = qmin(leaves, restTotal);
+            if (!(dec < restTotal))  // resting <= incoming: resting fully removed
+            {
+              sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention});
+              book.cancel(m->id);
+            }
+            else  // incoming smaller: reduce resting, incoming fully decremented
+            {
+              book.reduce(m->id, Quantity::fromRaw(restTotal.raw() - dec.raw()));
+            }
+            leaves = Quantity::fromRaw(leaves.raw() - dec.raw());
+            if (leaves.isZero())
+            {
+              takerCanceledBySTP = true;
+              break;
+            }
+            continue;  // incoming still has qty: re-peek next maker
+          }
+          case STPMode::None:
+            break;
+        }
+        if (takerCanceledBySTP)
+        {
+          break;
+        }
+      }
+
+      // Only the displayed peak is executable per bite; the book refills the
+      // hidden reserve (and re-queues at the tail) inside fillBest.
+      // Last look: the maker holds this fill pending its decision. Reserve the
+      // hit size out of the book and hand it to the engine; no trade yet.
+      if (m->lastLook && onLastLook_)
+      {
+        const Quantity heldQty = qmin(leaves, m->leaves);
+        onLastLook_(*m, heldQty, order);
+        book.fillBest(restingSide, heldQty);
+        leaves -= heldQty;
+        continue;
+      }
+
+      const Quantity fill = qmin(leaves, m->leaves);
+      const OrderId makerId = m->id;
+      const uint64_t makerAccount = m->accountId;
+      const Price makerPrice = m->price;
+      // Total (displayed + hidden) remaining after this fill -- so an iceberg
+      // reports leaves/complete against its whole size, not just the peak.
+      const Quantity makerTotalAfter = (m->leaves + m->hidden) - fill;
+      // Displayed peak remaining (for the public feed): a partial peak fill leaves
+      // (peak - fill) shown; a full-peak lift refills to min(peak, hidden). Must
+      // be read before fillBest, which refills/re-queues and may invalidate `m`.
+      const Quantity makerDisplayAfter =
+          (fill < m->leaves) ? (m->leaves - fill) : qmin(m->peak, m->hidden);
+
+      sink(Trade{nextTradeId(), order.symbol, makerPrice, fill, makerId, order.id, order.side,
+                 makerAccount, order.accountId});
+
+      book.fillBest(restingSide, fill);  // may invalidate `m`
+      leaves -= fill;
+      out.filled += fill;
+
+      sink(OrderExecuted{makerId, order.symbol, fill, makerTotalAfter, false,
+                         makerTotalAfter.isZero(), makerPrice, makerDisplayAfter});
+      sink(OrderExecuted{order.id, order.symbol, fill, leaves, true, leaves.isZero(), makerPrice,
+                         leaves});
+    }
+
+    out.leaves = leaves;
+
+    if (takerCanceledBySTP)
+    {
+      out.residualCanceled = true;
+      out.residualCancelReason = CancelReason::SelfTradePrevention;
+    }
+    else if (leaves.isZero())
+    {
+      out.takerComplete = true;
+    }
+    else if (isMarket)
+    {
+      out.residualCanceled = true;
+      out.residualCancelReason = CancelReason::MarketResidual;
+    }
+    else if (order.tif == TimeInForce::IOC)
+    {
+      out.residualCanceled = true;
+      out.residualCancelReason = CancelReason::ImmediateOrCancelResidual;
+    }
+    else if (order.tif == TimeInForce::FOK)
+    {
+      // All-or-none: a FOK that did not fully fill must be killed, never rest.
+      // The STP-aware precheck above should already have rejected it pre-match;
+      // this is the safety net so a FOK residual can never become a resting GTC.
+      out.residualCanceled = true;
+      out.residualCancelReason = CancelReason::FillOrKillResidual;
+    }
+    else
+    {
+      out.residualRests = true;  // GTC / GTD / POST_ONLY that did not cross
+    }
+
+    return out;
+  }
+
+ private:
+  // Self-trade-prevention scope of an account: its firm group if registered,
+  // else the account itself (identity -- account-level STP). Fast path when no
+  // groups are configured.
+  uint64_t stpScope(uint64_t account) const
+  {
+    if (stpGroup_.empty())
+    {
+      return account;
+    }
+    auto it = stpGroup_.find(account);
+    return it == stpGroup_.end() ? account : it->second;
+  }
+
+  // Pro-rata matching: at each crossing level distribute the aggressor across all
+  // resting orders proportionally to size (deterministic floor + FIFO remainder),
+  // for instruments with thick display levels. Scope: no
+  // iceberg refill and STP treated as None on pro-rata instruments.
+  MatchOutcome crossProRata(const NewOrder& order, Book& book,
+                            const std::function<uint64_t()>& nextTradeId,
+                            const EventSink& sink) const
+  {
+    using namespace detail;
+    MatchOutcome out;
+    const Side restingSide = opposite(order.side);
+    const bool isMarket = order.type == OrderType::MARKET;
+
+    if (order.postOnly)
+    {
+      if (RestingOrder* top = book.peekBest(restingSide);
+          top && crosses(order.side, order.price, order.type, top->price))
+      {
+        out.reject = RejectReason::PostOnlyWouldCross;
+        return out;
+      }
+    }
+    if (order.tif == TimeInForce::FOK)
+    {
+      if (book.availableWithin(order.side, order.price, isMarket) < order.quantity)
+      {
+        out.reject = RejectReason::FillOrKillUnfulfillable;
+        return out;
+      }
+    }
+
+    Quantity leaves = order.quantity;
+    std::vector<RestingOrder> level;
+    while (!leaves.isZero())
+    {
+      RestingOrder* top = book.peekBest(restingSide);
+      if (top == nullptr || !crosses(order.side, order.price, order.type, top->price))
+      {
+        break;
+      }
+      const Price levelPrice = top->price;
+      book.bestLevel(restingSide, level);
+      if (level.empty())
+      {
+        break;
+      }
+      int64_t tot = 0;
+      for (const auto& o : level)
+      {
+        tot += o.leaves.raw();
+      }
+      const int64_t want = std::min<int64_t>(leaves.raw(), tot);
+
+      std::vector<int64_t> alloc(level.size(), 0);
+      int64_t assigned = 0;
+      for (size_t i = 0; i < level.size(); ++i)
+      {
+        alloc[i] = static_cast<int64_t>(static_cast<__int128>(want) * level[i].leaves.raw() / tot);
+        assigned += alloc[i];
+      }
+      int64_t leftover = want - assigned;  // deterministic FIFO remainder
+      for (size_t i = 0; i < level.size() && leftover > 0; ++i)
+      {
+        const int64_t room = level[i].leaves.raw() - alloc[i];
+        if (room > 0)
+        {
+          const int64_t add = std::min(room, leftover);
+          alloc[i] += add;
+          leftover -= add;
+        }
+      }
+
+      for (size_t i = 0; i < level.size(); ++i)
+      {
+        if (alloc[i] <= 0)
+        {
+          continue;
+        }
+        const Quantity fill = Quantity::fromRaw(alloc[i]);
+        const OrderId makerId = level[i].id;
+        // total (displayed + hidden) remaining, so an iceberg reports against
+        // its whole size; consumeById refills the peak and re-queues.
+        const Quantity makerTotalAfter =
+            Quantity::fromRaw(level[i].leaves.raw() + level[i].hidden.raw() - alloc[i]);
+        const Quantity makerDisplayAfter =
+            (fill < level[i].leaves) ? (level[i].leaves - fill) : qmin(level[i].peak, level[i].hidden);
+        sink(Trade{nextTradeId(), order.symbol, levelPrice, fill, makerId, order.id, order.side,
+                   level[i].accountId, order.accountId});
+        book.consumeById(makerId, fill);
+        leaves = Quantity::fromRaw(leaves.raw() - alloc[i]);
+        out.filled += fill;
+        sink(OrderExecuted{makerId, order.symbol, fill, makerTotalAfter, false,
+                           makerTotalAfter.isZero(), levelPrice, makerDisplayAfter});
+        sink(OrderExecuted{order.id, order.symbol, fill, leaves, true, leaves.isZero(), levelPrice,
+                           leaves});
+      }
+      if (want < tot)
+      {
+        break;  // level partially consumed; aggressor exhausted
+      }
+    }
+
+    out.leaves = leaves;
+    if (leaves.isZero())
+    {
+      out.takerComplete = true;
+    }
+    else if (isMarket)
+    {
+      out.residualCanceled = true;
+      out.residualCancelReason = CancelReason::MarketResidual;
+    }
+    else if (order.tif == TimeInForce::IOC)
+    {
+      out.residualCanceled = true;
+      out.residualCancelReason = CancelReason::ImmediateOrCancelResidual;
+    }
+    else
+    {
+      out.residualRests = true;
+    }
+    return out;
+  }
+
+  MatchPolicy policy_;
+  LastLookHook onLastLook_;
+  std::unordered_map<uint64_t, uint64_t> stpGroup_;  // account -> firm group (empty = account-level STP)
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/matching_engine.h
+++ b/venue/include/flox-venue/matching_engine.h
@@ -1,0 +1,2121 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/ledger.h"
+#include "flox-venue/matcher.h"
+#include "flox-venue/messages.h"
+#include "flox-venue/stop_book.h"
+#include "flox/book/matching_book.h"
+#include "flox/book/resting_order.h"
+
+#include "flox/backtest/fee_schedule.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+// Reference price a conditional order (stop / take-profit / trailing) triggers
+// against. Spot: last trade price. Derivatives: usually the mark price.
+enum class TriggerRef : uint8_t
+{
+  Last = 0,
+  Mark = 1,
+};
+
+struct SymbolConfig
+{
+  SymbolId id{};
+  Price tickSize{};           // 0 = unchecked
+  Quantity lotSize{};         // 0 = unchecked
+  Quantity minQty{};          // 0 = unchecked
+  Price minPrice{};           // 0 = unchecked (price band / collar lower bound)
+  Price maxPrice{};           // 0 = unchecked (price band / collar upper bound)
+  Quantity maxOrderQty{};     // 0 = unchecked (fat-finger max size)
+  Volume maxOrderNotional{};  // 0 = unchecked (fat-finger max notional, limit orders)
+  bool halted{false};
+  TriggerRef triggerRef{TriggerRef::Last};
+  int64_t lastLookWindowNs{0};          // 0 = last look disabled venue-wide
+  bool lastLookAcceptOnTimeout{false};  // window elapses with no decision -> accept vs reject
+  AssetId baseAsset{0};                 // e.g. BTC in BTC-USD (settled to the seller/buyer)
+  AssetId quoteAsset{1};                // e.g. USD in BTC-USD
+  int32_t luldBps{0};                   // limit-up/limit-down band around the reference (0 = off)
+  int64_t luldHaltNs{0};                // trading pause on a band breach
+  bool linearPerp{false};               // derivatives: linear perpetual (margin, no asset delivery)
+  int32_t initialMarginBps{0};          // IM as bps of notional (1000 = 10% = 10x leverage)
+  int32_t maintenanceMarginBps{0};      // MM; position liquidated when equity < MM (0 = off)
+  bool autoDeleverage{false};           // ADL: recover a bankruptcy deficit from winners before insurance
+  Quantity maxPositionQty{};            // 0 = unchecked (max |position| per account, perp risk cap)
+  uint32_t maxOpenOrders{0};            // 0 = unchecked (max live resting orders per account)
+};
+
+template <class Book = MatchingBook>
+class MatchingEngine
+{
+ public:
+  MatchingEngine(SymbolConfig cfg, EventSink sink, Book book = Book{},
+                 MatchPolicy policy = MatchPolicy::PriceTimeFifo)
+      : cfg_(cfg), sink_(std::move(sink)), matcher_(policy), book_(std::move(book))
+  {
+    // Wrap the user sink to observe the trade stream (last price for stops,
+    // fees, MM-protection counters) and maintain per-account resting state.
+    emit_ = [this](const OutboundEvent& e)
+    {
+      if (const auto* t = std::get_if<Trade>(&e))
+      {
+        lastPrice_ = t->price;
+        hasLast_ = true;
+        onTradeObserved(*t);
+      }
+      else if (const auto* x = std::get_if<OrderExecuted>(&e))
+      {
+        if (x->complete)
+        {
+          releaseReservation(x->id);  // free any over-reserved remainder
+          forgetOrder(x->id);
+        }
+      }
+      else if (const auto* c = std::get_if<OrderCanceled>(&e))
+      {
+        releaseReservation(c->id);
+        forgetOrder(c->id);
+      }
+      sink_(e);
+      if (const auto* t = std::get_if<Trade>(&e))
+      {
+        settleTrade(*t);  // move base/quote + fees; emits FeeCharged via sink_
+      }
+    };
+
+    // Last look: the matcher hands each held fill here.
+    matcher_.setLastLookHook([this](const RestingOrder& maker, Quantity fill, const NewOrder& taker)
+                             { createHeld(maker, fill, taker); });
+  }
+
+  void submit(const InboundCommand& cmd) { submit(cmd, ++timeCounter_); }
+
+  // Timestamped submit (sequencer-stamped). Drives last-look expiry and MMP
+  // windows deterministically.
+  void submit(const InboundCommand& cmd, int64_t tsNs)
+  {
+    now_ = tsNs;
+    if (cfg_.halted && haltUntil_ > 0 && now_ >= haltUntil_)
+    {
+      cfg_.halted = false;  // timed LULD volatility pause elapsed
+      haltUntil_ = 0;
+    }
+    expireHolds();
+    expireOrders();
+    if (const auto* n = std::get_if<NewOrder>(&cmd))
+    {
+      onNew(*n);
+    }
+    else if (const auto* c = std::get_if<CancelOrder>(&cmd))
+    {
+      onCancel(*c);
+    }
+    else if (const auto* m = std::get_if<ModifyOrder>(&cmd))
+    {
+      onModify(*m);
+    }
+    else if (const auto* mc = std::get_if<MassCancel>(&cmd))
+    {
+      onMassCancel(*mc);
+    }
+    else if (const auto* q = std::get_if<Quote>(&cmd))
+    {
+      onQuote(*q);
+    }
+    else if (const auto* ll = std::get_if<LastLookDecision>(&cmd))
+    {
+      onLastLookDecision(*ll);
+    }
+    else if (const auto* sm = std::get_if<SetMark>(&cmd))
+    {
+      setMarkPrice(sm->mark);  // sequenced -> journaled -> replayed (liquidations reproduce)
+    }
+    else if (const auto* af = std::get_if<ApplyFunding>(&cmd))
+    {
+      applyFunding(af->rate, af->mark);
+    }
+    else if (const auto* ad = std::get_if<AdminCmd>(&cmd))
+    {
+      onAdmin(ad->action);  // sequenced -> journaled -> replayed (auction/halt reproduce)
+    }
+    processOco();
+    repeg();
+    mmpEnforce();
+  }
+
+  void setFeeSchedule(flox::FeeSchedule fees)
+  {
+    fees_ = std::move(fees);
+    feesEnabled_ = true;
+  }
+
+  // Market-maker protection: if `qtyLimit` is filled for `account` within
+  // `windowNs`, all its resting orders are pulled.
+  void setMmp(uint64_t account, Quantity qtyLimit, int64_t windowNs)
+  {
+    mmpCfg_[account] = MmpCfg{qtyLimit, windowNs};
+  }
+
+  // Pre-trade credit / buying-power gate. Returns true if the account may place
+  // the order. A real deployment binds this to the account/balance service.
+  using CreditCheck = std::function<bool(uint64_t account, Side, Price, Quantity)>;
+  void setCreditCheck(CreditCheck c) { credit_ = std::move(c); }
+
+  // Bind a settlement ledger. When set, order entry reserves buying power
+  // (quote for a bid, base for an ask), fills settle base<->quote and fees, and
+  // cancels release the remainder. `venueAccount` receives net fees.
+  void setLedger(Ledger* ledger, uint64_t venueAccount = 0)
+  {
+    ledger_ = ledger;
+    venueAccount_ = venueAccount;
+  }
+
+  // Perp position queries (signed contracts; average entry).
+  int64_t positionQty(uint64_t account) const
+  {
+    auto it = positions_.find(account);
+    return it == positions_.end() ? 0 : it->second.qtyRaw;
+  }
+  Price positionEntry(uint64_t account) const
+  {
+    auto it = positions_.find(account);
+    return it == positions_.end() ? Price{} : Price::fromRaw(it->second.entryRaw);
+  }
+
+  // Live resting orders tracked on this symbol (observability gauge).
+  uint64_t restingOrderCount() const noexcept { return orderAccount_.size(); }
+
+  struct OrderView
+  {
+    OrderId id{};
+    Side side{};
+    Price price{};
+    Quantity leaves{};  // total remaining (displayed + hidden)
+  };
+  struct PendingStopView
+  {
+    OrderId id{};
+    Side side{};
+    OrderType type{};
+    Price trigger{};
+    Quantity quantity{};
+  };
+  struct AccountSnapshot
+  {
+    std::vector<OrderView> openOrders;
+    std::vector<PendingStopView> pendingStops;  // conditional orders not yet triggered
+    int64_t positionQty{0};                     // signed perp contracts (0 for spot / flat)
+    Price positionEntry{};
+  };
+
+  // Client reconnect reconciliation: the account's live resting orders and perp
+  // position. Balances come from the ledger; combine at the gateway. Off the
+  // hot path (a query, not order flow).
+  AccountSnapshot snapshotAccount(uint64_t acct) const
+  {
+    AccountSnapshot s;
+    if (auto it = byAccount_.find(acct); it != byAccount_.end())
+    {
+      for (OrderId id : it->second)
+      {
+        if (const RestingOrder* r = book_.find(id))
+        {
+          s.openOrders.push_back(
+              {id, r->side, r->price, Quantity::fromRaw(r->leaves.raw() + r->hidden.raw())});
+        }
+      }
+    }
+    stops_.forEachPending(
+        [&](const NewOrder& o, Price trigger)
+        {
+          if (o.accountId == acct)
+          {
+            s.pendingStops.push_back({o.id, o.side, o.type, trigger, o.quantity});
+          }
+        });
+    s.positionQty = positionQty(acct);
+    s.positionEntry = positionEntry(acct);
+    return s;
+  }
+
+  // Total posted position margin across accounts (quote raw). After all resting
+  // orders are drained, this must equal the ledger's total reserved -- every
+  // reserved unit is backed by either a live order or an open position.
+  Amount totalPositionMargin() const
+  {
+    Amount t = 0;
+    for (const auto& [acct, p] : positions_)
+    {
+      (void)acct;
+      t += p.margin;
+    }
+    return t;
+  }
+
+  // Apply a funding payment (perps): each position transfers |notional|*rate
+  // to/from the clearing pool -- longs pay when rate > 0. `mark` values the leg.
+  void applyFunding(double rate, Price mark)
+  {
+    if (ledger_ == nullptr)
+    {
+      return;
+    }
+    for (auto& [acct, p] : positions_)
+    {
+      const __int128 notional =
+          static_cast<__int128>(mark.raw()) * iabs64(p.qtyRaw) / static_cast<__int128>(Price::Scale);
+      const Amount mag = static_cast<Amount>(static_cast<double>(notional) * rate);
+      const Amount signedPay = (p.qtyRaw > 0) ? -mag : mag;  // long pays when rate>0
+      ledger_->credit(acct, cfg_.quoteAsset, signedPay);
+      ledger_->credit(venueAccount_, cfg_.quoteAsset, -signedPay);
+    }
+    // Funding is charged to the wallet (`available`); when a max-leverage payer
+    // has no free collateral, that drives `available` negative, which the
+    // wallet-drag term in checkLiquidations now counts against maintenance
+    // equity -- so an unaffordable funding payment triggers liquidation instead
+    // of accruing silent bad debt.
+    checkLiquidations(mark);
+  }
+
+  // External mark-price update (derivatives). Drives mark-referenced stops and
+  // maintenance-margin liquidations.
+  void setMarkPrice(Price mark)
+  {
+    markPrice_ = mark;
+    hasMark_ = true;
+    processTriggers();
+    checkLiquidations(mark);
+  }
+
+  // Unrealized PnL of an account's perp position marked at `mark` (quote raw).
+  Amount unrealizedPnlRaw(uint64_t account, Price mark) const
+  {
+    auto it = positions_.find(account);
+    if (it == positions_.end())
+    {
+      return 0;
+    }
+    const int64_t sign = it->second.qtyRaw > 0 ? 1 : -1;
+    return static_cast<Amount>(static_cast<__int128>(mark.raw() - it->second.entryRaw) *
+                               iabs64(it->second.qtyRaw) / static_cast<__int128>(Price::Scale) * sign);
+  }
+
+  const Book& book() const noexcept { return book_; }
+  uint64_t tradesGenerated() const noexcept { return tradeSeq_; }
+
+  const SymbolConfig& config() const noexcept { return cfg_; }
+  void setHalted(bool halted) noexcept { cfg_.halted = halted; }  // control-plane hook
+
+  // Live risk-limit adjustment (control-plane): operators tighten these during
+  // volatility without a restart. Only the risk knobs are mutable -- structural
+  // fields (symbol id, tick size, assets, linearPerp) stay fixed. Applies to
+  // subsequent orders; existing resting orders are unaffected.
+  void setLuldBps(int32_t bps) noexcept { cfg_.luldBps = bps; }
+  void setFatFinger(Quantity maxOrderQty, Volume maxOrderNotional) noexcept
+  {
+    cfg_.maxOrderQty = maxOrderQty;
+    cfg_.maxOrderNotional = maxOrderNotional;
+  }
+  void setPositionLimit(Quantity maxPositionQty) noexcept { cfg_.maxPositionQty = maxPositionQty; }
+  void setMaxOpenOrders(uint32_t n) noexcept { cfg_.maxOpenOrders = n; }
+  void setMarginBps(int32_t initialBps, int32_t maintenanceBps) noexcept
+  {
+    cfg_.initialMarginBps = initialBps;
+    cfg_.maintenanceMarginBps = maintenanceBps;
+  }
+
+  // Firm-group STP: register an account under a firm/group id so self-trade
+  // prevention fires across all of a firm's accounts, not just the same account.
+  void setStpGroup(uint64_t account, uint64_t group) { matcher_.setStpGroup(account, group); }
+
+  // Operator emergency stop: halt the symbol (reject new orders) AND pull the
+  // entire resting book -- every live limit order and pending conditional --
+  // releasing reservations. Used on a fat-finger event or system anomaly.
+  void haltAndCancelAll()
+  {
+    cfg_.halted = true;
+    std::vector<OrderId> resting;
+    for (const auto& [acct, ids] : byAccount_)
+    {
+      (void)acct;
+      resting.insert(resting.end(), ids.begin(), ids.end());
+    }
+    std::sort(resting.begin(), resting.end());  // deterministic cancel order (layout-independent)
+    for (OrderId id : resting)
+    {
+      if (book_.cancel(id).has_value())
+      {
+        releaseReservation(id);
+        forgetOrder(id);
+        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt});
+      }
+    }
+    for (OrderId id : stops_.ids())
+    {
+      if (stops_.cancel(id))
+      {
+        releaseReservation(id);
+        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt});
+      }
+    }
+  }
+
+  // ---- session / auctions ----
+  // Pre-open: orders accumulate without matching (a crossed book is allowed).
+  void beginPreOpen() noexcept { auctionMode_ = true; }
+
+  // Dispatch a sequenced operator action (see AdminCmd). Routing admin actions
+  // through the command stream (not direct method calls) is what makes them
+  // survive journal replay / HA -- the auction uncross fills and the emergency
+  // cancel-all are reproduced at the same point relative to the orders.
+  void onAdmin(AdminAction a)
+  {
+    switch (a)
+    {
+      case AdminAction::BeginPreOpen:
+        beginPreOpen();
+        break;
+      case AdminAction::OpenContinuous:
+        openContinuous();
+        break;
+      case AdminAction::ResumeAuction:
+        resumeWithAuction();
+        break;
+      case AdminAction::HaltAndCancelAll:
+        haltAndCancelAll();
+        break;
+      case AdminAction::Halt:
+        setHalted(true);
+        break;
+      case AdminAction::Resume:
+        setHalted(false);
+        break;
+    }
+  }
+
+  // Resume a halted symbol through a re-opening auction: clear the halt (stop
+  // rejecting) and enter pre-open accumulation. Orders build a (possibly crossed)
+  // book without matching until the operator calls openContinuous(), which
+  // uncrosses at the single volume-maximizing price and switches to continuous.
+  // This is how venues reopen after a halt -- never straight into continuous.
+  void resumeWithAuction() noexcept
+  {
+    cfg_.halted = false;
+    haltUntil_ = 0;
+    auctionMode_ = true;
+  }
+  // Run the (opening / closing) uncross auction: match everything at the single
+  // volume-maximizing price, then resume continuous trading.
+  void openContinuous()
+  {
+    runAuction();
+    auctionMode_ = false;
+  }
+  // Explicit uncross without changing session mode (closing auction, etc.).
+  void runAuction()
+  {
+    std::vector<std::pair<Price, Quantity>> bids;
+    std::vector<std::pair<Price, Quantity>> asks;
+    book_.levels(Side::BUY, bids);
+    book_.levels(Side::SELL, asks);
+    if (bids.empty() || asks.empty())
+    {
+      return;
+    }
+    // Candidate prices = every distinct order price. Pick the one maximizing
+    // executable volume; tie-break on smallest demand/supply imbalance.
+    std::vector<Price> cands;
+    for (const auto& b : bids)
+    {
+      cands.push_back(b.first);
+    }
+    for (const auto& a : asks)
+    {
+      cands.push_back(a.first);
+    }
+    std::sort(cands.begin(), cands.end(), [](Price x, Price y)
+              { return x.raw() < y.raw(); });
+    cands.erase(std::unique(cands.begin(), cands.end(),
+                            [](Price x, Price y)
+                            { return x.raw() == y.raw(); }),
+                cands.end());
+
+    bool have = false;
+    Price bestP{};
+    Quantity bestExec{};
+    __int128 bestImb = 0;
+    for (Price p : cands)
+    {
+      Quantity dem{};
+      for (const auto& b : bids)
+      {
+        if (!(b.first < p))
+        {
+          dem += b.second;  // bid price >= p
+        }
+      }
+      Quantity sup{};
+      for (const auto& a : asks)
+      {
+        if (!(p < a.first))
+        {
+          sup += a.second;  // ask price <= p
+        }
+      }
+      const Quantity exec = (dem < sup) ? dem : sup;
+      if (exec.raw() == 0)
+      {
+        continue;
+      }
+      __int128 imb = static_cast<__int128>(dem.raw()) - static_cast<__int128>(sup.raw());
+      if (imb < 0)
+      {
+        imb = -imb;
+      }
+      if (!have || bestExec < exec || (exec.raw() == bestExec.raw() && imb < bestImb))
+      {
+        have = true;
+        bestExec = exec;
+        bestP = p;
+        bestImb = imb;
+      }
+    }
+    if (!have)
+    {
+      return;
+    }
+
+    // Uncross at bestP: repeatedly match best bid vs best ask, all at bestP.
+    const Price P = bestP;
+    while (true)
+    {
+      RestingOrder* bid = book_.peekBest(Side::BUY);
+      RestingOrder* ask = book_.peekBest(Side::SELL);
+      if (bid == nullptr || ask == nullptr || bid->price < P || P < ask->price)
+      {
+        break;
+      }
+      const Quantity fill = (bid->leaves < ask->leaves) ? bid->leaves : ask->leaves;
+      const OrderId bidId = bid->id;
+      const OrderId askId = ask->id;
+      const uint64_t bAcct = bid->accountId;
+      const uint64_t aAcct = ask->accountId;
+      emit_(Trade{++tradeSeq_, cfg_.id, P, fill, askId, bidId, Side::BUY, aAcct, bAcct});
+      book_.consumeById(bidId, fill);
+      book_.consumeById(askId, fill);
+      const RestingOrder* b2 = book_.find(bidId);
+      const RestingOrder* a2 = book_.find(askId);
+      const Quantity bl = b2 ? Quantity::fromRaw(b2->leaves.raw() + b2->hidden.raw()) : Quantity{};
+      const Quantity al = a2 ? Quantity::fromRaw(a2->leaves.raw() + a2->hidden.raw()) : Quantity{};
+      // Post-consume displayed peak (b2/a2 already refilled) for the public feed.
+      const Quantity bDisp = b2 ? b2->leaves : Quantity{};
+      const Quantity aDisp = a2 ? a2->leaves : Quantity{};
+      emit_(OrderExecuted{bidId, cfg_.id, fill, bl, false, bl.isZero(), P, bDisp});
+      emit_(OrderExecuted{askId, cfg_.id, fill, al, false, al.isZero(), P, aDisp});
+    }
+  }
+
+ private:
+  RejectReason validate(const NewOrder& o) const
+  {
+    if (o.symbol != cfg_.id)
+    {
+      return RejectReason::UnknownSymbol;
+    }
+    if (cfg_.halted)
+    {
+      return RejectReason::Halted;
+    }
+    if (o.quantity.raw() <= 0)
+    {
+      return RejectReason::InvalidQuantity;
+    }
+    if (!cfg_.minQty.isZero() && o.quantity < cfg_.minQty)
+    {
+      return RejectReason::InvalidQuantity;
+    }
+    if (!cfg_.lotSize.isZero() && (o.quantity.raw() % cfg_.lotSize.raw()) != 0)
+    {
+      return RejectReason::LotSizeViolation;
+    }
+    if (!cfg_.maxOrderQty.isZero() && cfg_.maxOrderQty < o.quantity)
+    {
+      return RejectReason::OrderTooLarge;  // fat-finger size
+    }
+    if (o.type == OrderType::LIMIT && !cfg_.maxOrderNotional.isZero() &&
+        cfg_.maxOrderNotional < (o.quantity * o.price))
+    {
+      return RejectReason::OrderTooLarge;  // fat-finger notional
+    }
+    if (o.type == OrderType::LIMIT)
+    {
+      if (o.price.raw() <= 0)
+      {
+        return RejectReason::InvalidPrice;
+      }
+      if (!cfg_.tickSize.isZero() && (o.price.raw() % cfg_.tickSize.raw()) != 0)
+      {
+        return RejectReason::TickSizeViolation;
+      }
+      if (!cfg_.minPrice.isZero() && o.price < cfg_.minPrice)
+      {
+        return RejectReason::InvalidPrice;
+      }
+      if (!cfg_.maxPrice.isZero() && cfg_.maxPrice < o.price)
+      {
+        return RejectReason::InvalidPrice;
+      }
+    }
+    if (book_.contains(o.id) || stops_.contains(o.id))
+    {
+      return RejectReason::DuplicateOrderId;
+    }
+    return RejectReason::None;
+  }
+
+  // Per-order perp risk gates shared by onNew and the trigger path (a triggered
+  // stop re-enters matching directly, NOT through onNew, so it must run these too
+  // -- otherwise a reduce-only stop opens an uncollateralized position and a
+  // plain stop bypasses the position cap). Caps a reduce-only order to the
+  // opposing position (0 reducible -> reject: nothing to reduce) and rejects a
+  // fill that would breach maxPositionQty. Mutates o.quantity for the cap.
+  RejectReason perpRiskGate(NewOrder& o)
+  {
+    if (!cfg_.linearPerp)
+    {
+      return RejectReason::None;
+    }
+    if (o.reduceOnly)
+    {
+      const auto pit = positions_.find(o.accountId);
+      const int64_t posQ = (pit == positions_.end()) ? 0 : pit->second.qtyRaw;
+      const int64_t reducible = (o.side == Side::BUY && posQ < 0)    ? -posQ
+                                : (o.side == Side::SELL && posQ > 0) ? posQ
+                                                                     : 0;
+      if (o.quantity.raw() > reducible)
+      {
+        o.quantity = Quantity::fromRaw(reducible);
+      }
+      if (o.quantity.raw() <= 0)
+      {
+        return RejectReason::InvalidQuantity;  // nothing to reduce -> reduce-only never opens
+      }
+    }
+    if (!cfg_.maxPositionQty.isZero())
+    {
+      const auto pit = positions_.find(o.accountId);
+      const int64_t posQ = (pit == positions_.end()) ? 0 : pit->second.qtyRaw;
+      const int64_t worst = posQ + (o.side == Side::BUY ? o.quantity.raw() : -o.quantity.raw());
+      if (iabs64(worst) > cfg_.maxPositionQty.raw())
+      {
+        return RejectReason::PositionLimitExceeded;
+      }
+    }
+    return RejectReason::None;
+  }
+
+  void onNew(NewOrder o)
+  {
+    if (o.ocoGroup > 0)
+    {
+      orderOco_[o.id] = o.ocoGroup;  // link before matching so a taker fill triggers OCO too
+      ocoMembers_[o.ocoGroup].push_back(o.id);
+    }
+    // Any early exit before the order commits (parks as a stop, or passes every
+    // gate and reaches matching/resting) must unlink it from its OCO group --
+    // otherwise a rejected leg lingers in ocoMembers_ and later cancels a reused
+    // id. `committed` is set once the order is live; the guard cleans up the rest.
+    bool committed = false;
+    struct OcoCleanup
+    {
+      MatchingEngine* self;
+      OrderId id;
+      bool linked;
+      const bool* committed;
+      ~OcoCleanup()
+      {
+        if (linked && !*committed)
+        {
+          self->unlinkOco(id);
+        }
+      }
+    } ocoCleanup{this, o.id, o.ocoGroup > 0, &committed};
+    if (o.peg != PegRef::None)
+    {
+      o.type = OrderType::LIMIT;  // a peg is a passive limit priced off the book
+      o.price = Price::fromRaw(pegTargetRaw(o.side, o.peg, o.pegOffsetRaw));
+    }
+    if (isConditional(o.type))
+    {
+      committed = onStop(o);  // parked in the stop book -> committed (keep OCO link)
+      return;
+    }
+    if (cfg_.maxOpenOrders > 0)
+    {
+      // Ingress DoS / risk gate: cap live resting orders per account. Once at
+      // the cap the account must cancel before adding more.
+      auto it = byAccount_.find(o.accountId);
+      if (it != byAccount_.end() && it->second.size() >= cfg_.maxOpenOrders)
+      {
+        sink_(OrderRejected{o.id, o.symbol, RejectReason::TooManyOpenOrders});
+        return;
+      }
+    }
+    if (cfg_.linearPerp && o.reduceOnly)
+    {
+      // Cap a reduce-only order to the opposing position size (never increases;
+      // 0 -> rejected by validate as invalid quantity).
+      const auto pit = positions_.find(o.accountId);
+      const int64_t posQ = (pit == positions_.end()) ? 0 : pit->second.qtyRaw;
+      const int64_t reducible = (o.side == Side::BUY && posQ < 0)    ? -posQ
+                                : (o.side == Side::SELL && posQ > 0) ? posQ
+                                                                     : 0;
+      if (o.quantity.raw() > reducible)
+      {
+        o.quantity = Quantity::fromRaw(reducible);
+      }
+    }
+    if (const RejectReason r = validate(o); r != RejectReason::None)
+    {
+      sink_(OrderRejected{o.id, o.symbol, r});
+      return;
+    }
+    if (cfg_.linearPerp && !cfg_.maxPositionQty.isZero())
+    {
+      // Reject if a full fill would grow the account's position past the cap.
+      const auto pit = positions_.find(o.accountId);
+      const int64_t posQ = (pit == positions_.end()) ? 0 : pit->second.qtyRaw;
+      const int64_t worst = posQ + (o.side == Side::BUY ? o.quantity.raw() : -o.quantity.raw());
+      if (iabs64(worst) > cfg_.maxPositionQty.raw())
+      {
+        sink_(OrderRejected{o.id, o.symbol, RejectReason::PositionLimitExceeded});
+        return;
+      }
+    }
+    if (!reserveFunds(o))
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InsufficientFunds});
+      return;  // pre-trade buying-power (ledger reservation or credit hook)
+    }
+    committed = true;  // past all reject gates: the order will match/rest, and any
+                       // OCO resolution is now owned by processOco / forgetOrder.
+
+    if (auctionMode_)
+    {
+      // Pre-open / auction: accumulate without matching (a crossed book is
+      // allowed). Market orders rest at the band edge so they always execute in
+      // the uncross.
+      Price restPx = o.price;
+      if (o.type == OrderType::MARKET)
+      {
+        restPx = (o.side == Side::BUY) ? cfg_.maxPrice : cfg_.minPrice;
+      }
+      RestingOrder ro{o.id, o.accountId, restPx, o.quantity, o.side};
+      ro.reduceOnly = o.reduceOnly;
+      book_.addResting(o.side, ro);
+      trackResting(o.id, o.accountId);
+      sink_(OrderAccepted{o.id, o.symbol, o.side, restPx, o.quantity, true});
+      return;
+    }
+
+    if (cfg_.luldBps > 0 && hasLast_ && o.type != OrderType::MARKET)
+    {
+      // Compute the band in 128-bit to avoid int64 overflow on a high-priced
+      // instrument (raw * bps can exceed INT64_MAX), then clamp it so the upper
+      // = last + band addition below cannot overflow either. An oversized band
+      // just means "no breach possible", which degrades safely.
+      const __int128 prod =
+          static_cast<__int128>(lastPrice_.raw()) * static_cast<__int128>(cfg_.luldBps) / 10000;
+      const int64_t maxBand = INT64_MAX - lastPrice_.raw();
+      const int64_t band = prod > static_cast<__int128>(maxBand) ? maxBand : static_cast<int64_t>(prod);
+      const Price upper = Price::fromRaw(lastPrice_.raw() + band);
+      const Price lower = Price::fromRaw(lastPrice_.raw() - band);
+      if ((o.side == Side::BUY && upper < o.price) || (o.side == Side::SELL && o.price < lower))
+      {
+        releaseReservation(o.id);
+        sink_(OrderRejected{o.id, o.symbol, RejectReason::LuldBreach});
+        cfg_.halted = true;  // trip a timed volatility pause
+        haltUntil_ = now_ + cfg_.luldHaltNs;
+        return;
+      }
+    }
+
+    const MatchOutcome out =
+        matcher_.cross(o, book_, [this]()
+                       { return ++tradeSeq_; }, emit_);
+
+    if (out.reject != RejectReason::None)
+    {
+      releaseReservation(o.id);  // post-only-would-cross / FOK-unfulfillable: free the reserve
+      sink_(OrderRejected{o.id, o.symbol, out.reject});
+      return;
+    }
+    if (out.residualRests)
+    {
+      RestingOrder ro{o.id, o.accountId, o.price, out.leaves, o.side};
+      ro.lastLook = o.lastLook;
+      ro.reduceOnly = o.reduceOnly;  // carried so a later modify preserves it
+      if (o.visibleQuantity.raw() > 0 && o.visibleQuantity < out.leaves)
+      {
+        ro.peak = o.visibleQuantity;    // iceberg: show a peak, hide the rest
+        ro.leaves = o.visibleQuantity;  // displayed
+        ro.hidden = out.leaves - o.visibleQuantity;
+      }
+      book_.addResting(o.side, ro);
+      trackResting(o.id, o.accountId);
+      if (o.tif == TimeInForce::GTD && o.expiryNs > 0)
+      {
+        expiry_[o.id] = o.expiryNs;
+      }
+      if (o.peg != PegRef::None)
+      {
+        pegged_[o.id] = {o.side, o.peg, o.pegOffsetRaw};
+      }
+      // Public feed shows only the displayed peak (ro.leaves); the hidden iceberg
+      // reserve (out.leaves - ro.leaves) is not leaked. Non-iceberg: they match.
+      sink_(OrderAccepted{o.id, o.symbol, o.side, o.price, out.leaves, true, ro.leaves});
+    }
+    else if (out.residualCanceled)
+    {
+      // The unfilled residual (IOC/FOK/MARKET/STP-newest) never rests, so its
+      // buying-power reservation must be released here -- this raw-sink path does
+      // not run the emit_ wrapper's release-on-cancel.
+      releaseReservation(o.id);
+      sink_(OrderCanceled{o.id, o.symbol, out.residualCancelReason});
+    }
+
+    processTriggers();  // this order's trades may have crossed resting stops
+  }
+
+  // Conditional order (stop / take-profit / trailing): park in the stop book
+  // until the last-trade price crosses the trigger.
+  // Park a conditional (stop / take-profit / trailing) order. Returns true if it
+  // was accepted into the stop book, false if rejected -- the caller uses this to
+  // decide whether to keep or unlink an OCO group membership.
+  bool onStop(const NewOrder& o)
+  {
+    if (o.symbol != cfg_.id)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::UnknownSymbol});
+      return false;
+    }
+    if (cfg_.halted)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::Halted});
+      return false;
+    }
+    if (o.quantity.raw() <= 0)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidQuantity});
+      return false;
+    }
+    const bool trailing = (o.type == OrderType::TRAILING_STOP);
+    if (!trailing && o.triggerPrice.raw() <= 0)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice});
+      return false;
+    }
+    if (trailing && o.trailingOffset.raw() <= 0)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice});
+      return false;
+    }
+    if (isLimitStop(o.type) && o.price.raw() <= 0)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice});
+      return false;
+    }
+    if (book_.contains(o.id) || stops_.contains(o.id))
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::DuplicateOrderId});
+      return false;
+    }
+
+    Price initTrig{};
+    if (trailing)
+    {
+      if (hasLast_)
+      {
+        initTrig = (o.side == Side::SELL)
+                       ? Price::fromRaw(lastPrice_.raw() - o.trailingOffset.raw())
+                       : Price::fromRaw(lastPrice_.raw() + o.trailingOffset.raw());
+      }
+    }
+    else
+    {
+      initTrig = o.triggerPrice;
+    }
+    stops_.add(o, initTrig, trailing);
+    sink_(OrderAccepted{o.id, o.symbol, o.side, o.triggerPrice, o.quantity, false});  // pending, not on book
+    processTriggers();                                                                // may already be in-the-money
+    return true;
+  }
+
+  // Fire every stop the current last price crosses, cascading: each fired stop
+  // trades, which can move the last price and trigger further stops.
+  std::optional<Price> triggerReference() const
+  {
+    if (cfg_.triggerRef == TriggerRef::Mark)
+    {
+      return hasMark_ ? std::optional<Price>{markPrice_} : std::nullopt;
+    }
+    return hasLast_ ? std::optional<Price>{lastPrice_} : std::nullopt;
+  }
+
+  void processTriggers()
+  {
+    auto ref = triggerReference();
+    if (!ref)
+    {
+      return;
+    }
+    stops_.updateTrailing(*ref);
+    while (auto agg = stops_.popTriggered(*ref))
+    {
+      sink_(OrderTriggered{agg->id, cfg_.id, *ref});
+      // Perp risk gates: a triggered stop re-enters matching HERE, not through
+      // onNew, so it must run the same reduce-only cap + position-limit checks --
+      // else a reduce-only stop opens an uncollateralized (im=0) position and a
+      // plain stop bypasses maxPositionQty. Reject (and free nothing -- not yet
+      // reserved) if the reduce-only cap leaves nothing or the cap is breached.
+      if (const RejectReason r = perpRiskGate(*agg); r != RejectReason::None)
+      {
+        sink_(OrderRejected{agg->id, cfg_.id, r});
+        ref = triggerReference();
+        if (!ref)
+        {
+          break;
+        }
+        stops_.updateTrailing(*ref);
+        continue;
+      }
+      // Reserve buying power now that the stop is a live aggressor -- else an
+      // underfunded triggered stop would settle via unchecked debit and create
+      // value (buyer receives base it can't pay for).
+      if (!reserveFunds(*agg))
+      {
+        sink_(OrderRejected{agg->id, cfg_.id, RejectReason::InsufficientFunds});
+        ref = triggerReference();
+        if (!ref)
+        {
+          break;
+        }
+        stops_.updateTrailing(*ref);
+        continue;
+      }
+      const MatchOutcome out =
+          matcher_.cross(*agg, book_, [this]()
+                         { return ++tradeSeq_; }, emit_);
+      if (out.reject != RejectReason::None)
+      {
+        releaseReservation(agg->id);
+        sink_(OrderRejected{agg->id, cfg_.id, out.reject});
+      }
+      else if (out.residualRests)
+      {
+        RestingOrder rro{agg->id, agg->accountId, agg->price, out.leaves, agg->side};
+        rro.reduceOnly = agg->reduceOnly;
+        book_.addResting(agg->side, rro);
+        trackResting(agg->id, agg->accountId);
+        sink_(OrderAccepted{agg->id, cfg_.id, agg->side, agg->price, out.leaves, true});
+      }
+      else if (out.residualCanceled)
+      {
+        releaseReservation(agg->id);
+        sink_(OrderCanceled{agg->id, cfg_.id, out.residualCancelReason});
+      }
+      ref = triggerReference();  // trades may have moved the last-price reference
+      if (!ref)
+      {
+        break;
+      }
+      stops_.updateTrailing(*ref);
+    }
+  }
+
+  void onModify(const ModifyOrder& m)
+  {
+    if (m.symbol != cfg_.id)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownSymbol});
+      return;
+    }
+    const RestingOrder* cur = book_.find(m.id);
+    if (cur == nullptr)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownOrder});
+      return;
+    }
+    if (m.newQty.raw() <= 0)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidQuantity});
+      return;
+    }
+
+    const Side side = cur->side;
+    const uint64_t acct = cur->accountId;
+    const Quantity curLeaves = cur->leaves;
+    const Quantity curHidden = cur->hidden;
+    const bool curReduceOnly = cur->reduceOnly;
+    const Price curPrice = cur->price;
+    const Price newPrice = (m.newPrice.raw() == 0) ? curPrice : m.newPrice;
+
+    // Validate the new price/qty before mutating so a bad modify leaves the
+    // original order untouched.
+    if (newPrice.raw() <= 0)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice});
+      return;
+    }
+    if (!cfg_.tickSize.isZero() && (newPrice.raw() % cfg_.tickSize.raw()) != 0)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::TickSizeViolation});
+      return;
+    }
+    if (!cfg_.minPrice.isZero() && newPrice < cfg_.minPrice)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice});
+      return;
+    }
+    if (!cfg_.maxPrice.isZero() && cfg_.maxPrice < newPrice)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice});
+      return;
+    }
+    if (!cfg_.lotSize.isZero() && (m.newQty.raw() % cfg_.lotSize.raw()) != 0)
+    {
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::LotSizeViolation});
+      return;
+    }
+
+    // Same price and shrinking: reduce in place, keeping time priority. Release
+    // the reservation for the freed quantity (proportional -- works for spot
+    // quote/base and perp IM alike) so the trader regains that buying power.
+    // Iceberg orders are excluded: their `leaves` is only the displayed peak,
+    // not the full remaining (hidden reserve lives in `curHidden`), so neither
+    // the proportional release (denominator would be the peak, not the total)
+    // nor book_.reduce (leaves the hidden reserve resting) is correct here.
+    // They fall through to the re-enter path, which releases the full old
+    // reservation and re-reserves at the new quantity.
+    if (newPrice == curPrice && m.newQty <= curLeaves && curHidden.isZero())
+    {
+      book_.reduce(m.id, m.newQty);
+      if (ledger_ != nullptr && m.newQty < curLeaves)
+      {
+        if (auto it = reserve_.find(m.id); it != reserve_.end() && curLeaves.raw() > 0)
+        {
+          const Amount freed = static_cast<Amount>(static_cast<__int128>(it->second.reservedRaw) *
+                                                   (curLeaves.raw() - m.newQty.raw()) / curLeaves.raw());
+          ledger_->release(it->second.account, it->second.asset, freed);
+          it->second.reservedRaw -= freed;
+        }
+      }
+      sink_(OrderModified{m.id, m.symbol, newPrice, m.newQty, true});
+      return;
+    }
+
+    // Price change or size increase: re-enter at the tail (lost priority). The
+    // old reservation is released and buying power is RE-CHECKED at the new
+    // price/qty -- a reprice-up must not leave the order under-collateralized.
+    book_.cancel(m.id);
+    releaseReservation(m.id);
+    NewOrder re;
+    re.id = m.id;
+    re.symbol = cfg_.id;
+    re.side = side;
+    re.type = OrderType::LIMIT;
+    re.price = newPrice;
+    re.quantity = m.newQty;
+    re.tif = TimeInForce::GTC;
+    re.accountId = acct;
+    re.reduceOnly = curReduceOnly;  // preserve reduce-only across the modify
+
+    // Perp risk gate: a modified perp order re-enters matching HERE, not through
+    // onNew, so it must run the same reduce-only cap + position-cap checks (spot:
+    // perpRiskGate is a no-op). reduceOnly is carried from the resting record onto
+    // `re` above, so perpRiskGate re-caps it to the current position -- a modify
+    // can neither grow past maxPositionQty nor flip a reduce-only order.
+    if (const RejectReason r = perpRiskGate(re); r != RejectReason::None)
+    {
+      forgetOrder(m.id);  // order was already canceled above -> stays gone
+      sink_(OrderRejected{m.id, m.symbol, r});
+      return;
+    }
+    if (!reserveFunds(re))  // cannot fund the modified order -> reject; order is gone
+    {
+      forgetOrder(m.id);
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InsufficientFunds});
+      return;
+    }
+    const MatchOutcome out =
+        matcher_.cross(re, book_, [this]()
+                       { return ++tradeSeq_; }, emit_);
+    if (out.residualRests)
+    {
+      RestingOrder mro{m.id, acct, newPrice, out.leaves, side};
+      mro.reduceOnly = re.reduceOnly;
+      book_.addResting(side, mro);
+      trackResting(m.id, acct);
+    }
+    sink_(OrderModified{m.id, m.symbol, newPrice, out.leaves, false});
+    processTriggers();  // a reprice-into-cross may have moved the last price
+  }
+
+  void onCancel(const CancelOrder& c)
+  {
+    if (c.symbol != cfg_.id)
+    {
+      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownSymbol});
+      return;
+    }
+    if (book_.cancel(c.id).has_value())
+    {
+      releaseReservation(c.id);
+      forgetOrder(c.id);
+      sink_(OrderCanceled{c.id, c.symbol, CancelReason::UserRequested});
+    }
+    else if (stops_.cancel(c.id))
+    {
+      sink_(OrderCanceled{c.id, c.symbol, CancelReason::UserRequested});
+    }
+    else
+    {
+      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownOrder});
+    }
+  }
+
+  // ---- per-account resting-order tracking (mass-cancel / MMP) ----
+  void trackResting(OrderId id, uint64_t account)
+  {
+    orderAccount_[id] = account;
+    byAccount_[account].insert(id);
+  }
+  void forgetOrder(OrderId id)
+  {
+    auto it = orderAccount_.find(id);
+    if (it == orderAccount_.end())
+    {
+      return;
+    }
+    auto ba = byAccount_.find(it->second);
+    if (ba != byAccount_.end())
+    {
+      ba->second.erase(id);
+    }
+    orderAccount_.erase(it);
+    expiry_.erase(id);
+    unlinkOco(id);
+    pegged_.erase(id);
+  }
+
+  // Remove an order from its OCO group, keeping orderOco_ and ocoMembers_ in
+  // sync. The fill path (processOco) erases ocoMembers_ itself; EVERY other exit
+  // (cancel / expiry / MMP / halt / liquidation / reject) must route through
+  // here, or a departed leg lingers in ocoMembers_ and later cancels a reused
+  // OrderId when the surviving sibling resolves (and the group vector leaks).
+  void unlinkOco(OrderId id)
+  {
+    auto it = orderOco_.find(id);
+    if (it == orderOco_.end())
+    {
+      return;
+    }
+    if (auto gm = ocoMembers_.find(it->second); gm != ocoMembers_.end())
+    {
+      auto& v = gm->second;
+      v.erase(std::remove(v.begin(), v.end(), id), v.end());
+      if (v.empty())
+      {
+        ocoMembers_.erase(gm);
+      }
+    }
+    orderOco_.erase(it);
+  }
+  void cancelAllForAccount(uint64_t account, CancelReason reason = CancelReason::UserRequested)
+  {
+    auto it = byAccount_.find(account);
+    if (it == byAccount_.end())
+    {
+      return;
+    }
+    std::vector<OrderId> ids(it->second.begin(), it->second.end());  // copy: erased in loop
+    std::sort(ids.begin(), ids.end());                               // deterministic cancel/event order (layout-independent)
+    for (OrderId id : ids)
+    {
+      if (book_.cancel(id).has_value())
+      {
+        releaseReservation(id);
+        forgetOrder(id);
+        sink_(OrderCanceled{id, cfg_.id, reason});
+      }
+    }
+  }
+  void onMassCancel(const MassCancel& mc)
+  {
+    if (mc.symbol != 0 && mc.symbol != cfg_.id)
+    {
+      return;
+    }
+    cancelAllForAccount(mc.accountId);
+  }
+
+  // ---- two-sided market-maker quote (replace prior bid/ask) ----
+  void onQuote(const Quote& q)
+  {
+    if (q.symbol != cfg_.id)
+    {
+      return;
+    }
+    if (book_.cancel(q.bidId).has_value())
+    {
+      releaseReservation(q.bidId);
+      forgetOrder(q.bidId);
+      sink_(OrderCanceled{q.bidId, cfg_.id, CancelReason::UserRequested});
+    }
+    if (book_.cancel(q.askId).has_value())
+    {
+      releaseReservation(q.askId);
+      forgetOrder(q.askId);
+      sink_(OrderCanceled{q.askId, cfg_.id, CancelReason::UserRequested});
+    }
+    if (q.bidQty.raw() > 0)
+    {
+      NewOrder b;
+      b.id = q.bidId;
+      b.symbol = cfg_.id;
+      b.side = Side::BUY;
+      b.type = OrderType::LIMIT;
+      b.price = q.bidPrice;
+      b.quantity = q.bidQty;
+      b.accountId = q.accountId;
+      onNew(b);
+    }
+    if (q.askQty.raw() > 0)
+    {
+      NewOrder a;
+      a.id = q.askId;
+      a.symbol = cfg_.id;
+      a.side = Side::SELL;
+      a.type = OrderType::LIMIT;
+      a.price = q.askPrice;
+      a.quantity = q.askQty;
+      a.accountId = q.accountId;
+      onNew(a);
+    }
+  }
+
+  // ---- market-maker protection: pull all quotes on a fill-rate breach ----
+  void onTradeObserved(const Trade& t)
+  {
+    // Hot path: skip the per-trade hash lookups entirely unless MMP or OCO is
+    // actually in use (the common case is neither).
+    if (!mmpCfg_.empty())
+    {
+      mmpAdd(t.makerAccount, t.quantity);
+      mmpAdd(t.takerAccount, t.quantity);
+    }
+    // OCO: a fill on either side wins its group; sibling cancellation is deferred
+    // to after matching (processOco) so we never mutate the book mid-match.
+    if (!orderOco_.empty())
+    {
+      if (auto it = orderOco_.find(t.makerId); it != orderOco_.end())
+      {
+        ocoPending_.emplace_back(it->second, t.makerId);
+      }
+      if (auto it = orderOco_.find(t.takerId); it != orderOco_.end())
+      {
+        ocoPending_.emplace_back(it->second, t.takerId);
+      }
+    }
+  }
+  void mmpAdd(uint64_t account, Quantity qty)
+  {
+    auto cfg = mmpCfg_.find(account);
+    if (cfg == mmpCfg_.end())
+    {
+      return;
+    }
+    auto& dq = mmpFills_[account];
+    dq.emplace_back(now_, qty);
+    while (!dq.empty() && dq.front().first <= now_ - cfg->second.windowNs)
+    {
+      dq.pop_front();
+    }
+    Quantity sum{};
+    for (const auto& p : dq)
+    {
+      sum += p.second;
+    }
+    if (!(sum < cfg->second.qtyLimit))  // sum >= limit
+    {
+      bool queued = false;
+      for (uint64_t a : mmpBreached_)
+      {
+        queued |= (a == account);
+      }
+      if (!queued)
+      {
+        mmpBreached_.push_back(account);
+      }
+    }
+  }
+  void mmpEnforce()
+  {
+    for (uint64_t acc : mmpBreached_)
+    {
+      cancelAllForAccount(acc);
+      mmpFills_[acc].clear();  // re-arm
+      sink_(MmpTriggered{acc, cfg_.id});
+    }
+    mmpBreached_.clear();
+  }
+
+  // ---- fees ----
+  void emitFees(const Trade& t)
+  {
+    if (!feesEnabled_)
+    {
+      return;
+    }
+    const double notional = (t.price * t.quantity).toDouble();
+    sink_(FeeCharged{t.makerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, true)), true});
+    sink_(FeeCharged{t.takerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, false)), false});
+  }
+
+  // ---- settlement ledger ----
+  struct Reservation
+  {
+    uint64_t account{};
+    AssetId asset{};
+    Amount reservedRaw{};
+    int64_t limitPriceRaw{};
+    Side side{};
+  };
+
+  Amount imForRaw(int64_t qtyRaw, int64_t priceRaw) const
+  {
+    const __int128 notional = static_cast<__int128>(priceRaw) * qtyRaw / static_cast<__int128>(Price::Scale);
+    return static_cast<Amount>(notional * cfg_.initialMarginBps / 10000);
+  }
+
+  bool reserveFunds(const NewOrder& o)
+  {
+    if (ledger_ != nullptr && cfg_.linearPerp)
+    {
+      // Derivatives: reserve initial margin in quote collateral (reduce-only
+      // reserves nothing -- it frees position margin instead).
+      const int64_t limitRaw =
+          (o.type == OrderType::LIMIT) ? o.price.raw()
+                                       : (o.side == Side::BUY ? cfg_.maxPrice.raw() : cfg_.minPrice.raw());
+      // A market/stop order with no price band (limitRaw == 0) cannot be bounded
+      // for margin: reserving 0 IM would let it open a position with no
+      // collateral. Reject rather than admit an uncollateralized fill.
+      if (!o.reduceOnly && o.type != OrderType::LIMIT && limitRaw <= 0)
+      {
+        return false;
+      }
+      const Amount im = o.reduceOnly ? 0 : imForRaw(o.quantity.raw(), limitRaw);
+      if (im > 0 && !ledger_->reserve(o.accountId, cfg_.quoteAsset, im))
+      {
+        return false;
+      }
+      reserve_[o.id] = Reservation{o.accountId, cfg_.quoteAsset, im, limitRaw, o.side};
+      return true;
+    }
+    if (ledger_ != nullptr)
+    {
+      AssetId asset;
+      Amount amt;
+      int64_t limitRaw;
+      if (o.side == Side::BUY)
+      {
+        const Price px = (o.type == OrderType::LIMIT || cfg_.maxPrice.raw() == 0) ? o.price
+                                                                                  : cfg_.maxPrice;
+        // A market/stop buy with no price band (px == 0) cannot bound its quote
+        // spend, so reserving amountOf(0) would gate nothing and let the fill
+        // drive the account's reserved balance negative. Reject it instead.
+        if (px.raw() <= 0)
+        {
+          return false;
+        }
+        asset = cfg_.quoteAsset;
+        amt = amountOf(px * o.quantity);
+        limitRaw = px.raw();
+      }
+      else
+      {
+        asset = cfg_.baseAsset;
+        amt = amountOf(o.quantity);
+        limitRaw = o.price.raw();
+      }
+      if (!ledger_->reserve(o.accountId, asset, amt))
+      {
+        return false;
+      }
+      reserve_[o.id] = Reservation{o.accountId, asset, amt, limitRaw, o.side};
+      return true;
+    }
+    if (credit_)
+    {
+      return credit_(o.accountId, o.side, o.price, o.quantity);
+    }
+    return true;
+  }
+
+  void releaseReservation(OrderId id)
+  {
+    if (ledger_ == nullptr)
+    {
+      return;
+    }
+    auto it = reserve_.find(id);
+    if (it == reserve_.end())
+    {
+      return;
+    }
+    if (it->second.reservedRaw > 0)
+    {
+      ledger_->release(it->second.account, it->second.asset, it->second.reservedRaw);
+    }
+    reserve_.erase(it);
+  }
+
+  void settleTrade(const Trade& t)
+  {
+    if (ledger_ == nullptr)
+    {
+      emitFees(t);  // no settlement: fee events only
+      return;
+    }
+    if (cfg_.linearPerp)
+    {
+      settlePerp(t);
+      return;
+    }
+    const Amount notional = amountOf(t.price * t.quantity);
+    const Amount qtyRaw = amountOf(t.quantity);
+    const bool takerBuys = (t.takerSide == Side::BUY);
+    const OrderId buyerId = takerBuys ? t.takerId : t.makerId;
+    const uint64_t buyerAcct = takerBuys ? t.takerAccount : t.makerAccount;
+    const OrderId sellerId = takerBuys ? t.makerId : t.takerId;
+    const uint64_t sellerAcct = takerBuys ? t.makerAccount : t.takerAccount;
+
+    // Buyer: pay quote from reserved (refund over-reservation), receive base.
+    if (auto rb = reserve_.find(buyerId); rb != reserve_.end())
+    {
+      const Amount limitNotional = static_cast<Amount>(
+          static_cast<__int128>(rb->second.limitPriceRaw) * static_cast<__int128>(t.quantity.raw()) /
+          static_cast<__int128>(Price::Scale));
+      ledger_->spendReserved(buyerAcct, cfg_.quoteAsset, notional);
+      if (limitNotional > notional)
+      {
+        ledger_->release(buyerAcct, cfg_.quoteAsset, limitNotional - notional);
+      }
+      rb->second.reservedRaw -= limitNotional;
+    }
+    else
+    {
+      ledger_->debit(buyerAcct, cfg_.quoteAsset, notional);
+    }
+    ledger_->credit(buyerAcct, cfg_.baseAsset, qtyRaw);
+
+    // Seller: deliver base from reserved, receive quote.
+    if (auto rs = reserve_.find(sellerId); rs != reserve_.end())
+    {
+      ledger_->spendReserved(sellerAcct, cfg_.baseAsset, qtyRaw);
+      rs->second.reservedRaw -= qtyRaw;
+    }
+    else
+    {
+      ledger_->debit(sellerAcct, cfg_.baseAsset, qtyRaw);
+    }
+    ledger_->credit(sellerAcct, cfg_.quoteAsset, notional);
+
+    if (feesEnabled_)
+    {
+      const double notionalD = (t.price * t.quantity).toDouble();
+      chargeFee(t.makerId, t.makerAccount, fees_.feeFor(now_, notionalD, true), true);
+      chargeFee(t.takerId, t.takerAccount, fees_.feeFor(now_, notionalD, false), false);
+    }
+  }
+
+  void chargeFee(OrderId id, uint64_t acct, double feeD, bool maker)
+  {
+    const Amount fee = static_cast<Amount>(Volume::fromDouble(feeD).raw());
+    // Signed move: participant -fee, venue +fee (conserves value; fee<0 = rebate).
+    ledger_->credit(acct, cfg_.quoteAsset, -fee);
+    ledger_->credit(venueAccount_, cfg_.quoteAsset, fee);
+    sink_(FeeCharged{id, cfg_.id, Volume::fromDouble(feeD), maker});
+  }
+
+  // ---- linear-perp clearing ----
+  struct Position
+  {
+    int64_t qtyRaw{0};    // signed contracts (Quantity raw)
+    int64_t entryRaw{0};  // average entry price (Price raw)
+    Amount margin{0};     // posted position margin (quote raw), reserved in the ledger
+  };
+
+  static int64_t iabs64(int64_t v) { return v < 0 ? -v : v; }
+
+  // Move reserved IM for `qtyRaw` from the order reservation to position margin
+  // (stays reserved in the ledger; returns the amount).
+  Amount consumeOrderIM(OrderId orderId, int64_t qtyRaw)
+  {
+    auto it = reserve_.find(orderId);
+    if (it == reserve_.end())
+    {
+      return 0;
+    }
+    Amount im = imForRaw(qtyRaw, it->second.limitPriceRaw);
+    if (im > it->second.reservedRaw)
+    {
+      im = it->second.reservedRaw;
+    }
+    it->second.reservedRaw -= im;
+    return im;
+  }
+  // A reducing order's own reserved IM was not needed -> release it to available.
+  void releaseOrderIM(OrderId orderId, int64_t qtyRaw, uint64_t acct)
+  {
+    auto it = reserve_.find(orderId);
+    if (it == reserve_.end())
+    {
+      return;
+    }
+    Amount im = imForRaw(qtyRaw, it->second.limitPriceRaw);
+    if (im > it->second.reservedRaw)
+    {
+      im = it->second.reservedRaw;
+    }
+    it->second.reservedRaw -= im;
+    if (im > 0)
+    {
+      ledger_->release(acct, cfg_.quoteAsset, im);
+    }
+  }
+
+  void updatePerpPosition(uint64_t acct, OrderId orderId, bool fillBuy, int64_t qtyRaw,
+                          int64_t priceRaw)
+  {
+    Position& p = positions_[acct];
+    const int64_t fillSign = fillBuy ? 1 : -1;
+    int64_t remaining = qtyRaw;
+
+    const int64_t posSign = (p.qtyRaw > 0) ? 1 : (p.qtyRaw < 0 ? -1 : 0);
+    if (posSign != 0 && posSign != fillSign)
+    {
+      const int64_t reduceQty = std::min<int64_t>(remaining, iabs64(p.qtyRaw));
+      // realized PnL vs entry (long: (price-entry)*qty; short: (entry-price)*qty)
+      const __int128 pnl = static_cast<__int128>(priceRaw - p.entryRaw) * reduceQty /
+                           static_cast<__int128>(Price::Scale) * posSign;
+      ledger_->credit(acct, cfg_.quoteAsset, static_cast<Amount>(pnl));
+      ledger_->credit(venueAccount_, cfg_.quoteAsset, -static_cast<Amount>(pnl));
+      // release position margin for the reduced portion
+      const Amount relMargin =
+          static_cast<Amount>(static_cast<__int128>(p.margin) * reduceQty / iabs64(p.qtyRaw));
+      ledger_->release(acct, cfg_.quoteAsset, relMargin);
+      p.margin -= relMargin;
+      releaseOrderIM(orderId, reduceQty, acct);
+      p.qtyRaw += fillSign * reduceQty;  // toward zero
+      remaining -= reduceQty;
+      if (p.qtyRaw == 0)
+      {
+        p.entryRaw = 0;
+      }
+    }
+
+    if (remaining > 0)
+    {
+      const Amount im = consumeOrderIM(orderId, remaining);
+      const int64_t absOld = iabs64(p.qtyRaw);
+      const __int128 num = static_cast<__int128>(absOld) * p.entryRaw +
+                           static_cast<__int128>(remaining) * priceRaw;
+      p.entryRaw = static_cast<int64_t>(num / (absOld + remaining));
+      p.qtyRaw += fillSign * remaining;
+      p.margin += im;
+    }
+
+    if (p.qtyRaw == 0)
+    {
+      if (p.margin > 0)
+      {
+        ledger_->release(acct, cfg_.quoteAsset, p.margin);
+        p.margin = 0;
+      }
+      positions_.erase(acct);
+    }
+  }
+
+  void settlePerp(const Trade& t)
+  {
+    const bool takerBuys = (t.takerSide == Side::BUY);
+    const OrderId buyerId = takerBuys ? t.takerId : t.makerId;
+    const uint64_t buyerAcct = takerBuys ? t.takerAccount : t.makerAccount;
+    const OrderId sellerId = takerBuys ? t.makerId : t.takerId;
+    const uint64_t sellerAcct = takerBuys ? t.makerAccount : t.takerAccount;
+    updatePerpPosition(buyerAcct, buyerId, true, t.quantity.raw(), t.price.raw());
+    updatePerpPosition(sellerAcct, sellerId, false, t.quantity.raw(), t.price.raw());
+    if (feesEnabled_)
+    {
+      const double notionalD = (t.price * t.quantity).toDouble();
+      chargeFee(t.makerId, t.makerAccount, fees_.feeFor(now_, notionalD, true), true);
+      chargeFee(t.takerId, t.takerAccount, fees_.feeFor(now_, notionalD, false), false);
+    }
+  }
+
+  // Maintenance-margin sweep: liquidate every position whose equity (posted
+  // margin + unrealized PnL) has fallen below the maintenance requirement.
+  void checkLiquidations(Price mark)
+  {
+    if (ledger_ == nullptr || !cfg_.linearPerp || cfg_.maintenanceMarginBps == 0)
+    {
+      return;
+    }
+    std::vector<uint64_t> toLiq;
+    for (const auto& [acct, p] : positions_)
+    {
+      const Amount uPnl = unrealizedPnlRaw(acct, mark);
+      const __int128 notional =
+          static_cast<__int128>(mark.raw()) * iabs64(p.qtyRaw) / static_cast<__int128>(Price::Scale);
+      const Amount mmReq = static_cast<Amount>(notional * cfg_.maintenanceMarginBps / 10000);
+      // A negative wallet (funding/fees charged to `available` with no free
+      // collateral to absorb them) drags the maintenance-equity check: otherwise
+      // funding could push a max-leverage payer's wallet unboundedly negative
+      // with no liquidation (silent bad debt). A healthy (>=0) wallet stays
+      // isolated from the position, so positive balances never prevent an
+      // otherwise-due liquidation -- the drag only ever tightens the check.
+      const Amount wallet = ledger_->available(acct, cfg_.quoteAsset);
+      const Amount walletDrag = wallet < 0 ? wallet : 0;
+      if (p.margin + uPnl + walletDrag < mmReq)
+      {
+        toLiq.push_back(acct);
+      }
+    }
+    // Deterministic order: forceClose emits Liquidation events (folded into the
+    // determinism hash) and, with ADL on, shared counterparties make the close
+    // order matter -- it must not depend on positions_ (unordered_map) layout.
+    std::sort(toLiq.begin(), toLiq.end());
+    for (uint64_t a : toLiq)
+    {
+      forceClose(a, mark);
+    }
+  }
+
+  // Force-close a position at the mark price: realize PnL through the clearing
+  // pool, return posted margin, and let the insurance fund (venue account) cover
+  // any negative-equity (bankruptcy) deficit.
+  void forceClose(uint64_t acct, Price mark)
+  {
+    auto it = positions_.find(acct);
+    if (it == positions_.end())
+    {
+      return;
+    }
+    const Position p = it->second;
+    positions_.erase(it);
+    // Cancel the account's other resting orders first: their initial margin is
+    // locked in `reserved` and is the account's own collateral. Freeing it back
+    // to `available` before the bankruptcy test below ensures a total-equity-
+    // solvent account covers its own shortfall instead of the insurance fund
+    // paying out to it (a mis-socialization invisible to conservation-of-total).
+    cancelAllForAccount(acct, CancelReason::Liquidation);
+    const int64_t sign = p.qtyRaw > 0 ? 1 : -1;
+    const int64_t qtyAbs = iabs64(p.qtyRaw);
+    const Amount uPnl = static_cast<Amount>(static_cast<__int128>(mark.raw() - p.entryRaw) * qtyAbs /
+                                            static_cast<__int128>(Price::Scale) * sign);
+    ledger_->credit(acct, cfg_.quoteAsset, uPnl);
+    ledger_->credit(venueAccount_, cfg_.quoteAsset, -uPnl);
+    if (p.margin > 0)
+    {
+      ledger_->release(acct, cfg_.quoteAsset, p.margin);
+    }
+    bool bankrupt = false;
+    const Amount avail = ledger_->available(acct, cfg_.quoteAsset);
+    Amount deficit = 0;
+    if (avail < 0)
+    {
+      bankrupt = true;
+      deficit = -avail;
+      ledger_->credit(acct, cfg_.quoteAsset, -avail);  // insurance fund tops up to zero
+      ledger_->credit(venueAccount_, cfg_.quoteAsset, avail);
+    }
+    sink_(Liquidation{acct, cfg_.id, Quantity::fromRaw(qtyAbs), mark, bankrupt});
+    if (bankrupt && cfg_.autoDeleverage)
+    {
+      autoDeleverageEngine(sign, deficit, mark);  // claw the deficit back from winners
+    }
+  }
+
+  // Auto-deleverage the isolated-margin book: recover a bankruptcy deficit from
+  // the most profitable opposite-side positions (close at mark, haircut their
+  // gain into the insurance fund) instead of socializing it. Same model as the
+  // portfolio path (cross_margin.h); every ledger op stays balanced.
+  void autoDeleverageEngine(int64_t bankruptSign, Amount deficit, Price mark)
+  {
+    if (deficit <= 0)
+    {
+      return;
+    }
+    struct Cand
+    {
+      uint64_t acct;
+      Amount uPnl;
+    };
+    std::vector<Cand> cands;
+    for (const auto& [oa, pos] : positions_)
+    {
+      const int64_t s = pos.qtyRaw > 0 ? 1 : (pos.qtyRaw < 0 ? -1 : 0);
+      if (s == 0 || s == bankruptSign)
+      {
+        continue;  // opposite side only
+      }
+      const Amount up = static_cast<Amount>(static_cast<__int128>(mark.raw() - pos.entryRaw) *
+                                            pos.qtyRaw / static_cast<__int128>(Price::Scale));
+      if (up > 0)
+      {
+        cands.push_back({oa, up});
+      }
+    }
+    // Most profitable first; `acct` breaks ties deterministically so the chosen
+    // ADL victim (an emitted Liquidation, folded into the determinism hash) does
+    // not depend on positions_ iteration order or std::sort's instability.
+    std::sort(cands.begin(), cands.end(),
+              [](const Cand& x, const Cand& y)
+              { return x.uPnl != y.uPnl ? x.uPnl > y.uPnl : x.acct < y.acct; });
+
+    Amount remaining = deficit;
+    for (const auto& c : cands)
+    {
+      if (remaining <= 0)
+      {
+        break;
+      }
+      auto it = positions_.find(c.acct);
+      if (it == positions_.end())
+      {
+        continue;
+      }
+      const Position p = it->second;
+      positions_.erase(it);
+      const int64_t qtyAbs = iabs64(p.qtyRaw);
+      const Amount uPnl = static_cast<Amount>(static_cast<__int128>(mark.raw() - p.entryRaw) *
+                                              p.qtyRaw / static_cast<__int128>(Price::Scale));
+      ledger_->credit(c.acct, cfg_.quoteAsset, uPnl);  // realize gain at mark
+      ledger_->credit(venueAccount_, cfg_.quoteAsset, -uPnl);
+      if (p.margin > 0)
+      {
+        ledger_->release(c.acct, cfg_.quoteAsset, p.margin);
+      }
+      const Amount haircut = remaining < uPnl ? remaining : uPnl;
+      // Debit is all-or-nothing and `available` may be below the haircut, so
+      // credit the venue only what is actually confiscated -- otherwise the
+      // unconditional credit against a no-op debit mints money. Uncovered
+      // remainder falls to the insurance fund (normal ADL waterfall).
+      const Amount avail = ledger_->available(c.acct, cfg_.quoteAsset);
+      const Amount taken = std::min<Amount>(haircut, avail > 0 ? avail : 0);
+      if (taken > 0)
+      {
+        ledger_->debit(c.acct, cfg_.quoteAsset, taken);
+        ledger_->credit(venueAccount_, cfg_.quoteAsset, taken);
+      }
+      remaining -= taken;
+      sink_(Liquidation{c.acct, cfg_.id, Quantity::fromRaw(qtyAbs), mark, /*bankrupt*/ false,
+                        /*adl*/ true});
+    }
+  }
+
+  // ---- last look ----
+  struct Held
+  {
+    uint64_t id{};
+    OrderId taker{};
+    uint64_t takerAccount{};
+    Side takerSide{};
+    OrderId maker{};
+    uint64_t makerAccount{};
+    Price price{};
+    Quantity qty{};
+    int64_t deadline{};
+  };
+  void createHeld(const RestingOrder& maker, Quantity fill, const NewOrder& taker)
+  {
+    const uint64_t id = ++heldSeq_;
+    held_[id] = Held{id, taker.id, taker.accountId, taker.side, maker.id,
+                     maker.accountId, maker.price, fill, now_ + cfg_.lastLookWindowNs};
+    sink_(FillHeld{id, cfg_.id, maker.id, taker.id, maker.price, fill});
+    if (!book_.contains(maker.id))
+    {
+      forgetOrder(maker.id);
+    }
+  }
+  // Release one leg's buying-power reservation for a held quantity that will NOT
+  // trade (last-look reject / timeout). Mirrors the per-fill decrement settleTrade
+  // would have applied, but returns the funds to `available` instead of spending
+  // them -- so both parties are made whole for a fill that never happened, and no
+  // reservation is stranded in `reserved` forever. Cleans up a fully-released,
+  // no-longer-resting order's reservation + tracking maps.
+  void releaseHeldLeg(OrderId id, Quantity qty)
+  {
+    if (ledger_ == nullptr)
+    {
+      return;
+    }
+    auto it = reserve_.find(id);
+    if (it == reserve_.end())
+    {
+      return;
+    }
+    Amount rel;
+    if (cfg_.linearPerp)
+    {
+      rel = imForRaw(qty.raw(), it->second.limitPriceRaw);
+    }
+    else if (it->second.side == Side::BUY)
+    {
+      rel = static_cast<Amount>(static_cast<__int128>(it->second.limitPriceRaw) *
+                                static_cast<__int128>(qty.raw()) / static_cast<__int128>(Price::Scale));
+    }
+    else
+    {
+      rel = amountOf(qty);
+    }
+    if (rel > it->second.reservedRaw)
+    {
+      rel = it->second.reservedRaw;
+    }
+    if (rel > 0)
+    {
+      ledger_->release(it->second.account, it->second.asset, rel);
+    }
+    it->second.reservedRaw -= rel;
+    if (it->second.reservedRaw <= 0 && !book_.contains(id))
+    {
+      reserve_.erase(it);
+      forgetOrder(id);
+    }
+  }
+  void resolveHeld(typename std::unordered_map<uint64_t, Held>::iterator it, bool accept)
+  {
+    const Held h = it->second;
+    held_.erase(it);
+    if (accept)
+    {
+      emit_(Trade{++tradeSeq_, cfg_.id, h.price, h.qty, h.maker, h.taker, h.takerSide,
+                  h.makerAccount, h.takerAccount});
+      const RestingOrder* mk = book_.find(h.maker);
+      const Quantity makerLeaves = mk ? Quantity::fromRaw(mk->leaves.raw() + mk->hidden.raw()) : Quantity{};
+      const Quantity makerDisp = mk ? mk->leaves : Quantity{};  // displayed peak for public feed
+      emit_(OrderExecuted{h.maker, cfg_.id, h.qty, makerLeaves, false, makerLeaves.isZero(), h.price,
+                          makerDisp});
+      emit_(OrderExecuted{h.taker, cfg_.id, h.qty, Quantity{}, true, false, h.price, Quantity{}});
+    }
+    else
+    {
+      // Reject / timeout: the held qty does not trade. Return both parties' held
+      // buying power to available (else it is stranded in `reserved` forever and
+      // the taker is never made whole for the fill that did not happen).
+      releaseHeldLeg(h.taker, h.qty);
+      releaseHeldLeg(h.maker, h.qty);
+      sink_(FillRejected{h.id, cfg_.id, h.taker});
+    }
+  }
+  void onLastLookDecision(const LastLookDecision& d)
+  {
+    auto it = held_.find(d.heldId);
+    if (it == held_.end())
+    {
+      sink_(OrderRejected{d.heldId, cfg_.id, RejectReason::UnknownOrder});
+      return;
+    }
+    resolveHeld(it, d.accept);
+  }
+  // GTD: cancel resting orders whose expiry time has passed (deterministic by
+  // sequencer-ts). Runs on every submit before the command is processed.
+  void expireOrders()
+  {
+    if (expiry_.empty())
+    {
+      return;
+    }
+    std::vector<OrderId> due;
+    for (const auto& [id, exp] : expiry_)
+    {
+      if (now_ >= exp)
+      {
+        due.push_back(id);
+      }
+    }
+    std::sort(due.begin(), due.end());  // deterministic expiry/event order (layout-independent)
+    for (OrderId id : due)
+    {
+      expiry_.erase(id);
+      if (book_.cancel(id).has_value())  // still resting -> expire it
+      {
+        releaseReservation(id);
+        forgetOrder(id);
+        sink_(OrderCanceled{id, cfg_.id, CancelReason::Expired});
+      }
+    }
+  }
+
+  // Peg price for `side` tracking `ref` (+ signed offset), tick-aligned, clamped
+  // to not cross the opposite touch and to stay inside the price band.
+  int64_t pegTargetRaw(Side side, PegRef ref, int64_t offsetRaw) const
+  {
+    const auto bb = book_.bestBid();
+    const auto ba = book_.bestAsk();
+    const int64_t last =
+        hasLast_ ? lastPrice_.raw() : ((cfg_.minPrice.raw() + cfg_.maxPrice.raw()) / 2);
+    int64_t refRaw;
+    switch (ref)
+    {
+      case PegRef::Bid:
+        refRaw = bb ? bb->raw() : (ba ? ba->raw() : last);
+        break;
+      case PegRef::Ask:
+        refRaw = ba ? ba->raw() : (bb ? bb->raw() : last);
+        break;
+      case PegRef::Mid:
+        refRaw = (bb && ba) ? (bb->raw() + ba->raw()) / 2 : (bb ? bb->raw() : (ba ? ba->raw() : last));
+        break;
+      default:
+        return 0;
+    }
+    int64_t target = refRaw + offsetRaw;
+    const int64_t tick = cfg_.tickSize.raw();
+    if (tick > 0)
+    {
+      target = target / tick * tick;  // align down to tick
+    }
+    if (side == Side::BUY && ba && target >= ba->raw())
+    {
+      target = ba->raw() - tick;  // never cross
+    }
+    if (side == Side::SELL && bb && target <= bb->raw())
+    {
+      target = bb->raw() + tick;
+    }
+    if (cfg_.minPrice.raw() > 0 && target < cfg_.minPrice.raw())
+    {
+      target = cfg_.minPrice.raw();
+    }
+    if (cfg_.maxPrice.raw() > 0 && target > cfg_.maxPrice.raw())
+    {
+      target = cfg_.maxPrice.raw();
+    }
+    return target;
+  }
+
+  // Re-price pegged orders to track the book at each submit boundary. Repricing
+  // re-queues the order (time priority resets) and, for real-money settlement,
+  // re-reserves buying power at the new price (cancels the peg if unaffordable).
+  void repeg()
+  {
+    if (pegged_.empty())
+    {
+      return;
+    }
+    std::vector<OrderId> ids;
+    ids.reserve(pegged_.size());
+    for (const auto& [id, p] : pegged_)
+    {
+      ids.push_back(id);
+    }
+    // Deterministic order: a peg reprice reads the book that PRIOR pegs in this
+    // pass already mutated, so the processing order is state-affecting. Sort by id
+    // so the outcome does not depend on pegged_ (unordered_map) layout -- same
+    // layout-independence standard as the ADL/liquidation paths.
+    std::sort(ids.begin(), ids.end());
+    for (OrderId id : ids)
+    {
+      auto pit = pegged_.find(id);
+      if (pit == pegged_.end())
+      {
+        continue;
+      }
+      const Peg pg = pit->second;
+      // Remove the order from the book BEFORE computing its peg target: otherwise
+      // pegTargetRaw reads best-bid/ask/mid INCLUDING this order's own resting
+      // quantity, so a peg that is the touch references itself and ratchets one
+      // tick toward the opposite touch on every submit (creep + priority churn +
+      // OrderModified spam) even when the real market never moved. Cancelling
+      // first mirrors the creation path, where the order isn't resting yet.
+      auto ro = book_.cancel(id);
+      if (!ro)
+      {
+        pegged_.erase(id);
+        continue;  // already filled / gone
+      }
+      const int64_t target = pegTargetRaw(pg.side, pg.ref, pg.offsetRaw);
+      if (ro->price.raw() == target)
+      {
+        book_.addResting(ro->side, *ro);  // unchanged -> put it back
+        continue;
+      }
+      if (ledger_ != nullptr)
+      {
+        releaseReservation(id);
+        NewOrder synth;
+        synth.id = id;
+        synth.symbol = cfg_.id;
+        synth.side = ro->side;
+        synth.type = OrderType::LIMIT;
+        synth.price = Price::fromRaw(target);
+        synth.quantity = Quantity::fromRaw(ro->leaves.raw() + ro->hidden.raw());
+        synth.accountId = ro->accountId;
+        if (!reserveFunds(synth))  // cannot fund the reprice -> drop the peg
+        {
+          forgetOrder(id);
+          pegged_.erase(id);
+          sink_(OrderCanceled{id, cfg_.id, CancelReason::UserRequested});
+          continue;
+        }
+      }
+      RestingOrder nr = *ro;
+      nr.price = Price::fromRaw(target);
+      book_.addResting(nr.side, nr);
+      sink_(OrderModified{id, cfg_.id, Price::fromRaw(target), nr.leaves, false});
+    }
+  }
+
+  // OCO: after matching, cancel the losing siblings of every group that had a
+  // fill this submit. The filled ("winner") order is left alone.
+  void processOco()
+  {
+    if (ocoPending_.empty())
+    {
+      return;
+    }
+    for (const auto& [group, winner] : ocoPending_)
+    {
+      auto git = ocoMembers_.find(group);
+      if (git == ocoMembers_.end())
+      {
+        continue;  // already resolved this submit
+      }
+      const std::vector<OrderId> members = git->second;  // copy: cancel mutates maps
+      ocoMembers_.erase(git);
+      for (OrderId id : members)
+      {
+        orderOco_.erase(id);
+        if (id != winner)
+        {
+          cancelOcoSibling(id);
+        }
+      }
+    }
+    ocoPending_.clear();
+  }
+  void cancelOcoSibling(OrderId id)
+  {
+    if (book_.cancel(id).has_value())
+    {
+      releaseReservation(id);
+      forgetOrder(id);
+      sink_(OrderCanceled{id, cfg_.id, CancelReason::OcoTriggered});
+    }
+    else if (stops_.cancel(id))
+    {
+      sink_(OrderCanceled{id, cfg_.id, CancelReason::OcoTriggered});
+    }
+  }
+
+  void expireHolds()
+  {
+    if (held_.empty())
+    {
+      return;
+    }
+    std::vector<uint64_t> due;
+    for (const auto& [id, h] : held_)
+    {
+      if (now_ >= h.deadline)
+      {
+        due.push_back(id);
+      }
+    }
+    // Deterministic order: a timeout-accept assigns ++tradeSeq_, so the resolution
+    // order feeds the event stream -- must not depend on held_ (unordered_map) layout.
+    std::sort(due.begin(), due.end());
+    for (uint64_t id : due)
+    {
+      auto it = held_.find(id);
+      if (it != held_.end())
+      {
+        resolveHeld(it, cfg_.lastLookAcceptOnTimeout);
+      }
+    }
+  }
+
+  SymbolConfig cfg_;
+  EventSink sink_;
+  EventSink emit_;  // sink_ wrapper that tracks lastPrice_ from trades
+  Matcher<Book> matcher_;
+  Book book_;
+  StopBook stops_;
+  Price lastPrice_{};
+  bool hasLast_{false};
+  Price markPrice_{};
+  bool hasMark_{false};
+  uint64_t tradeSeq_{0};
+
+  int64_t now_{0};
+  int64_t timeCounter_{0};
+  std::unordered_map<OrderId, uint64_t> orderAccount_;
+  std::unordered_map<uint64_t, std::unordered_set<OrderId>> byAccount_;
+  std::unordered_map<OrderId, int64_t> expiry_;                    // GTD: orderId -> expiry sequencer-ts
+  std::unordered_map<OrderId, uint64_t> orderOco_;                 // orderId -> OCO group
+  std::unordered_map<uint64_t, std::vector<OrderId>> ocoMembers_;  // group -> member orderIds
+  std::vector<std::pair<uint64_t, OrderId>> ocoPending_;           // (group, winner) collected while matching
+  struct Peg
+  {
+    Side side;
+    PegRef ref;
+    int64_t offsetRaw;
+  };
+  std::unordered_map<OrderId, Peg> pegged_;  // orderId -> peg spec (re-priced each submit)
+
+  flox::FeeSchedule fees_;
+  bool feesEnabled_{false};
+
+  struct MmpCfg
+  {
+    Quantity qtyLimit{};
+    int64_t windowNs{};
+  };
+  std::unordered_map<uint64_t, MmpCfg> mmpCfg_;
+  std::unordered_map<uint64_t, std::deque<std::pair<int64_t, Quantity>>> mmpFills_;
+  std::vector<uint64_t> mmpBreached_;
+  CreditCheck credit_;
+
+  std::unordered_map<uint64_t, Held> held_;
+  uint64_t heldSeq_{0};
+
+  Ledger* ledger_{nullptr};
+  uint64_t venueAccount_{0};
+  std::unordered_map<OrderId, Reservation> reserve_;
+  std::unordered_map<uint64_t, Position> positions_;  // perp positions per account
+  bool auctionMode_{false};
+  int64_t haltUntil_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/matching_engine.h
+++ b/venue/include/flox-venue/matching_engine.h
@@ -18,6 +18,7 @@
 #include "flox/backtest/fee_schedule.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <deque>
 #include <optional>
@@ -61,6 +62,12 @@ struct SymbolConfig
   bool autoDeleverage{false};           // ADL: recover a bankruptcy deficit from winners before insurance
   Quantity maxPositionQty{};            // 0 = unchecked (max |position| per account, perp risk cap)
   uint32_t maxOpenOrders{0};            // 0 = unchecked (max live resting orders per account)
+
+  // Per-symbol fixed-point scale, same semantics as core SymbolInfo. Default
+  // 1e8 = the compile-time Price/Quantity scale. Money always settles at
+  // kMoneyScale regardless. Must satisfy scalesValid().
+  int64_t priceScale{Price::Scale};
+  int64_t qtyScale{Quantity::Scale};
 };
 
 template <class Book = MatchingBook>
@@ -71,6 +78,7 @@ class MatchingEngine
                  MatchPolicy policy = MatchPolicy::PriceTimeFifo)
       : cfg_(cfg), sink_(std::move(sink)), matcher_(policy), book_(std::move(book))
   {
+    assert(scalesValid(cfg_.priceScale, cfg_.qtyScale));
     // Wrap the user sink to observe the trade stream (last price for stops,
     // fees, MM-protection counters) and maintain per-account resting state.
     emit_ = [this](const OutboundEvent& e)
@@ -280,8 +288,8 @@ class MatchingEngine
     }
     for (auto& [acct, p] : positions_)
     {
-      const __int128 notional =
-          static_cast<__int128>(mark.raw()) * iabs64(p.qtyRaw) / static_cast<__int128>(Price::Scale);
+      const Amount notional =
+          notionalRaw(mark.raw(), iabs64(p.qtyRaw), cfg_.priceScale, cfg_.qtyScale);
       const Amount mag = static_cast<Amount>(static_cast<double>(notional) * rate);
       const Amount signedPay = (p.qtyRaw > 0) ? -mag : mag;  // long pays when rate>0
       ledger_->credit(acct, cfg_.quoteAsset, signedPay);
@@ -314,8 +322,9 @@ class MatchingEngine
       return 0;
     }
     const int64_t sign = it->second.qtyRaw > 0 ? 1 : -1;
-    return static_cast<Amount>(static_cast<__int128>(mark.raw() - it->second.entryRaw) *
-                               iabs64(it->second.qtyRaw) / static_cast<__int128>(Price::Scale) * sign);
+    return notionalRaw(mark.raw() - it->second.entryRaw, iabs64(it->second.qtyRaw),
+                       cfg_.priceScale, cfg_.qtyScale) *
+           sign;
   }
 
   const Book& book() const noexcept { return book_; }
@@ -1295,7 +1304,10 @@ class MatchingEngine
     {
       return;
     }
-    const double notional = (t.price * t.quantity).toDouble();
+    const double notional =
+        static_cast<double>(
+            notionalRaw(t.price.raw(), t.quantity.raw(), cfg_.priceScale, cfg_.qtyScale)) /
+        kMoneyScale;
     sink_(FeeCharged{t.makerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, true)), true});
     sink_(FeeCharged{t.takerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, false)), false});
   }
@@ -1312,8 +1324,8 @@ class MatchingEngine
 
   Amount imForRaw(int64_t qtyRaw, int64_t priceRaw) const
   {
-    const __int128 notional = static_cast<__int128>(priceRaw) * qtyRaw / static_cast<__int128>(Price::Scale);
-    return static_cast<Amount>(notional * cfg_.initialMarginBps / 10000);
+    const Amount notional = notionalRaw(priceRaw, qtyRaw, cfg_.priceScale, cfg_.qtyScale);
+    return notional * cfg_.initialMarginBps / 10000;
   }
 
   bool reserveFunds(const NewOrder& o)
@@ -1357,7 +1369,7 @@ class MatchingEngine
           return false;
         }
         asset = cfg_.quoteAsset;
-        amt = amountOf(px * o.quantity);
+        amt = notionalRaw(px.raw(), o.quantity.raw(), cfg_.priceScale, cfg_.qtyScale);
         limitRaw = px.raw();
       }
       else
@@ -1410,7 +1422,8 @@ class MatchingEngine
       settlePerp(t);
       return;
     }
-    const Amount notional = amountOf(t.price * t.quantity);
+    const Amount notional =
+        notionalRaw(t.price.raw(), t.quantity.raw(), cfg_.priceScale, cfg_.qtyScale);
     const Amount qtyRaw = amountOf(t.quantity);
     const bool takerBuys = (t.takerSide == Side::BUY);
     const OrderId buyerId = takerBuys ? t.takerId : t.makerId;
@@ -1421,9 +1434,8 @@ class MatchingEngine
     // Buyer: pay quote from reserved (refund over-reservation), receive base.
     if (auto rb = reserve_.find(buyerId); rb != reserve_.end())
     {
-      const Amount limitNotional = static_cast<Amount>(
-          static_cast<__int128>(rb->second.limitPriceRaw) * static_cast<__int128>(t.quantity.raw()) /
-          static_cast<__int128>(Price::Scale));
+      const Amount limitNotional = notionalRaw(rb->second.limitPriceRaw, t.quantity.raw(),
+                                               cfg_.priceScale, cfg_.qtyScale);
       ledger_->spendReserved(buyerAcct, cfg_.quoteAsset, notional);
       if (limitNotional > notional)
       {
@@ -1451,7 +1463,10 @@ class MatchingEngine
 
     if (feesEnabled_)
     {
-      const double notionalD = (t.price * t.quantity).toDouble();
+      const double notionalD =
+          static_cast<double>(
+              notionalRaw(t.price.raw(), t.quantity.raw(), cfg_.priceScale, cfg_.qtyScale)) /
+          kMoneyScale;
       chargeFee(t.makerId, t.makerAccount, fees_.feeFor(now_, notionalD, true), true);
       chargeFee(t.takerId, t.takerAccount, fees_.feeFor(now_, notionalD, false), false);
     }
@@ -1525,10 +1540,10 @@ class MatchingEngine
     {
       const int64_t reduceQty = std::min<int64_t>(remaining, iabs64(p.qtyRaw));
       // realized PnL vs entry (long: (price-entry)*qty; short: (entry-price)*qty)
-      const __int128 pnl = static_cast<__int128>(priceRaw - p.entryRaw) * reduceQty /
-                           static_cast<__int128>(Price::Scale) * posSign;
-      ledger_->credit(acct, cfg_.quoteAsset, static_cast<Amount>(pnl));
-      ledger_->credit(venueAccount_, cfg_.quoteAsset, -static_cast<Amount>(pnl));
+      const Amount pnl =
+          notionalRaw(priceRaw - p.entryRaw, reduceQty, cfg_.priceScale, cfg_.qtyScale) * posSign;
+      ledger_->credit(acct, cfg_.quoteAsset, pnl);
+      ledger_->credit(venueAccount_, cfg_.quoteAsset, -pnl);
       // release position margin for the reduced portion
       const Amount relMargin =
           static_cast<Amount>(static_cast<__int128>(p.margin) * reduceQty / iabs64(p.qtyRaw));
@@ -1576,7 +1591,10 @@ class MatchingEngine
     updatePerpPosition(sellerAcct, sellerId, false, t.quantity.raw(), t.price.raw());
     if (feesEnabled_)
     {
-      const double notionalD = (t.price * t.quantity).toDouble();
+      const double notionalD =
+          static_cast<double>(
+              notionalRaw(t.price.raw(), t.quantity.raw(), cfg_.priceScale, cfg_.qtyScale)) /
+          kMoneyScale;
       chargeFee(t.makerId, t.makerAccount, fees_.feeFor(now_, notionalD, true), true);
       chargeFee(t.takerId, t.takerAccount, fees_.feeFor(now_, notionalD, false), false);
     }
@@ -1594,9 +1612,9 @@ class MatchingEngine
     for (const auto& [acct, p] : positions_)
     {
       const Amount uPnl = unrealizedPnlRaw(acct, mark);
-      const __int128 notional =
-          static_cast<__int128>(mark.raw()) * iabs64(p.qtyRaw) / static_cast<__int128>(Price::Scale);
-      const Amount mmReq = static_cast<Amount>(notional * cfg_.maintenanceMarginBps / 10000);
+      const Amount notional =
+          notionalRaw(mark.raw(), iabs64(p.qtyRaw), cfg_.priceScale, cfg_.qtyScale);
+      const Amount mmReq = notional * cfg_.maintenanceMarginBps / 10000;
       // A negative wallet (funding/fees charged to `available` with no free
       // collateral to absorb them) drags the maintenance-equity check: otherwise
       // funding could push a max-leverage payer's wallet unboundedly negative
@@ -1640,8 +1658,8 @@ class MatchingEngine
     cancelAllForAccount(acct, CancelReason::Liquidation);
     const int64_t sign = p.qtyRaw > 0 ? 1 : -1;
     const int64_t qtyAbs = iabs64(p.qtyRaw);
-    const Amount uPnl = static_cast<Amount>(static_cast<__int128>(mark.raw() - p.entryRaw) * qtyAbs /
-                                            static_cast<__int128>(Price::Scale) * sign);
+    const Amount uPnl =
+        notionalRaw(mark.raw() - p.entryRaw, qtyAbs, cfg_.priceScale, cfg_.qtyScale) * sign;
     ledger_->credit(acct, cfg_.quoteAsset, uPnl);
     ledger_->credit(venueAccount_, cfg_.quoteAsset, -uPnl);
     if (p.margin > 0)
@@ -1688,8 +1706,8 @@ class MatchingEngine
       {
         continue;  // opposite side only
       }
-      const Amount up = static_cast<Amount>(static_cast<__int128>(mark.raw() - pos.entryRaw) *
-                                            pos.qtyRaw / static_cast<__int128>(Price::Scale));
+      const Amount up =
+          notionalRaw(mark.raw() - pos.entryRaw, pos.qtyRaw, cfg_.priceScale, cfg_.qtyScale);
       if (up > 0)
       {
         cands.push_back({oa, up});
@@ -1717,8 +1735,8 @@ class MatchingEngine
       const Position p = it->second;
       positions_.erase(it);
       const int64_t qtyAbs = iabs64(p.qtyRaw);
-      const Amount uPnl = static_cast<Amount>(static_cast<__int128>(mark.raw() - p.entryRaw) *
-                                              p.qtyRaw / static_cast<__int128>(Price::Scale));
+      const Amount uPnl =
+          notionalRaw(mark.raw() - p.entryRaw, p.qtyRaw, cfg_.priceScale, cfg_.qtyScale);
       ledger_->credit(c.acct, cfg_.quoteAsset, uPnl);  // realize gain at mark
       ledger_->credit(venueAccount_, cfg_.quoteAsset, -uPnl);
       if (p.margin > 0)
@@ -1791,8 +1809,7 @@ class MatchingEngine
     }
     else if (it->second.side == Side::BUY)
     {
-      rel = static_cast<Amount>(static_cast<__int128>(it->second.limitPriceRaw) *
-                                static_cast<__int128>(qty.raw()) / static_cast<__int128>(Price::Scale));
+      rel = notionalRaw(it->second.limitPriceRaw, qty.raw(), cfg_.priceScale, cfg_.qtyScale);
     }
     else
     {

--- a/venue/include/flox-venue/messages.h
+++ b/venue/include/flox-venue/messages.h
@@ -1,0 +1,281 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox/common.h"  // Price, Quantity, Side, OrderId, OrderType, TimeInForce, STPMode, SymbolId
+
+#include "flox-venue/reject_reason.h"
+
+#include <cstdint>
+#include <variant>
+
+namespace flox::venue
+{
+
+// Saturating double -> fixed-point conversion for UNTRUSTED input (REST/FIX
+// numeric fields). Decimal::fromDouble multiplies by Scale and casts to int64;
+// a hostile value like 5e52 would overflow that cast (undefined behavior). Clamp
+// to a safe range and neutralize NaN before converting.
+template <class D>
+inline D safeDecimal(double v)
+{
+  const double kMax = 9.0e18 / static_cast<double>(D::Scale);  // < INT64_MAX after *Scale
+  if (!(v == v))
+  {
+    v = 0.0;  // NaN
+  }
+  if (v > kMax)
+  {
+    v = kMax;
+  }
+  else if (v < -kMax)
+  {
+    v = -kMax;
+  }
+  return D::fromDouble(v);
+}
+
+// ---- Inbound commands -----------------------------------------------------
+
+// Peg reference: a resting order tracks the book, re-priced at each submit
+// boundary. Bid/Ask peg to the near or far touch; Mid to the midpoint.
+enum class PegRef : uint8_t
+{
+  None = 0,
+  Bid,
+  Ask,
+  Mid,
+};
+
+struct NewOrder
+{
+  OrderId id{};
+  SymbolId symbol{};
+  Side side{};
+  OrderType type{OrderType::LIMIT};  // LIMIT | MARKET and the conditional (stop / take-profit / trailing) types
+  Price price{};                     // ignored for MARKET
+  Quantity quantity{};
+  TimeInForce tif{TimeInForce::GTC};
+  bool postOnly{false};
+  STPMode stp{STPMode::None};
+  uint64_t accountId{0};
+  uint64_t clientOrderId{0};
+  Quantity visibleQuantity{};  // iceberg display size; 0 or >= quantity = fully visible
+  Price triggerPrice{};        // stop / take-profit activation price
+  Price trailingOffset{};      // trailing-stop offset (price distance from extreme)
+  bool lastLook{false};        // maker holds a fill for a last-look window before confirming
+  bool reduceOnly{false};      // derivatives: may only reduce/close a position, never increase
+  int64_t expiryNs{0};         // GTD: sequencer-ts at/after which a resting order auto-cancels (0 = none)
+  uint64_t ocoGroup{0};        // OCO: orders sharing a group cancel each other on the first fill (0 = none)
+  PegRef peg{PegRef::None};    // peg: re-price to track Bid/Ask/Mid each submit boundary
+  int64_t pegOffsetRaw{0};     // signed price offset from the peg reference (raw ticks)
+};
+
+struct CancelOrder
+{
+  OrderId id{};
+  SymbolId symbol{};
+  uint64_t accountId{0};
+};
+
+struct ModifyOrder  // cancel/replace
+{
+  OrderId id{};
+  SymbolId symbol{};
+  Price newPrice{};   // raw 0 = keep current price
+  Quantity newQty{};  // new leaves target
+  uint64_t accountId{0};
+};
+
+struct MassCancel  // cancel every resting order of an account (MM cancel-all)
+{
+  uint64_t accountId{};
+  SymbolId symbol{};
+};
+
+struct Quote  // two-sided market-maker quote (replace prior quote on this symbol)
+{
+  OrderId bidId{};
+  OrderId askId{};
+  SymbolId symbol{};
+  Price bidPrice{};
+  Quantity bidQty{};  // 0 = no bid side
+  Price askPrice{};
+  Quantity askQty{};  // 0 = no ask side
+  uint64_t accountId{};
+};
+
+struct LastLookDecision  // maker accepts or rejects a held last-look fill
+{
+  uint64_t heldId{};
+  SymbolId symbol{};
+  bool accept{};
+  uint64_t accountId{};
+};
+
+// Oracle/admin inputs that mutate state (drive liquidations / funding). They are
+// sequenced and journaled like orders so deterministic replay reproduces every
+// mark-driven liquidation and funding payment -- without them, derivatives
+// recovery would diverge from the live state.
+struct SetMark  // update the mark price (triggers maintenance-margin liquidations)
+{
+  SymbolId symbol{};
+  Price mark{};
+};
+
+struct ApplyFunding  // settle a funding payment across open positions
+{
+  SymbolId symbol{};
+  double rate{};
+  Price mark{};
+};
+
+// Operator/session actions that mutate MATCHABLE state (auction uncross fills,
+// emergency cancel-all, halt). Sequenced + journaled like orders so replay
+// reproduces them at the exact point in the stream -- otherwise a crash after an
+// opening uncross or an emergency halt-cancel would recover a divergent book /
+// ledger. (Persistent risk-limit/config knobs are recovered from the config
+// store, not the WAL, so they are NOT AdminCmds.)
+enum class AdminAction : uint8_t
+{
+  BeginPreOpen,      // enter pre-open call-auction accumulation (no matching)
+  OpenContinuous,    // uncross at the single clearing price, resume continuous
+  ResumeAuction,     // clear halt + enter pre-open (re-opening auction)
+  HaltAndCancelAll,  // emergency: halt + cancel the entire resting book
+  Halt,              // reject new orders
+  Resume,            // clear halt
+};
+
+struct AdminCmd
+{
+  SymbolId symbol{};
+  AdminAction action{};
+};
+
+using InboundCommand = std::variant<NewOrder, CancelOrder, ModifyOrder, MassCancel, Quote,
+                                    LastLookDecision, SetMark, ApplyFunding, AdminCmd>;
+
+// ---- Outbound events ------------------------------------------------------
+
+struct OrderAccepted  // order accepted / working
+{
+  OrderId id{};
+  SymbolId symbol{};
+  Side side{};
+  Price price{};
+  Quantity leavesQty{};      // full working quantity (for the owner's ack)
+  bool restingOnBook{true};  // false = working but not on the visible book (pending stop)
+  Quantity displayQty{};     // publicly visible size (== leavesQty unless iceberg; 0 = use leavesQty)
+};
+
+struct OrderRejected
+{
+  OrderId id{};
+  SymbolId symbol{};
+  RejectReason reason{};
+};
+
+struct Trade
+{
+  uint64_t tradeId{};
+  SymbolId symbol{};
+  Price price{};  // maker price
+  Quantity quantity{};
+  OrderId makerId{};
+  OrderId takerId{};
+  Side takerSide{};
+  uint64_t makerAccount{};
+  uint64_t takerAccount{};
+};
+
+struct OrderExecuted  // per-order execution report on a fill
+{
+  OrderId id{};
+  SymbolId symbol{};
+  Quantity lastQty{};
+  Quantity leavesQty{};
+  bool aggressor{false};  // true = taker leg
+  bool complete{false};   // fully filled
+  Price lastPx{};         // price of this fill (for the exec report / client reconciliation)
+  // Displayed remaining after this fill, for the PUBLIC market-data feed. For a
+  // non-iceberg this equals leavesQty; for an iceberg it is only the visible peak
+  // (never the hidden reserve), so the public book cannot be probed for hidden
+  // size. leavesQty stays the whole remaining for the owner's exec report.
+  Quantity displayLeaves{};
+};
+
+struct OrderCanceled
+{
+  OrderId id{};
+  SymbolId symbol{};
+  CancelReason reason{};
+};
+
+struct OrderModified
+{
+  OrderId id{};
+  SymbolId symbol{};
+  Price price{};
+  Quantity leavesQty{};
+  bool priorityKept{false};  // false = re-entered at the tail (lost time priority)
+};
+
+struct OrderTriggered  // a stop / take-profit activated and was injected into matching
+{
+  OrderId id{};
+  SymbolId symbol{};
+  Price refPrice{};  // reference (last-trade) price that crossed the trigger
+};
+
+struct FillHeld  // last-look: a fill is held pending the maker's decision
+{
+  uint64_t heldId{};
+  SymbolId symbol{};
+  OrderId makerId{};
+  OrderId takerId{};
+  Price price{};
+  Quantity qty{};
+};
+
+struct FillRejected  // last-look: the held fill was rejected (or timed out)
+{
+  uint64_t heldId{};
+  SymbolId symbol{};
+  OrderId takerId{};
+};
+
+struct MmpTriggered  // market-maker protection fired: the account was mass-canceled
+{
+  uint64_t accountId{};
+  SymbolId symbol{};
+};
+
+struct FeeCharged  // per-leg maker/taker fee (negative = rebate)
+{
+  OrderId id{};
+  SymbolId symbol{};
+  Volume fee{};
+  bool maker{};
+};
+
+struct Liquidation  // a perp position was force-closed below maintenance margin
+{
+  uint64_t account{};
+  SymbolId symbol{};
+  Quantity qty{};   // absolute size closed
+  Price price{};    // mark price at liquidation
+  bool bankrupt{};  // equity went negative -> insurance fund covered the deficit
+  bool adl{};       // auto-deleveraged: closed to absorb a bankrupt counterparty
+};
+
+using OutboundEvent =
+    std::variant<OrderAccepted, OrderRejected, Trade, OrderExecuted, OrderCanceled, OrderModified,
+                 OrderTriggered, FillHeld, FillRejected, MmpTriggered, FeeCharged, Liquidation>;
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/metrics.h
+++ b/venue/include/flox-venue/metrics.h
@@ -1,0 +1,142 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+#include "flox-venue/reject_reason.h"
+
+#include <array>
+#include <cstdint>
+
+namespace flox::venue
+{
+
+class LatencyHistogram
+{
+ public:
+  static constexpr int kBuckets = 64;  // bucket b covers [2^(b-1), 2^b) ns
+
+  void record(uint64_t ns) noexcept
+  {
+    int b = (ns == 0) ? 0 : (64 - __builtin_clzll(ns));
+    if (b >= kBuckets)
+    {
+      b = kBuckets - 1;
+    }
+    ++buckets_[static_cast<size_t>(b)];
+    ++count_;
+    sumNs_ += ns;
+    if (ns > maxNs_)
+    {
+      maxNs_ = ns;
+    }
+  }
+
+  uint64_t count() const noexcept { return count_; }
+  uint64_t maxNs() const noexcept { return maxNs_; }
+  double meanNs() const noexcept { return count_ ? static_cast<double>(sumNs_) / count_ : 0.0; }
+
+  // Upper-bound (ns) of the bucket holding the p-th percentile [0,1].
+  uint64_t percentileNs(double p) const noexcept
+  {
+    if (count_ == 0)
+    {
+      return 0;
+    }
+    const uint64_t target = static_cast<uint64_t>(static_cast<double>(count_) * p);
+    uint64_t cum = 0;
+    for (int b = 0; b < kBuckets; ++b)
+    {
+      cum += buckets_[static_cast<size_t>(b)];
+      if (cum >= target && buckets_[static_cast<size_t>(b)] > 0)
+      {
+        return (b == 0) ? 1 : (1ULL << b);
+      }
+    }
+    return maxNs_;
+  }
+
+ private:
+  std::array<uint64_t, kBuckets> buckets_{};
+  uint64_t count_{0};
+  uint64_t sumNs_{0};
+  uint64_t maxNs_{0};
+};
+
+struct Metrics
+{
+  LatencyHistogram submitLatency;
+  uint64_t accepted{0};
+  uint64_t trades{0};
+  uint64_t cancels{0};
+  uint64_t rejects{0};
+  uint64_t modifies{0};
+  uint64_t liquidations{0};
+  uint64_t holds{0};
+  __int128 volumeRaw{0};  // cumulative traded notional (quote raw)
+  static constexpr size_t kReasons = 24;
+  std::array<uint64_t, kReasons> rejectsByReason{};  // indexed by RejectReason
+
+  void observe(const OutboundEvent& e) noexcept;
+};
+
+// Point-in-time venue state that is NOT derivable from the outbound event stream
+// -- sampled from the ledger and risk manager by the monitoring thread and
+// exported as Prometheus gauges. Zero is a valid, meaningful value here.
+struct Gauges
+{
+  __int128 insuranceFundRaw{0};    // venue collateral balance (insurance fund)
+  double fundingRate{0.0};         // last settled funding rate
+  __int128 openInterestRaw{0};     // aggregate open position notional (quote raw)
+  uint64_t openPositions{0};       // count of open perp positions
+  uint64_t restingOrders{0};       // live orders across the book
+  int64_t markPriceAgeNs{0};       // age of the current mark/index (feed-lag alert)
+  uint64_t liquidationsPaused{0};  // 1 = liquidation circuit breaker engaged
+};
+
+inline void Metrics::observe(const OutboundEvent& e) noexcept
+{
+  if (const auto* t = std::get_if<Trade>(&e))
+  {
+    ++trades;
+    volumeRaw += static_cast<__int128>(t->price.raw()) * t->quantity.raw() /
+                 static_cast<__int128>(Price::Scale);
+  }
+  else if (std::get_if<OrderAccepted>(&e))
+  {
+    ++accepted;
+  }
+  else if (std::get_if<OrderCanceled>(&e))
+  {
+    ++cancels;
+  }
+  else if (const auto* r = std::get_if<OrderRejected>(&e))
+  {
+    ++rejects;
+    const size_t idx = static_cast<size_t>(r->reason);
+    if (idx < kReasons)
+    {
+      ++rejectsByReason[idx];
+    }
+  }
+  else if (std::get_if<OrderModified>(&e))
+  {
+    ++modifies;
+  }
+  else if (std::get_if<Liquidation>(&e))
+  {
+    ++liquidations;
+  }
+  else if (std::get_if<FillHeld>(&e))
+  {
+    ++holds;
+  }
+}
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/metrics.h
+++ b/venue/include/flox-venue/metrics.h
@@ -8,11 +8,13 @@
  */
 #pragma once
 
+#include "flox-venue/ledger.h"
 #include "flox-venue/messages.h"
 #include "flox-venue/reject_reason.h"
 
 #include <array>
 #include <cstdint>
+#include <unordered_map>
 
 namespace flox::venue
 {
@@ -79,11 +81,21 @@ struct Metrics
   uint64_t modifies{0};
   uint64_t liquidations{0};
   uint64_t holds{0};
-  __int128 volumeRaw{0};  // cumulative traded notional (quote raw)
+  __int128 volumeRaw{0};  // cumulative traded notional (quote raw, kMoneyScale)
   static constexpr size_t kReasons = 24;
   std::array<uint64_t, kReasons> rejectsByReason{};  // indexed by RejectReason
 
+  // Symbols with a non-default scale must be registered so trade notional is
+  // normalized to kMoneyScale; unregistered symbols use the default 1e8.
+  void setSymbolScales(SymbolId s, int64_t priceScale, int64_t qtyScale)
+  {
+    scales_[s] = {priceScale, qtyScale};
+  }
+
   void observe(const OutboundEvent& e) noexcept;
+
+ private:
+  std::unordered_map<SymbolId, std::pair<int64_t, int64_t>> scales_;
 };
 
 // Point-in-time venue state that is NOT derivable from the outbound event stream
@@ -105,8 +117,11 @@ inline void Metrics::observe(const OutboundEvent& e) noexcept
   if (const auto* t = std::get_if<Trade>(&e))
   {
     ++trades;
-    volumeRaw += static_cast<__int128>(t->price.raw()) * t->quantity.raw() /
-                 static_cast<__int128>(Price::Scale);
+    auto it = scales_.find(t->symbol);
+    const auto [pS, qS] = it == scales_.end()
+                              ? std::pair<int64_t, int64_t>{Price::Scale, Quantity::Scale}
+                              : it->second;
+    volumeRaw += notionalRaw(t->price.raw(), t->quantity.raw(), pS, qS);
   }
   else if (std::get_if<OrderAccepted>(&e))
   {

--- a/venue/include/flox-venue/metrics_server.h
+++ b/venue/include/flox-venue/metrics_server.h
@@ -1,0 +1,112 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/socket_acceptor.h"
+#include "flox/util/transport.h"
+
+#include <unistd.h>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+
+namespace flox::venue
+{
+
+class MetricsServer
+{
+ public:
+  using Snapshot = std::function<std::string()>;  // /metrics body
+  using Ready = std::function<bool()>;
+
+  explicit MetricsServer(Snapshot snap, Ready ready = []
+                                        { return true; })
+      : snap_(std::move(snap)), ready_(std::move(ready))
+  {
+  }
+
+  int start(uint16_t port)
+  {
+    return acceptor_.start(port, [this](int fd)
+                           { connLoop(fd); });
+  }
+  void stop() { acceptor_.stop(); }
+  int port() const noexcept { return acceptor_.port(); }
+
+ private:
+  static void respond(int fd, const char* status, const char* ctype, const std::string& body)
+  {
+    std::string r = "HTTP/1.1 ";
+    r += status;
+    r += "\r\nContent-Type: ";
+    r += ctype;
+    r += "\r\nContent-Length: ";
+    r += std::to_string(body.size());
+    r += "\r\nConnection: close\r\n\r\n";
+    r += body;
+    net::writeAll(fd, reinterpret_cast<const uint8_t*>(r.data()), r.size());
+  }
+
+  void connLoop(int fd)
+  {
+    std::string req;
+    uint8_t tmp[2048];
+    while (req.find("\r\n\r\n") == std::string::npos)
+    {
+      const ssize_t r = ::read(fd, tmp, sizeof tmp);
+      if (r <= 0 || req.size() > (1u << 16))
+      {
+        ::close(fd);
+        return;
+      }
+      req.append(reinterpret_cast<char*>(tmp), static_cast<size_t>(r));
+    }
+
+    // Parse "GET <path> HTTP/1.1".
+    const size_t sp1 = req.find(' ');
+    const size_t sp2 = (sp1 == std::string::npos) ? std::string::npos : req.find(' ', sp1 + 1);
+    std::string path;
+    if (sp1 != std::string::npos && sp2 != std::string::npos)
+    {
+      path = req.substr(sp1 + 1, sp2 - sp1 - 1);
+    }
+
+    if (path == "/metrics")
+    {
+      respond(fd, "200 OK", "text/plain; version=0.0.4", snap_());
+    }
+    else if (path == "/healthz")
+    {
+      respond(fd, "200 OK", "text/plain", "ok\n");
+    }
+    else if (path == "/readyz")
+    {
+      if (ready_())
+      {
+        respond(fd, "200 OK", "text/plain", "ready\n");
+      }
+      else
+      {
+        respond(fd, "503 Service Unavailable", "text/plain", "not ready\n");
+      }
+    }
+    else
+    {
+      respond(fd, "404 Not Found", "text/plain", "not found\n");
+    }
+    ::close(fd);
+  }
+
+  Snapshot snap_;
+  Ready ready_;
+  SocketAcceptor acceptor_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/metrics_server.h
+++ b/venue/include/flox-venue/metrics_server.h
@@ -27,8 +27,7 @@ class MetricsServer
   using Ready = std::function<bool()>;
 
   explicit MetricsServer(Snapshot snap, Ready ready = []
-                                        { return true; })
-      : snap_(std::move(snap)), ready_(std::move(ready))
+                                        { return true; }) : snap_(std::move(snap)), ready_(std::move(ready))
   {
   }
 

--- a/venue/include/flox-venue/ouch_codec.h
+++ b/venue/include/flox-venue/ouch_codec.h
@@ -1,0 +1,212 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+#include "flox/util/wire.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace flox::venue
+{
+
+// Inbound message tags (client -> venue).
+enum class OuchIn : uint8_t
+{
+  EnterOrder = 'O',
+  CancelOrder = 'X',
+  ReplaceOrder = 'U',
+};
+
+// Outbound message tags (venue -> client).
+enum class OuchOut : uint8_t
+{
+  Accepted = 'A',
+  Executed = 'E',
+  Trade = 'T',
+  Canceled = 'C',
+  Rejected = 'J',
+  Replaced = 'R',
+  Triggered = 'G',
+};
+
+class OuchCodec
+{
+ public:
+  // ---- inbound: wire -> InboundCommand ----
+  static void encode(const InboundCommand& cmd, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    if (const auto* n = std::get_if<NewOrder>(&cmd))
+    {
+      out.push_back(static_cast<uint8_t>(OuchIn::EnterOrder));
+      wire::put(out, n->id, 8);
+      wire::put(out, n->symbol, 4);
+      out.push_back(static_cast<uint8_t>(n->side));
+      out.push_back(static_cast<uint8_t>(n->type));
+      out.push_back(static_cast<uint8_t>(n->tif));
+      out.push_back(n->postOnly ? 1 : 0);
+      out.push_back(static_cast<uint8_t>(n->stp));
+      wire::put(out, static_cast<uint64_t>(n->price.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(n->quantity.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(n->visibleQuantity.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(n->triggerPrice.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(n->trailingOffset.raw()), 8);
+      wire::put(out, n->accountId, 8);
+      wire::put(out, n->clientOrderId, 8);
+      // Derivatives / MM / advanced-order fields (must not be silently dropped:
+      // a reduce-only order that loses the flag would OPEN a position).
+      out.push_back(n->reduceOnly ? 1 : 0);
+      out.push_back(n->lastLook ? 1 : 0);
+      out.push_back(static_cast<uint8_t>(n->peg));
+      wire::put(out, static_cast<uint64_t>(n->expiryNs), 8);
+      wire::put(out, n->ocoGroup, 8);
+      wire::put(out, static_cast<uint64_t>(n->pegOffsetRaw), 8);
+    }
+    else if (const auto* c = std::get_if<CancelOrder>(&cmd))
+    {
+      out.push_back(static_cast<uint8_t>(OuchIn::CancelOrder));
+      wire::put(out, c->id, 8);
+      wire::put(out, c->symbol, 4);
+      wire::put(out, c->accountId, 8);
+    }
+    else
+    {
+      const auto& m = std::get<ModifyOrder>(cmd);
+      out.push_back(static_cast<uint8_t>(OuchIn::ReplaceOrder));
+      wire::put(out, m.id, 8);
+      wire::put(out, m.symbol, 4);
+      wire::put(out, static_cast<uint64_t>(m.newPrice.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(m.newQty.raw()), 8);
+      wire::put(out, m.accountId, 8);
+    }
+  }
+
+  static std::optional<InboundCommand> decode(const uint8_t* p, size_t n)
+  {
+    wire::Reader r{p, n, 0, true};
+    const uint8_t tag = r.u8();
+    if (tag == static_cast<uint8_t>(OuchIn::EnterOrder))
+    {
+      NewOrder o;
+      o.id = r.u(8);
+      o.symbol = static_cast<SymbolId>(r.u(4));
+      o.side = static_cast<Side>(r.u8());
+      o.type = static_cast<OrderType>(r.u8());
+      o.tif = static_cast<TimeInForce>(r.u8());
+      o.postOnly = r.u8() != 0;
+      o.stp = static_cast<STPMode>(r.u8());
+      o.price = Price::fromRaw(r.i(8));
+      o.quantity = Quantity::fromRaw(r.i(8));
+      o.visibleQuantity = Quantity::fromRaw(r.i(8));
+      o.triggerPrice = Price::fromRaw(r.i(8));
+      o.trailingOffset = Price::fromRaw(r.i(8));
+      o.accountId = r.u(8);
+      o.clientOrderId = r.u(8);
+      o.reduceOnly = r.u8() != 0;
+      o.lastLook = r.u8() != 0;
+      o.peg = static_cast<PegRef>(r.u8());
+      o.expiryNs = static_cast<int64_t>(r.u(8));
+      o.ocoGroup = r.u(8);
+      o.pegOffsetRaw = static_cast<int64_t>(r.u(8));
+      return r.ok ? std::optional<InboundCommand>{o} : std::nullopt;
+    }
+    if (tag == static_cast<uint8_t>(OuchIn::CancelOrder))
+    {
+      CancelOrder c;
+      c.id = r.u(8);
+      c.symbol = static_cast<SymbolId>(r.u(4));
+      c.accountId = r.u(8);
+      return r.ok ? std::optional<InboundCommand>{c} : std::nullopt;
+    }
+    if (tag == static_cast<uint8_t>(OuchIn::ReplaceOrder))
+    {
+      ModifyOrder m;
+      m.id = r.u(8);
+      m.symbol = static_cast<SymbolId>(r.u(4));
+      m.newPrice = Price::fromRaw(r.i(8));
+      m.newQty = Quantity::fromRaw(r.i(8));
+      m.accountId = r.u(8);
+      return r.ok ? std::optional<InboundCommand>{m} : std::nullopt;
+    }
+    return std::nullopt;
+  }
+
+  // ---- outbound: OutboundEvent -> wire exec report ----
+  static void encode(const OutboundEvent& ev, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    if (const auto* a = std::get_if<OrderAccepted>(&ev))
+    {
+      out.push_back(static_cast<uint8_t>(OuchOut::Accepted));
+      wire::put(out, a->id, 8);
+      wire::put(out, a->symbol, 4);
+      out.push_back(static_cast<uint8_t>(a->side));
+      wire::put(out, static_cast<uint64_t>(a->price.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(a->leavesQty.raw()), 8);
+      out.push_back(a->restingOnBook ? 1 : 0);
+    }
+    else if (const auto* x = std::get_if<OrderExecuted>(&ev))
+    {
+      out.push_back(static_cast<uint8_t>(OuchOut::Executed));
+      wire::put(out, x->id, 8);
+      wire::put(out, x->symbol, 4);
+      wire::put(out, static_cast<uint64_t>(x->lastQty.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(x->lastPx.raw()), 8);  // fill price
+      wire::put(out, static_cast<uint64_t>(x->leavesQty.raw()), 8);
+      out.push_back(x->aggressor ? 1 : 0);
+      out.push_back(x->complete ? 1 : 0);
+    }
+    else if (const auto* t = std::get_if<Trade>(&ev))
+    {
+      out.push_back(static_cast<uint8_t>(OuchOut::Trade));
+      wire::put(out, t->tradeId, 8);
+      wire::put(out, t->symbol, 4);
+      wire::put(out, static_cast<uint64_t>(t->price.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(t->quantity.raw()), 8);
+      wire::put(out, t->makerId, 8);
+      wire::put(out, t->takerId, 8);
+      out.push_back(static_cast<uint8_t>(t->takerSide));
+    }
+    else if (const auto* c = std::get_if<OrderCanceled>(&ev))
+    {
+      out.push_back(static_cast<uint8_t>(OuchOut::Canceled));
+      wire::put(out, c->id, 8);
+      wire::put(out, c->symbol, 4);
+      out.push_back(static_cast<uint8_t>(c->reason));
+    }
+    else if (const auto* j = std::get_if<OrderRejected>(&ev))
+    {
+      out.push_back(static_cast<uint8_t>(OuchOut::Rejected));
+      wire::put(out, j->id, 8);
+      wire::put(out, j->symbol, 4);
+      out.push_back(static_cast<uint8_t>(j->reason));
+    }
+    else if (const auto* m = std::get_if<OrderModified>(&ev))
+    {
+      out.push_back(static_cast<uint8_t>(OuchOut::Replaced));
+      wire::put(out, m->id, 8);
+      wire::put(out, m->symbol, 4);
+      wire::put(out, static_cast<uint64_t>(m->price.raw()), 8);
+      wire::put(out, static_cast<uint64_t>(m->leavesQty.raw()), 8);
+      out.push_back(m->priorityKept ? 1 : 0);
+    }
+    else if (const auto* g = std::get_if<OrderTriggered>(&ev))
+    {
+      out.push_back(static_cast<uint8_t>(OuchOut::Triggered));
+      wire::put(out, g->id, 8);
+      wire::put(out, g->symbol, 4);
+      wire::put(out, static_cast<uint64_t>(g->refPrice.raw()), 8);
+    }
+  }
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/prometheus.h
+++ b/venue/include/flox-venue/prometheus.h
@@ -1,0 +1,170 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/metrics.h"
+
+#include <cstdint>
+#include <string>
+
+namespace flox::venue
+{
+namespace prom
+{
+
+inline std::string u128ToStr(unsigned __int128 v)
+{
+  if (v == 0)
+  {
+    return "0";
+  }
+  char buf[40];
+  char* p = buf + sizeof buf;
+  while (v > 0)
+  {
+    *--p = static_cast<char>('0' + static_cast<int>(v % 10));
+    v /= 10;
+  }
+  return std::string(p, buf + sizeof buf);
+}
+
+inline std::string i128ToStr(__int128 v)
+{
+  if (v < 0)
+  {
+    return "-" + u128ToStr(static_cast<unsigned __int128>(-v));
+  }
+  return u128ToStr(static_cast<unsigned __int128>(v));
+}
+
+// One counter block: HELP + TYPE + value line.
+inline void counter(std::string& out, const char* name, const char* help, uint64_t v)
+{
+  out += "# HELP ";
+  out += name;
+  out += ' ';
+  out += help;
+  out += "\n# TYPE ";
+  out += name;
+  out += " counter\n";
+  out += name;
+  out += ' ';
+  out += std::to_string(v);
+  out += '\n';
+}
+
+// One gauge block: HELP + TYPE + value line (value already rendered to string).
+inline void gaugeStr(std::string& out, const char* name, const char* help, const std::string& v)
+{
+  out += "# HELP ";
+  out += name;
+  out += ' ';
+  out += help;
+  out += "\n# TYPE ";
+  out += name;
+  out += " gauge\n";
+  out += name;
+  out += ' ';
+  out += v;
+  out += '\n';
+}
+
+// Latency summary from the histogram: p50/p99/p99.9 quantiles + _sum + _count.
+inline void latencySummary(std::string& out, const char* name, const char* help,
+                           const LatencyHistogram& h)
+{
+  out += "# HELP ";
+  out += name;
+  out += ' ';
+  out += help;
+  out += "\n# TYPE ";
+  out += name;
+  out += " summary\n";
+  const double qs[3] = {0.5, 0.99, 0.999};
+  const char* ql[3] = {"0.5", "0.99", "0.999"};
+  for (int i = 0; i < 3; ++i)
+  {
+    out += name;
+    out += "{quantile=\"";
+    out += ql[i];
+    out += "\"} ";
+    out += std::to_string(h.percentileNs(qs[i]));
+    out += '\n';
+  }
+  out += name;
+  out += "_sum ";
+  out += std::to_string(static_cast<uint64_t>(h.meanNs() * static_cast<double>(h.count())));
+  out += '\n';
+  out += name;
+  out += "_count ";
+  out += std::to_string(h.count());
+  out += '\n';
+}
+
+// Render a full Metrics snapshot as a Prometheus text page.
+inline std::string render(const Metrics& m)
+{
+  std::string out;
+  out.reserve(1024);
+  counter(out, "fme_orders_accepted_total", "Orders accepted onto the book", m.accepted);
+  counter(out, "fme_trades_total", "Trades matched", m.trades);
+  counter(out, "fme_cancels_total", "Orders canceled", m.cancels);
+  counter(out, "fme_rejects_total", "Orders rejected", m.rejects);
+  counter(out, "fme_modifies_total", "Orders modified", m.modifies);
+  counter(out, "fme_liquidations_total", "Positions liquidated", m.liquidations);
+  counter(out, "fme_fill_holds_total", "Fills held for last-look", m.holds);
+
+  out += "# HELP fme_traded_volume_raw Cumulative traded notional (quote, fixed-point raw)\n";
+  out += "# TYPE fme_traded_volume_raw counter\n";
+  out += "fme_traded_volume_raw ";
+  out += i128ToStr(m.volumeRaw);
+  out += '\n';
+
+  // Per-reason reject breakdown (labeled series). Only nonzero reasons emitted.
+  out += "# HELP fme_rejects_by_reason_total Orders rejected, by reason\n";
+  out += "# TYPE fme_rejects_by_reason_total counter\n";
+  for (size_t i = 0; i < Metrics::kReasons; ++i)
+  {
+    if (m.rejectsByReason[i] == 0)
+    {
+      continue;
+    }
+    out += "fme_rejects_by_reason_total{reason=\"";
+    out += toString(static_cast<RejectReason>(i));
+    out += "\"} ";
+    out += std::to_string(m.rejectsByReason[i]);
+    out += '\n';
+  }
+
+  latencySummary(out, "fme_submit_latency_ns", "Submit-to-response latency (ns)", m.submitLatency);
+  return out;
+}
+
+// Render counters + latency AND point-in-time venue gauges (insurance, funding,
+// open interest) sampled from the ledger/risk manager.
+inline std::string render(const Metrics& m, const Gauges& g)
+{
+  std::string out = render(m);
+  gaugeStr(out, "fme_insurance_fund_raw", "Insurance fund balance (quote, fixed-point raw)",
+           i128ToStr(g.insuranceFundRaw));
+  gaugeStr(out, "fme_funding_rate", "Last settled funding rate (fraction)",
+           std::to_string(g.fundingRate));
+  gaugeStr(out, "fme_open_interest_raw", "Aggregate open position notional (quote raw)",
+           i128ToStr(g.openInterestRaw));
+  gaugeStr(out, "fme_open_positions", "Open perp positions", std::to_string(g.openPositions));
+  gaugeStr(out, "fme_resting_orders", "Live resting orders", std::to_string(g.restingOrders));
+  gaugeStr(out, "fme_mark_price_age_ns", "Age of the current mark/index (ns; feed-lag alert)",
+           std::to_string(g.markPriceAgeNs));
+  gaugeStr(out, "fme_liquidations_paused", "1 = liquidation circuit breaker engaged",
+           std::to_string(g.liquidationsPaused));
+  return out;
+}
+
+}  // namespace prom
+}  // namespace flox::venue

--- a/venue/include/flox-venue/reject_reason.h
+++ b/venue/include/flox-venue/reject_reason.h
@@ -1,0 +1,52 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace flox::venue
+{
+
+enum class RejectReason : uint8_t
+{
+  None = 0,
+  UnknownSymbol,
+  Halted,
+  InvalidQuantity,
+  InvalidPrice,
+  TickSizeViolation,
+  LotSizeViolation,
+  DuplicateOrderId,
+  UnknownOrder,
+  PostOnlyWouldCross,
+  FillOrKillUnfulfillable,
+  OrderTooLarge,          // fat-finger: exceeds max order qty / notional
+  InsufficientFunds,      // pre-trade credit / buying-power check failed
+  LuldBreach,             // price outside the limit-up/limit-down volatility band
+  PositionLimitExceeded,  // would grow the account's position past the symbol cap
+  TooManyOpenOrders,      // account already at its max live-order count (ingress DoS/risk gate)
+};
+
+enum class CancelReason : uint8_t
+{
+  UserRequested = 0,
+  ImmediateOrCancelResidual,
+  MarketResidual,
+  SelfTradePrevention,
+  Expired,
+  OcoTriggered,        // canceled because a linked OCO order filled first
+  VenueHalt,           // canceled by an operator emergency halt-and-cancel
+  Liquidation,         // canceled because the account was liquidated (free its collateral)
+  FillOrKillResidual,  // a FOK that did not fully fill -- killed, never rests
+};
+
+const char* toString(RejectReason r) noexcept;
+const char* toString(CancelReason r) noexcept;
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/resend_buffer.h
+++ b/venue/include/flox-venue/resend_buffer.h
@@ -1,0 +1,117 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace flox::venue
+{
+
+struct SeqMessage
+{
+  uint64_t seq{};
+  int64_t tsNs{};
+  OutboundEvent event{};
+};
+
+class ResendBuffer
+{
+ public:
+  // Assign the next per-session sequence number, buffer the message, return seq.
+  uint64_t append(uint64_t session, const OutboundEvent& e, int64_t tsNs)
+  {
+    auto& s = sessions_[session];
+    const uint64_t seq = ++s.lastSeq;
+    s.log.push_back(SeqMessage{seq, tsNs, e});
+    return seq;
+  }
+
+  uint64_t lastSeq(uint64_t session) const
+  {
+    auto it = sessions_.find(session);
+    return it == sessions_.end() ? 0 : it->second.lastSeq;
+  }
+
+  // Replay buffered messages with seq >= fromSeq, in order (gap-fill on reconnect).
+  std::vector<SeqMessage> resend(uint64_t session, uint64_t fromSeq) const
+  {
+    std::vector<SeqMessage> out;
+    auto it = sessions_.find(session);
+    if (it == sessions_.end())
+    {
+      return out;
+    }
+    for (const auto& m : it->second.log)
+    {
+      if (m.seq >= fromSeq)
+      {
+        out.push_back(m);
+      }
+    }
+    return out;
+  }
+
+  // Drop acknowledged history up to and including `throughSeq` (bounded memory).
+  void ackThrough(uint64_t session, uint64_t throughSeq)
+  {
+    auto it = sessions_.find(session);
+    if (it == sessions_.end())
+    {
+      return;
+    }
+    auto& log = it->second.log;
+    size_t keep = 0;
+    while (keep < log.size() && log[keep].seq <= throughSeq)
+    {
+      ++keep;
+    }
+    log.erase(log.begin(), log.begin() + static_cast<std::ptrdiff_t>(keep));
+  }
+
+ private:
+  struct Session
+  {
+    uint64_t lastSeq{0};
+    std::vector<SeqMessage> log;
+  };
+  std::unordered_map<uint64_t, Session> sessions_;
+};
+
+// Client-side gap detector: tracks the next expected sequence and reports the
+// first missing seq when a message arrives out of order.
+class GapDetector
+{
+ public:
+  // Returns {gap, fromSeq}: gap=true means a resend for [fromSeq, seq) is needed.
+  std::pair<bool, uint64_t> observe(uint64_t seq)
+  {
+    if (seq == expected_)
+    {
+      ++expected_;
+      return {false, 0};
+    }
+    if (seq > expected_)
+    {
+      const uint64_t from = expected_;
+      expected_ = seq + 1;
+      return {true, from};
+    }
+    return {false, 0};  // duplicate / already seen
+  }
+  uint64_t expected() const noexcept { return expected_; }
+
+ private:
+  uint64_t expected_{1};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/rest_json.h
+++ b/venue/include/flox-venue/rest_json.h
@@ -1,0 +1,327 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace flox::venue
+{
+
+class RestJson
+{
+ public:
+  // ---- inbound: JSON body -> InboundCommand ----
+  // Schema: {"action":"new|cancel|modify", ...fields}
+  static std::optional<InboundCommand> decode(const std::string& json)
+  {
+    std::unordered_map<std::string, std::string> f;
+    if (!parse(json, f))
+    {
+      return std::nullopt;
+    }
+    auto has = [&](const char* k)
+    { return f.count(k) != 0; };
+    auto s = [&](const char* k)
+    { return has(k) ? f[k] : std::string{}; };
+    auto u64 = [&](const char* k)
+    { return static_cast<uint64_t>(std::strtoull(s(k).c_str(), nullptr, 10)); };
+    auto sym = [&](const char* k)
+    { return static_cast<SymbolId>(std::strtoul(s(k).c_str(), nullptr, 10)); };
+    auto price = [&](const char* k)
+    { return safeDecimal<Price>(std::strtod(s(k).c_str(), nullptr)); };
+    auto qtyf = [&](const char* k)
+    { return safeDecimal<Quantity>(std::strtod(s(k).c_str(), nullptr)); };
+
+    const std::string action = s("action");
+    if (action == "new")
+    {
+      NewOrder o;
+      o.id = u64("id");
+      o.clientOrderId = has("clientOrderId") ? u64("clientOrderId") : o.id;
+      o.symbol = sym("symbol");
+      o.side = (s("side") == "sell") ? Side::SELL : Side::BUY;
+      o.quantity = qtyf("qty");
+      o.accountId = u64("account");
+      const std::string t = s("ordType");
+      if (t == "market")
+      {
+        o.type = OrderType::MARKET;
+      }
+      else if (t == "stop")
+      {
+        o.type = OrderType::STOP_MARKET;
+      }
+      else if (t == "stop_limit")
+      {
+        o.type = OrderType::STOP_LIMIT;
+      }
+      else if (t == "take_profit")
+      {
+        o.type = OrderType::TAKE_PROFIT_MARKET;
+      }
+      else if (t == "trailing")
+      {
+        o.type = OrderType::TRAILING_STOP;
+      }
+      else
+      {
+        o.type = OrderType::LIMIT;
+      }
+      if (has("price"))
+      {
+        o.price = price("price");
+      }
+      if (has("trigger"))
+      {
+        o.triggerPrice = price("trigger");
+      }
+      if (has("trailingOffset"))
+      {
+        o.trailingOffset = price("trailingOffset");
+      }
+      if (has("visible"))
+      {
+        o.visibleQuantity = qtyf("visible");
+      }
+      const std::string tif = s("tif");
+      if (tif == "ioc")
+      {
+        o.tif = TimeInForce::IOC;
+      }
+      else if (tif == "fok")
+      {
+        o.tif = TimeInForce::FOK;
+      }
+      else
+      {
+        o.tif = TimeInForce::GTC;
+      }
+      if (s("postOnly") == "true")
+      {
+        o.postOnly = true;
+      }
+      if (s("reduceOnly") == "true")
+      {
+        o.reduceOnly = true;  // derivatives: never open
+      }
+      const std::string stp = s("stp");  // self-trade prevention mode
+      if (stp == "cancelNewest")
+      {
+        o.stp = STPMode::CancelNewest;
+      }
+      else if (stp == "cancelOldest")
+      {
+        o.stp = STPMode::CancelOldest;
+      }
+      else if (stp == "cancelBoth")
+      {
+        o.stp = STPMode::CancelBoth;
+      }
+      else if (stp == "decrement")
+      {
+        o.stp = STPMode::Decrement;
+      }
+      return InboundCommand{o};
+    }
+    if (action == "cancel")
+    {
+      return InboundCommand{CancelOrder{u64("id"), sym("symbol"), u64("account")}};
+    }
+    if (action == "modify")
+    {
+      ModifyOrder m;
+      m.id = u64("id");
+      m.symbol = sym("symbol");
+      if (has("price"))
+      {
+        m.newPrice = price("price");
+      }
+      m.newQty = qtyf("qty");
+      m.accountId = u64("account");
+      return InboundCommand{m};
+    }
+    return std::nullopt;
+  }
+
+  // ---- outbound: OutboundEvent -> JSON ----
+  static std::string encode(const OutboundEvent& ev)
+  {
+    std::string o = "{";
+    auto kv = [&](const char* k, const std::string& v, bool quote)
+    {
+      if (o.size() > 1)
+      {
+        o += ",";
+      }
+      o += "\"";
+      o += k;
+      o += "\":";
+      if (quote)
+      {
+        o += "\"";
+      }
+      o += v;
+      if (quote)
+      {
+        o += "\"";
+      }
+    };
+    auto id = [](uint64_t v)
+    { return std::to_string(v); };
+    auto pr = [](Price p)
+    { return std::to_string(p.toDouble()); };
+    auto qn = [](Quantity q)
+    { return std::to_string(q.toDouble()); };
+
+    if (const auto* a = std::get_if<OrderAccepted>(&ev))
+    {
+      kv("type", "accepted", true);
+      kv("id", id(a->id), false);
+      kv("side", a->side == Side::SELL ? "sell" : "buy", true);
+      kv("price", pr(a->price), false);
+      kv("leaves", qn(a->leavesQty), false);
+      kv("onBook", a->restingOnBook ? "true" : "false", false);
+    }
+    else if (const auto* t = std::get_if<Trade>(&ev))
+    {
+      kv("type", "trade", true);
+      kv("tradeId", id(t->tradeId), false);
+      kv("price", pr(t->price), false);
+      kv("qty", qn(t->quantity), false);
+      kv("maker", id(t->makerId), false);
+      kv("taker", id(t->takerId), false);
+    }
+    else if (const auto* x = std::get_if<OrderExecuted>(&ev))
+    {
+      kv("type", "executed", true);
+      kv("id", id(x->id), false);
+      kv("lastQty", qn(x->lastQty), false);
+      kv("leaves", qn(x->leavesQty), false);
+      kv("complete", x->complete ? "true" : "false", false);
+    }
+    else if (const auto* c = std::get_if<OrderCanceled>(&ev))
+    {
+      kv("type", "canceled", true);
+      kv("id", id(c->id), false);
+      kv("reason", toString(c->reason), true);
+    }
+    else if (const auto* j = std::get_if<OrderRejected>(&ev))
+    {
+      kv("type", "rejected", true);
+      kv("id", id(j->id), false);
+      kv("reason", toString(j->reason), true);
+    }
+    else if (const auto* m = std::get_if<OrderModified>(&ev))
+    {
+      kv("type", "modified", true);
+      kv("id", id(m->id), false);
+      kv("price", pr(m->price), false);
+      kv("leaves", qn(m->leavesQty), false);
+    }
+    else if (const auto* g = std::get_if<OrderTriggered>(&ev))
+    {
+      kv("type", "triggered", true);
+      kv("id", id(g->id), false);
+      kv("refPrice", pr(g->refPrice), false);
+    }
+    o += "}";
+    return o;
+  }
+
+ private:
+  static std::string parseString(const std::string& s, size_t& i)
+  {
+    std::string out;
+    ++i;  // opening quote
+    while (i < s.size() && s[i] != '"')
+    {
+      if (s[i] == '\\' && i + 1 < s.size())
+      {
+        ++i;
+      }
+      out += s[i++];
+    }
+    if (i < s.size())
+    {
+      ++i;  // closing quote
+    }
+    return out;
+  }
+
+  static bool parse(const std::string& s, std::unordered_map<std::string, std::string>& out)
+  {
+    size_t i = 0;
+    auto ws = [&]
+    { while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i]))){ ++i;
+} };
+    ws();
+    if (i >= s.size() || s[i] != '{')
+    {
+      return false;
+    }
+    ++i;
+    ws();
+    if (i < s.size() && s[i] == '}')
+    {
+      return true;
+    }
+    while (i < s.size())
+    {
+      ws();
+      if (i >= s.size() || s[i] != '"')
+      {
+        return false;
+      }
+      const std::string key = parseString(s, i);
+      ws();
+      if (i >= s.size() || s[i] != ':')
+      {
+        return false;
+      }
+      ++i;
+      ws();
+      std::string val;
+      if (i < s.size() && s[i] == '"')
+      {
+        val = parseString(s, i);
+      }
+      else
+      {
+        const size_t st = i;
+        while (i < s.size() && s[i] != ',' && s[i] != '}' &&
+               !std::isspace(static_cast<unsigned char>(s[i])))
+        {
+          ++i;
+        }
+        val = s.substr(st, i - st);
+      }
+      out[key] = val;
+      ws();
+      if (i < s.size() && s[i] == ',')
+      {
+        ++i;
+        continue;
+      }
+      if (i < s.size() && s[i] == '}')
+      {
+        return true;
+      }
+      return false;
+    }
+    return false;
+  }
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/segregation.h
+++ b/venue/include/flox-venue/segregation.h
@@ -1,0 +1,73 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/ledger.h"
+
+#include <cstdint>
+#include <unordered_set>
+#include <utility>
+
+namespace flox::venue
+{
+
+class SegregationReport
+{
+ public:
+  SegregationReport(const Ledger& led, std::unordered_set<uint64_t> houseAccounts)
+      : led_(led), house_(std::move(houseAccounts))
+  {
+  }
+
+  // Segregated client money owed for `asset`: the sum of each client's POSITIVE
+  // balance. A client's debit (negative) balance is the firm's receivable from
+  // that client, NOT a reduction of what the firm owes other clients -- netting
+  // it in (as a plain signed sum would) understates the segregation requirement
+  // and lets a real custody shortfall report as fully backed. A negative client
+  // wallet is reachable (funding can drive `available` negative on an account
+  // whose position margin keeps it unliquidated).
+  Amount clientTotal(AssetId asset) const
+  {
+    Amount t = 0;
+    led_.forEachBalance([&](uint64_t acct, AssetId a, Amount total)
+                        { if (a == asset && !house_.count(acct) && total > 0){ t += total;
+} });
+    return t;
+  }
+
+  // House (operational + insurance) money for `asset`.
+  Amount houseTotal(AssetId asset) const
+  {
+    Amount t = 0;
+    led_.forEachBalance([&](uint64_t acct, AssetId a, Amount total)
+                        { if (a == asset && house_.count(acct)){ t += total;
+} });
+    return t;
+  }
+
+  // Client money must be fully covered by the segregated custody balance.
+  bool fullyBacked(AssetId asset, Amount custodyBalance) const
+  {
+    return custodyBalance >= clientTotal(asset);
+  }
+
+  // Regulatory shortfall: how much custody falls short of client money owed
+  // (0 when fully backed). A positive value is a reportable breach.
+  Amount shortfall(AssetId asset, Amount custodyBalance) const
+  {
+    const Amount owed = clientTotal(asset);
+    return custodyBalance < owed ? owed - custodyBalance : 0;
+  }
+
+ private:
+  const Ledger& led_;
+  std::unordered_set<uint64_t> house_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/sequenced_shard.h
+++ b/venue/include/flox-venue/sequenced_shard.h
@@ -1,0 +1,157 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/journal.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/messages.h"
+#include "flox/book/matching_book.h"
+
+#include "flox/util/eventing/event_bus.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace flox::venue
+{
+
+// ---- ingress: normalized commands from every gateway ----
+struct InboundCommandEvent;
+struct ICommandListener
+{
+  virtual ~ICommandListener() = default;
+  virtual void onCommand(const InboundCommandEvent& ev) = 0;
+};
+struct InboundCommandEvent
+{
+  using Listener = ICommandListener;
+  InboundCommand cmd{};
+  uint64_t tickSequence = 0;  // gateway sequence number, stamped by the bus
+};
+
+// ---- outbound: engine events fanned out to exec-report / market-data / ... ----
+struct EngineEventMsg;
+struct IEngineEventListener
+{
+  virtual ~IEngineEventListener() = default;
+  virtual void onEngineEvent(const EngineEventMsg& ev) = 0;
+};
+struct EngineEventMsg
+{
+  using Listener = IEngineEventListener;
+  OutboundEvent event{};
+  uint64_t tickSequence = 0;
+};
+
+}  // namespace flox::venue
+
+namespace flox
+{
+template <>
+struct EventDispatcher<flox::venue::InboundCommandEvent>
+{
+  static void dispatch(const flox::venue::InboundCommandEvent& ev, flox::venue::ICommandListener& l)
+  {
+    l.onCommand(ev);
+  }
+};
+template <>
+struct EventDispatcher<flox::venue::EngineEventMsg>
+{
+  static void dispatch(const flox::venue::EngineEventMsg& ev, flox::venue::IEngineEventListener& l)
+  {
+    l.onEngineEvent(ev);
+  }
+};
+}  // namespace flox
+
+namespace flox::venue
+{
+
+template <class Book = MatchingBook, size_t IngressCap = 1 << 16, size_t OutboundCap = 1 << 16>
+class SequencedShard
+{
+ public:
+  using IngressBus = flox::EventBus<InboundCommandEvent, IngressCap, 4>;
+  using OutboundBus = flox::EventBus<EngineEventMsg, OutboundCap, 8>;
+
+  SequencedShard(SymbolConfig cfg, const std::string& journalPath, Book book = Book{})
+      : journal_(journalPath),
+        consumer_(cfg, journal_, outbound_, std::move(book))
+  {
+    ingress_.enableDrainOnStop();
+    outbound_.enableDrainOnStop();
+  }
+
+  // Subscribe an outbound consumer (exec-report, market-data, ...). Must be
+  // called before start().
+  bool subscribeOutbound(IEngineEventListener* l, bool required = true)
+  {
+    return outbound_.subscribe(l, required);
+  }
+
+  void start()
+  {
+    outbound_.start();  // must be live before the matching thread publishes
+    ingress_.subscribe(&consumer_, true);
+    ingress_.start();
+  }
+
+  // Producer side (gateway). Returns the ingress sequence number.
+  int64_t submit(const InboundCommand& cmd) { return ingress_.publish(InboundCommandEvent{cmd}); }
+
+  void flush()
+  {
+    ingress_.flush();
+    outbound_.flush();
+  }
+
+  void stop()
+  {
+    ingress_.flush();
+    ingress_.stop();
+    outbound_.flush();
+    outbound_.stop();
+    journal_.flush();
+  }
+
+  uint64_t journaled() const noexcept { return journal_.count(); }
+
+ private:
+  class MatchingConsumer : public ICommandListener
+  {
+   public:
+    MatchingConsumer(SymbolConfig cfg, Journal& journal, OutboundBus& out, Book book)
+        : journal_(journal),
+          out_(out),
+          engine_(cfg, [this](const OutboundEvent& ev)
+                  { out_.publish(EngineEventMsg{ev}); }, std::move(book))
+    {
+    }
+
+    void onCommand(const InboundCommandEvent& ev) override
+    {
+      journal_.append(ev.cmd);  // write-ahead, before applying
+      engine_.submit(ev.cmd);
+    }
+
+   private:
+    Journal& journal_;
+    OutboundBus& out_;
+    MatchingEngine<Book> engine_;
+  };
+
+  Journal journal_;
+  OutboundBus outbound_;
+  MatchingConsumer consumer_;
+  IngressBus ingress_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/session.h
+++ b/venue/include/flox-venue/session.h
@@ -1,0 +1,201 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+#include "flox/util/crypto.h"
+
+#include "flox/backtest/rate_limit_policy.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace flox::venue
+{
+
+inline flox::RateLimitPolicy::ActionKind actionOf(const InboundCommand& c) noexcept
+{
+  if (std::get_if<NewOrder>(&c))
+  {
+    return flox::RateLimitPolicy::ActionKind::Submit;
+  }
+  if (std::get_if<CancelOrder>(&c) || std::get_if<MassCancel>(&c))
+  {
+    return flox::RateLimitPolicy::ActionKind::Cancel;
+  }
+  if (std::get_if<Quote>(&c))
+  {
+    return flox::RateLimitPolicy::ActionKind::Submit;
+  }
+  if (std::get_if<LastLookDecision>(&c))
+  {
+    return flox::RateLimitPolicy::ActionKind::QueryAccount;
+  }
+  return flox::RateLimitPolicy::ActionKind::Replace;
+}
+
+enum class SessionReject : uint8_t
+{
+  None = 0,
+  Unauthenticated,
+  RateLimited,
+  DecodeError,
+};
+
+inline const char* toString(SessionReject r) noexcept
+{
+  switch (r)
+  {
+    case SessionReject::None:
+      return "None";
+    case SessionReject::Unauthenticated:
+      return "Unauthenticated";
+    case SessionReject::RateLimited:
+      return "RateLimited";
+    case SessionReject::DecodeError:
+      return "DecodeError";
+  }
+  return "?";
+}
+
+class GatewaySession
+{
+ public:
+  using Decoder = std::function<std::optional<InboundCommand>(const uint8_t*, size_t)>;
+
+  GatewaySession(uint64_t account, Decoder decode,
+                 flox::RateLimitPolicy limits = flox::RateLimitPolicy::binance_um_futures(),
+                 std::string secret = {})
+      : account_(account), decode_(std::move(decode)), limits_(std::move(limits)), secret_(std::move(secret))
+  {
+  }
+
+  void authenticate(bool ok) noexcept { authed_ = ok; }
+  bool authenticated() const noexcept { return authed_; }
+  uint64_t account() const noexcept { return account_; }
+  // Bind this session to an authenticated account (e.g. after logon resolves the
+  // API key to an account). Once bound to a non-zero account, handle() forces
+  // that account onto every command -- see stampAccount.
+  void bindAccount(uint64_t a) noexcept { account_ = a; }
+
+  // API-key HMAC logon (crypto-exchange style): the client signs
+  // "apiKey:timestamp" with the shared secret. Verifies signature (constant
+  // time) and timestamp skew, then marks the session authenticated.
+  bool logon(const std::string& apiKey, uint64_t ts, const std::string& sigHex, uint64_t nowTs,
+             uint64_t maxSkewSec = 5)
+  {
+    if (secret_.empty())
+    {
+      return false;
+    }
+    const uint64_t skew = (nowTs > ts) ? (nowTs - ts) : (ts - nowTs);
+    if (skew > maxSkewSec)
+    {
+      return false;
+    }
+    const std::string payload = apiKey + ":" + std::to_string(ts);
+    const auto mac = crypto::hmacSha256(reinterpret_cast<const uint8_t*>(secret_.data()),
+                                        secret_.size(),
+                                        reinterpret_cast<const uint8_t*>(payload.data()),
+                                        payload.size());
+    const std::string expect = crypto::toHex(mac.data(), mac.size());
+    if (expect.size() != sigHex.size())
+    {
+      return false;
+    }
+    unsigned diff = 0;
+    for (size_t i = 0; i < expect.size(); ++i)
+    {
+      diff |= static_cast<unsigned>(expect[i] ^ sigHex[i]);
+    }
+    if (diff == 0)
+    {
+      authed_ = true;
+      return true;
+    }
+    return false;
+  }
+
+  // Decode + admission-control one inbound frame. Returns the command to submit,
+  // or nullopt with `out` set to the rejection reason.
+  std::optional<InboundCommand> handle(const uint8_t* p, size_t n, int64_t nowNs,
+                                       SessionReject& out)
+  {
+    out = SessionReject::None;
+    if (!authed_)
+    {
+      out = SessionReject::Unauthenticated;
+      return std::nullopt;
+    }
+    auto cmd = decode_(p, n);
+    if (!cmd)
+    {
+      out = SessionReject::DecodeError;
+      return std::nullopt;
+    }
+    // Authorization: a session bound to a real account may only act as that
+    // account. Overwrite the client-supplied accountId so a client can never
+    // place orders on, spend the collateral of, or mass-cancel another account
+    // by writing a different id into the payload. account_ == 0 is the "unbound
+    // / trusted-transport" sentinel (current gateway stubs) and passes through.
+    if (account_ != 0)
+    {
+      stampAccount(*cmd, account_);
+    }
+    if (!limits_.tryConsume(actionOf(*cmd), nowNs))
+    {
+      out = SessionReject::RateLimited;
+      return std::nullopt;
+    }
+    return cmd;
+  }
+
+ private:
+  // Force `a` onto every account-bearing command so the session can only ever
+  // act as its own authenticated account. Admin/market commands (SetMark,
+  // ApplyFunding) carry no account and are left untouched here.
+  static void stampAccount(InboundCommand& c, uint64_t a) noexcept
+  {
+    if (auto* n = std::get_if<NewOrder>(&c))
+    {
+      n->accountId = a;
+    }
+    else if (auto* x = std::get_if<CancelOrder>(&c))
+    {
+      x->accountId = a;
+    }
+    else if (auto* m = std::get_if<ModifyOrder>(&c))
+    {
+      m->accountId = a;
+    }
+    else if (auto* mc = std::get_if<MassCancel>(&c))
+    {
+      mc->accountId = a;
+    }
+    else if (auto* q = std::get_if<Quote>(&c))
+    {
+      q->accountId = a;
+    }
+    else if (auto* ll = std::get_if<LastLookDecision>(&c))
+    {
+      ll->accountId = a;
+    }
+  }
+
+  uint64_t account_;
+  Decoder decode_;
+  flox::RateLimitPolicy limits_;
+  std::string secret_;
+  bool authed_{false};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/socket_acceptor.h
+++ b/venue/include/flox-venue/socket_acceptor.h
@@ -1,0 +1,153 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <atomic>
+#include <csignal>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+// A peer that vanishes mid-write must never take the process down. BSD/macOS
+// suppress SIGPIPE per-socket (SO_NOSIGPIPE); Linux has no such option and
+// SSL_write cannot pass MSG_NOSIGNAL, so we ignore the signal process-wide once.
+// EPIPE is then returned to the writer, which closes the session cleanly.
+inline void suppressSigpipe(int fd) noexcept
+{
+#ifdef SO_NOSIGPIPE
+  int one = 1;
+  ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof one);
+#else
+  (void)fd;
+  static const bool ignored = []
+  { ::signal(SIGPIPE, SIG_IGN); return true; }();
+  (void)ignored;
+#endif
+}
+
+class SocketAcceptor
+{
+ public:
+  using OnConn = std::function<void(int fd)>;
+
+  ~SocketAcceptor() { stop(); }
+
+  // Listen on loopback:port (0 = ephemeral). Returns the bound port, or -1.
+  int start(uint16_t port, OnConn onConn)
+  {
+    onConn_ = std::move(onConn);
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    listenFd_.store(fd);
+    if (fd < 0)
+    {
+      return -1;
+    }
+    int one = 1;
+    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof one);
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = htons(port);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) < 0)
+    {
+      ::close(fd);
+      listenFd_.store(-1);
+      return -1;
+    }
+    socklen_t sl = sizeof a;
+    ::getsockname(fd, reinterpret_cast<sockaddr*>(&a), &sl);
+    port_ = ntohs(a.sin_port);
+    ::listen(fd, 16);
+    running_.store(true);
+    acceptThread_ = std::thread([this]
+                                { acceptLoop(); });
+    return port_;
+  }
+
+  void stop()
+  {
+    if (!running_.exchange(false))
+    {
+      return;
+    }
+    // Take the descriptor out atomically: the accept thread reads it in its
+    // ::accept() call, so it must not observe a torn or dangling value.
+    const int fd = listenFd_.exchange(-1);
+    if (fd >= 0)
+    {
+      ::shutdown(fd, SHUT_RDWR);
+      ::close(fd);
+    }
+    if (acceptThread_.joinable())
+    {
+      acceptThread_.join();
+    }
+    // The accept thread has been joined, so no new connection threads can be
+    // appended; take them under the lock all the same and join outside it.
+    std::vector<std::thread> conns;
+    {
+      std::lock_guard<std::mutex> lk(connsMutex_);
+      conns.swap(conns_);
+    }
+    for (auto& t : conns)
+    {
+      if (t.joinable())
+      {
+        t.join();
+      }
+    }
+  }
+
+  int port() const noexcept { return port_; }
+  bool running() const noexcept { return running_.load(); }
+
+ private:
+  void acceptLoop()
+  {
+    while (running_.load())
+    {
+      const int fd = ::accept(listenFd_.load(), nullptr, nullptr);
+      if (fd < 0)
+      {
+        if (!running_.load())
+        {
+          break;
+        }
+        continue;
+      }
+      int one = 1;
+      ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
+      suppressSigpipe(fd);
+      std::lock_guard<std::mutex> lk(connsMutex_);
+      conns_.emplace_back([this, fd]
+                          { onConn_(fd); });
+    }
+  }
+
+  OnConn onConn_;
+  std::atomic<int> listenFd_{-1};
+  int port_{0};
+  std::atomic<bool> running_{false};
+  std::thread acceptThread_;
+  std::mutex connsMutex_;
+  std::vector<std::thread> conns_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/stop_book.h
+++ b/venue/include/flox-venue/stop_book.h
@@ -1,0 +1,329 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace flox::venue
+{
+
+inline bool isConditional(OrderType t) noexcept
+{
+  return t == OrderType::STOP_MARKET || t == OrderType::STOP_LIMIT ||
+         t == OrderType::TAKE_PROFIT_MARKET || t == OrderType::TAKE_PROFIT_LIMIT ||
+         t == OrderType::TRAILING_STOP;
+}
+
+inline bool isLimitStop(OrderType t) noexcept
+{
+  return t == OrderType::STOP_LIMIT || t == OrderType::TAKE_PROFIT_LIMIT;
+}
+
+inline bool isTakeProfit(OrderType t) noexcept
+{
+  return t == OrderType::TAKE_PROFIT_MARKET || t == OrderType::TAKE_PROFIT_LIMIT;
+}
+
+class StopBook
+{
+ public:
+  bool empty() const noexcept
+  {
+    return up_.empty() && down_.empty() && trailing_.empty();
+  }
+
+  bool contains(OrderId id) const noexcept { return loc_.count(id) != 0; }
+
+  // All pending conditional-order ids (for venue-wide emergency cancel).
+  std::vector<OrderId> ids() const
+  {
+    std::vector<OrderId> out;
+    out.reserve(loc_.size());
+    for (const auto& [id, l] : loc_)
+    {
+      (void)l;
+      out.push_back(id);
+    }
+    return out;
+  }
+
+  // Enumerate every pending conditional order (its NewOrder + current trigger)
+  // -- for account snapshots / reconnect reconciliation.
+  template <class Fn>
+  void forEachPending(Fn&& fn) const
+  {
+    for (const auto& [t, p] : up_)
+    {
+      (void)t;
+      fn(p.order, p.trigger);
+    }
+    for (const auto& [t, p] : down_)
+    {
+      (void)t;
+      fn(p.order, p.trigger);
+    }
+    for (const auto& p : trailing_)
+    {
+      fn(p.order, p.trigger);
+    }
+  }
+
+  void add(const NewOrder& o, Price initialTrigger, bool trailing)
+  {
+    if (trailing)
+    {
+      trailing_.push_back(Pending{o, initialTrigger});
+      loc_[o.id] = Loc{Container::Trailing, initialTrigger};
+      return;
+    }
+    // Up = fires when ref >= trigger (BUY stop-loss, SELL take-profit).
+    const bool up = (o.side == Side::BUY) != isTakeProfit(o.type);
+    if (up)
+    {
+      up_.emplace(initialTrigger, Pending{o, initialTrigger});
+      loc_[o.id] = Loc{Container::Up, initialTrigger};
+    }
+    else
+    {
+      down_.emplace(initialTrigger, Pending{o, initialTrigger});
+      loc_[o.id] = Loc{Container::Down, initialTrigger};
+    }
+  }
+
+  bool cancel(OrderId id)
+  {
+    auto lit = loc_.find(id);
+    if (lit == loc_.end())
+    {
+      return false;
+    }
+    const Loc loc = lit->second;
+    loc_.erase(lit);
+    switch (loc.container)
+    {
+      case Container::Up:
+        eraseFrom(up_, loc.trigger, id);
+        return true;
+      case Container::Down:
+        eraseFrom(down_, loc.trigger, id);
+        return true;
+      case Container::Trailing:
+        for (size_t i = 0; i < trailing_.size(); ++i)
+        {
+          if (trailing_[i].order.id == id)
+          {
+            trailing_.erase(trailing_.begin() + static_cast<std::ptrdiff_t>(i));
+            break;
+          }
+        }
+        return true;
+    }
+    return false;
+  }
+
+  // Ratchet trailing triggers toward the market; a trailing stop never loosens.
+  void updateTrailing(Price last)
+  {
+    for (auto& s : trailing_)
+    {
+      const int64_t off = s.order.trailingOffset.raw();
+      if (s.order.side == Side::SELL)
+      {
+        const Price cand = Price::fromRaw(last.raw() - off);
+        if (s.trigger.raw() == 0 || cand > s.trigger)
+        {
+          s.trigger = cand;
+        }
+      }
+      else
+      {
+        const Price cand = Price::fromRaw(last.raw() + off);
+        if (s.trigger.raw() == 0 || cand < s.trigger)
+        {
+          s.trigger = cand;
+        }
+      }
+    }
+  }
+
+  // Pop the highest-priority triggered stop as an aggressor NewOrder. Firing
+  // order: most-in-the-money first (largest cross distance), ties by id.
+  std::optional<NewOrder> popTriggered(Price ref)
+  {
+    bool have = false;
+    int64_t bestDist = -1;
+    OrderId bestId = 0;
+    Container bestC = Container::Up;
+    Price bestTrig{};
+
+    auto consider = [&](Container c, Price trig, OrderId id, int64_t dist)
+    {
+      if (!have || dist > bestDist || (dist == bestDist && id < bestId))
+      {
+        have = true;
+        bestDist = dist;
+        bestId = id;
+        bestC = c;
+        bestTrig = trig;
+      }
+    };
+
+    // Up: fires when ref >= trigger; most crossed = lowest trigger = begin().
+    if (!up_.empty() && !(ref < up_.begin()->first))
+    {
+      const Price trig = up_.begin()->first;
+      OrderId id = 0;
+      bool first = true;
+      for (auto it = up_.lower_bound(trig); it != up_.end() && it->first == trig; ++it)
+      {
+        if (first || it->second.order.id < id)
+        {
+          id = it->second.order.id;
+          first = false;
+        }
+      }
+      consider(Container::Up, trig, id, ref.raw() - trig.raw());
+    }
+    // Down: fires when ref <= trigger; most crossed = highest trigger = begin().
+    if (!down_.empty() && !(down_.begin()->first < ref))
+    {
+      const Price trig = down_.begin()->first;
+      OrderId id = 0;
+      bool first = true;
+      for (auto it = down_.lower_bound(trig); it != down_.end() && it->first == trig; ++it)
+      {
+        if (first || it->second.order.id < id)
+        {
+          id = it->second.order.id;
+          first = false;
+        }
+      }
+      consider(Container::Down, trig, id, trig.raw() - ref.raw());
+    }
+    // Trailing: small side list, scan for eligible.
+    int trailIdx = -1;
+    for (size_t i = 0; i < trailing_.size(); ++i)
+    {
+      const auto& s = trailing_[i];
+      if (s.trigger.raw() == 0)
+      {
+        continue;
+      }
+      const bool fires = (s.order.side == Side::BUY) ? !(ref < s.trigger) : !(s.trigger < ref);
+      if (!fires)
+      {
+        continue;
+      }
+      const int64_t dist = (s.order.side == Side::BUY) ? (ref.raw() - s.trigger.raw())
+                                                       : (s.trigger.raw() - ref.raw());
+      const OrderId id = s.order.id;
+      if (!have || dist > bestDist || (dist == bestDist && id < bestId))
+      {
+        have = true;
+        bestDist = dist;
+        bestId = id;
+        bestC = Container::Trailing;
+        trailIdx = static_cast<int>(i);
+      }
+    }
+
+    if (!have)
+    {
+      return std::nullopt;
+    }
+
+    NewOrder agg;
+    if (bestC == Container::Trailing)
+    {
+      agg = toAggressor(trailing_[static_cast<size_t>(trailIdx)]);
+      trailing_.erase(trailing_.begin() + trailIdx);
+    }
+    else if (bestC == Container::Up)
+    {
+      auto it = up_.lower_bound(bestTrig);
+      for (; it != up_.end() && it->first == bestTrig; ++it)
+      {
+        if (it->second.order.id == bestId)
+        {
+          break;
+        }
+      }
+      agg = toAggressor(it->second);
+      up_.erase(it);
+    }
+    else
+    {
+      auto it = down_.lower_bound(bestTrig);
+      for (; it != down_.end() && it->first == bestTrig; ++it)
+      {
+        if (it->second.order.id == bestId)
+        {
+          break;
+        }
+      }
+      agg = toAggressor(it->second);
+      down_.erase(it);
+    }
+    loc_.erase(bestId);
+    return agg;
+  }
+
+ private:
+  struct Pending
+  {
+    NewOrder order{};
+    Price trigger{};
+  };
+  enum class Container : uint8_t
+  {
+    Up,
+    Down,
+    Trailing
+  };
+  struct Loc
+  {
+    Container container{};
+    Price trigger{};
+  };
+
+  static NewOrder toAggressor(const Pending& s)
+  {
+    NewOrder o = s.order;
+    o.type = isLimitStop(s.order.type) ? OrderType::LIMIT : OrderType::MARKET;
+    o.visibleQuantity = Quantity{};  // a triggered stop aggresses in full
+    return o;
+  }
+
+  template <class Map>
+  static void eraseFrom(Map& m, Price trigger, OrderId id)
+  {
+    for (auto it = m.lower_bound(trigger); it != m.end() && it->first == trigger; ++it)
+    {
+      if (it->second.order.id == id)
+      {
+        m.erase(it);
+        return;
+      }
+    }
+  }
+
+  std::multimap<Price, Pending> up_;                         // ascending: begin() = lowest trigger
+  std::multimap<Price, Pending, std::greater<Price>> down_;  // begin() = highest trigger
+  std::vector<Pending> trailing_;
+  std::unordered_map<OrderId, Loc> loc_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/symbol_router.h
+++ b/venue/include/flox-venue/symbol_router.h
@@ -1,0 +1,109 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+inline SymbolId symbolOf(const InboundCommand& c) noexcept
+{
+  if (const auto* n = std::get_if<NewOrder>(&c))
+  {
+    return n->symbol;
+  }
+  if (const auto* x = std::get_if<CancelOrder>(&c))
+  {
+    return x->symbol;
+  }
+  if (const auto* m = std::get_if<ModifyOrder>(&c))
+  {
+    return m->symbol;
+  }
+  if (const auto* mc = std::get_if<MassCancel>(&c))
+  {
+    return mc->symbol;
+  }
+  if (const auto* q = std::get_if<Quote>(&c))
+  {
+    return q->symbol;
+  }
+  if (const auto* ll = std::get_if<LastLookDecision>(&c))
+  {
+    return ll->symbol;
+  }
+  if (const auto* sm = std::get_if<SetMark>(&c))
+  {
+    return sm->symbol;
+  }
+  if (const auto* af = std::get_if<ApplyFunding>(&c))
+  {
+    return af->symbol;
+  }
+  return std::get<AdminCmd>(c).symbol;
+}
+
+template <class Book = MatchingBook>
+class SymbolRouter
+{
+ public:
+  explicit SymbolRouter(size_t nShards) : nShards_(nShards == 0 ? 1 : nShards) {}
+
+  size_t shardOf(SymbolId s) const noexcept { return std::hash<SymbolId>{}(s) % nShards_; }
+  size_t shardCount() const noexcept { return nShards_; }
+  bool has(SymbolId s) const noexcept { return engines_.count(s) != 0; }
+
+  MatchingEngine<Book>& addSymbol(SymbolConfig cfg, EventSink sink, Book book = Book{})
+  {
+    auto eng = std::make_unique<MatchingEngine<Book>>(cfg, std::move(sink), std::move(book));
+    auto& ref = *eng;
+    engines_.emplace(cfg.id, std::move(eng));
+    return ref;
+  }
+
+  void submit(const InboundCommand& cmd)
+  {
+    if (auto it = engines_.find(symbolOf(cmd)); it != engines_.end())
+    {
+      it->second->submit(cmd);
+    }
+  }
+
+  // Cross-shard account view for reconnect: the account's per-symbol snapshots,
+  // limited to symbols where it has activity (orders / stops / a position).
+  std::vector<std::pair<SymbolId, typename MatchingEngine<Book>::AccountSnapshot>> snapshotAccount(
+      uint64_t acct) const
+  {
+    std::vector<std::pair<SymbolId, typename MatchingEngine<Book>::AccountSnapshot>> out;
+    for (const auto& [sym, eng] : engines_)
+    {
+      auto s = eng->snapshotAccount(acct);
+      if (!s.openOrders.empty() || !s.pendingStops.empty() || s.positionQty != 0)
+      {
+        out.emplace_back(sym, std::move(s));
+      }
+    }
+    return out;
+  }
+
+ private:
+  size_t nShards_;
+  std::unordered_map<SymbolId, std::unique_ptr<MatchingEngine<Book>>> engines_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/tape_recorder.h
+++ b/venue/include/flox-venue/tape_recorder.h
@@ -1,0 +1,75 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include "flox/replay/binary_format_v1.h"
+#include "flox/replay/writers/binary_log_writer.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace flox::venue
+{
+
+class TapeRecorder
+{
+ public:
+  TapeRecorder(const std::string& dir, const std::string& filename)
+  {
+    flox::replay::WriterConfig cfg;
+    cfg.output_dir = dir;
+    cfg.output_filename = filename;
+    writer_ = std::make_unique<flox::replay::BinaryLogWriter>(std::move(cfg));
+    writer_->setHasTrades(true);
+  }
+
+  // Ingests the engine's outbound stream; persists every trade print.
+  // `tsNs` should be the sequencer-stamped time; here a monotonic counter keeps
+  // the tape sorted deterministically without a wall-clock dependency.
+  void onEvent(const OutboundEvent& e)
+  {
+    const auto* t = std::get_if<Trade>(&e);
+    if (t == nullptr)
+    {
+      return;
+    }
+    flox::replay::TradeRecord rec{};
+    rec.exchange_ts_ns = ++ts_;
+    rec.recv_ts_ns = ts_;
+    rec.price_raw = t->price.raw();
+    rec.qty_raw = t->quantity.raw();
+    rec.trade_id = t->tradeId;
+    rec.symbol_id = t->symbol;
+    rec.side = static_cast<uint8_t>(t->takerSide);
+    writer_->writeTrade(rec);
+  }
+
+  void close()
+  {
+    if (writer_)
+    {
+      writer_->close();
+    }
+  }
+
+  uint64_t tradesWritten() const
+  {
+    return writer_ ? writer_->stats().trades_written : 0;
+  }
+
+ private:
+  std::unique_ptr<flox::replay::BinaryLogWriter> writer_;
+  int64_t ts_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/tcp_gateway.h
+++ b/venue/include/flox-venue/tcp_gateway.h
@@ -1,0 +1,80 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/cancel_on_disconnect.h"
+#include "flox-venue/messages.h"
+#include "flox-venue/session.h"
+#include "flox-venue/socket_acceptor.h"
+#include "flox/util/transport.h"
+
+#include <unistd.h>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+class TcpGateway
+{
+ public:
+  using Responder = std::function<void(const uint8_t*, size_t)>;
+  using Handler = std::function<void(const InboundCommand&, const Responder&)>;
+
+  explicit TcpGateway(GatewaySession::Decoder decoder) : decoder_(std::move(decoder)) {}
+
+  void setCancelOnDisconnect(bool on) noexcept { cancelOnDisconnect_.store(on); }
+
+  int start(uint16_t port, Handler handler)
+  {
+    handler_ = std::move(handler);
+    // Contain any exception to this one connection -- connLoop is a thread body,
+    // so an escape would reach std::terminate and take down the whole venue.
+    return acceptor_.start(port, [this](int fd)
+                           {
+                             try { connLoop(fd); }
+                             catch (...) { ::close(fd); } });
+  }
+  void stop() { acceptor_.stop(); }
+  int port() const noexcept { return acceptor_.port(); }
+
+ private:
+  void connLoop(int fd)
+  {
+    GatewaySession session(0, decoder_);
+    session.authenticate(true);  // transport-level auth out of scope here
+    const Responder responder = [fd](const uint8_t* p, size_t n)
+    { net::writeFrame(fd, p, n); };
+    std::vector<uint8_t> frame;
+    DisconnectCanceller cod(cancelOnDisconnect_.load());
+    while (acceptor_.running() && net::readFrame(fd, frame))
+    {
+      SessionReject rej{};
+      auto cmd = session.handle(frame.data(), frame.size(), ++clock_, rej);
+      if (cmd)
+      {
+        cod.track(*cmd);
+        handler_(*cmd, responder);
+      }
+    }
+    cod.flush(handler_);
+    ::close(fd);
+  }
+
+  GatewaySession::Decoder decoder_;
+  Handler handler_;
+  SocketAcceptor acceptor_;
+  std::atomic<bool> cancelOnDisconnect_{false};
+  std::atomic<int64_t> clock_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/tls_gateway.h
+++ b/venue/include/flox-venue/tls_gateway.h
@@ -1,0 +1,192 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/cancel_on_disconnect.h"
+#include "flox-venue/messages.h"
+#include "flox-venue/session.h"
+#include "flox-venue/socket_acceptor.h"
+#include "flox/util/transport.h"
+
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+
+#include <unistd.h>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+namespace tls
+{
+
+// Server context with a fresh in-memory self-signed P-256 certificate.
+inline SSL_CTX* serverCtx()
+{
+  SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
+  EVP_PKEY* pkey = EVP_EC_gen("P-256");
+  X509* x = X509_new();
+  ASN1_INTEGER_set(X509_get_serialNumber(x), 1);
+  X509_gmtime_adj(X509_getm_notBefore(x), 0);
+  X509_gmtime_adj(X509_getm_notAfter(x), 31536000L);
+  X509_set_pubkey(x, pkey);
+  X509_NAME* name = X509_get_subject_name(x);
+  X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                             reinterpret_cast<const unsigned char*>("localhost"), -1, -1, 0);
+  X509_set_issuer_name(x, name);
+  X509_sign(x, pkey, EVP_sha256());
+  SSL_CTX_use_certificate(ctx, x);
+  SSL_CTX_use_PrivateKey(ctx, pkey);
+  X509_free(x);
+  EVP_PKEY_free(pkey);
+  return ctx;
+}
+
+inline SSL_CTX* clientCtx()
+{
+  SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+  SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, nullptr);  // self-signed test cert
+  return ctx;
+}
+
+inline bool writeAll(SSL* s, const uint8_t* p, size_t n)
+{
+  size_t o = 0;
+  while (o < n)
+  {
+    const int w = SSL_write(s, p + o, static_cast<int>(n - o));
+    if (w <= 0)
+    {
+      return false;
+    }
+    o += static_cast<size_t>(w);
+  }
+  return true;
+}
+inline bool readAll(SSL* s, uint8_t* p, size_t n)
+{
+  size_t o = 0;
+  while (o < n)
+  {
+    const int r = SSL_read(s, p + o, static_cast<int>(n - o));
+    if (r <= 0)
+    {
+      return false;
+    }
+    o += static_cast<size_t>(r);
+  }
+  return true;
+}
+inline bool writeFrame(SSL* s, const uint8_t* p, size_t n)
+{
+  const uint8_t h[4] = {static_cast<uint8_t>(n >> 24), static_cast<uint8_t>(n >> 16),
+                        static_cast<uint8_t>(n >> 8), static_cast<uint8_t>(n)};
+  return writeAll(s, h, 4) && writeAll(s, p, n);
+}
+inline bool readFrame(SSL* s, std::vector<uint8_t>& out)
+{
+  uint8_t h[4];
+  if (!readAll(s, h, 4))
+  {
+    return false;
+  }
+  const uint32_t len = (uint32_t(h[0]) << 24) | (uint32_t(h[1]) << 16) | (uint32_t(h[2]) << 8) | h[3];
+  // Reject a hostile length prefix before allocating: a 4-byte header must not
+  // reserve up to 4 GiB over the TLS channel. Shares the core framing cap so the
+  // two cannot drift apart.
+  if (len > flox::net::kMaxFrame)
+  {
+    return false;
+  }
+  out.resize(len);
+  return len == 0 || readAll(s, out.data(), len);
+}
+
+}  // namespace tls
+
+class TlsGateway
+{
+ public:
+  using Responder = std::function<void(const uint8_t*, size_t)>;
+  using Handler = std::function<void(const InboundCommand&, const Responder&)>;
+
+  explicit TlsGateway(GatewaySession::Decoder decoder)
+      : decoder_(std::move(decoder)), ctx_(tls::serverCtx())
+  {
+  }
+  ~TlsGateway()
+  {
+    stop();
+    if (ctx_)
+    {
+      SSL_CTX_free(ctx_);
+    }
+  }
+
+  void setCancelOnDisconnect(bool on) noexcept { cancelOnDisconnect_.store(on); }
+
+  int start(uint16_t port, Handler handler)
+  {
+    handler_ = std::move(handler);
+    // Contain any exception to this one connection -- connLoop is a thread body,
+    // so an escape would reach std::terminate and take down the whole venue.
+    return acceptor_.start(port, [this](int fd)
+                           {
+                             try { connLoop(fd); }
+                             catch (...) { ::close(fd); } });
+  }
+  void stop() { acceptor_.stop(); }
+  int port() const noexcept { return acceptor_.port(); }
+
+ private:
+  void connLoop(int fd)
+  {
+    SSL* ssl = SSL_new(ctx_);
+    SSL_set_fd(ssl, fd);
+    if (SSL_accept(ssl) <= 0)
+    {
+      SSL_free(ssl);
+      ::close(fd);
+      return;
+    }
+    GatewaySession session(0, decoder_);
+    session.authenticate(true);
+    const Responder responder = [ssl](const uint8_t* p, size_t n)
+    { tls::writeFrame(ssl, p, n); };
+    std::vector<uint8_t> frame;
+    DisconnectCanceller cod(cancelOnDisconnect_.load());
+    while (acceptor_.running() && tls::readFrame(ssl, frame))
+    {
+      SessionReject rej{};
+      auto cmd = session.handle(frame.data(), frame.size(), ++clock_, rej);
+      if (cmd)
+      {
+        cod.track(*cmd);
+        handler_(*cmd, responder);
+      }
+    }
+    cod.flush(handler_);
+    SSL_shutdown(ssl);
+    SSL_free(ssl);
+    ::close(fd);
+  }
+
+  GatewaySession::Decoder decoder_;
+  SSL_CTX* ctx_{nullptr};
+  Handler handler_;
+  SocketAcceptor acceptor_;
+  std::atomic<bool> cancelOnDisconnect_{false};
+  std::atomic<int64_t> clock_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/udp_multicast.h
+++ b/venue/include/flox-venue/udp_multicast.h
@@ -1,0 +1,146 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/itch_codec.h"
+#include "flox-venue/market_data.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace flox::venue
+{
+
+class UdpMdPublisher
+{
+ public:
+  bool open(const char* group, uint16_t port, bool multicast = true)
+  {
+    fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd_ < 0)
+    {
+      return false;
+    }
+    std::memset(&dst_, 0, sizeof dst_);
+    dst_.sin_family = AF_INET;
+    dst_.sin_port = htons(port);
+    ::inet_pton(AF_INET, group, &dst_.sin_addr);
+    if (multicast)
+    {
+      in_addr iface{};
+      iface.s_addr = htonl(INADDR_LOOPBACK);  // colo: bind to the data NIC
+      ::setsockopt(fd_, IPPROTO_IP, IP_MULTICAST_IF, &iface, sizeof iface);
+      unsigned char loop = 1;
+      ::setsockopt(fd_, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof loop);
+      unsigned char ttl = 1;
+      ::setsockopt(fd_, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof ttl);
+    }
+    return true;
+  }
+
+  void publish(const MdMessage& m)
+  {
+    ItchCodec::encode(m, buf_);
+    ::sendto(fd_, buf_.data(), buf_.size(), 0, reinterpret_cast<sockaddr*>(&dst_), sizeof dst_);
+  }
+
+  void close()
+  {
+    if (fd_ >= 0)
+    {
+      ::close(fd_);
+      fd_ = -1;
+    }
+  }
+  ~UdpMdPublisher() { close(); }
+
+ private:
+  int fd_{-1};
+  sockaddr_in dst_{};
+  std::vector<uint8_t> buf_;
+};
+
+class UdpMdSubscriber
+{
+ public:
+  bool join(const char* group, uint16_t port, bool multicast = true)
+  {
+    fd_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd_ < 0)
+    {
+      return false;
+    }
+    int one = 1;
+    ::setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &one, sizeof one);
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_port = htons(port);
+    a.sin_addr.s_addr = multicast ? htonl(INADDR_ANY) : htonl(INADDR_LOOPBACK);
+    if (::bind(fd_, reinterpret_cast<sockaddr*>(&a), sizeof a) < 0)
+    {
+      return false;
+    }
+    socklen_t sl = sizeof a;
+    ::getsockname(fd_, reinterpret_cast<sockaddr*>(&a), &sl);
+    port_ = ntohs(a.sin_port);
+    if (multicast)
+    {
+      ip_mreq mr{};
+      ::inet_pton(AF_INET, group, &mr.imr_multiaddr);
+      mr.imr_interface.s_addr = htonl(INADDR_LOOPBACK);
+      if (::setsockopt(fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mr, sizeof mr) < 0)
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void setTimeout(int ms)
+  {
+    timeval tv{ms / 1000, (ms % 1000) * 1000};
+    ::setsockopt(fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+  }
+
+  // Receive and decode one message; returns false on timeout / error.
+  bool recv(MdMessage& out)
+  {
+    uint8_t buf[ItchCodec::kSize];
+    const ssize_t n = ::recvfrom(fd_, buf, sizeof buf, 0, nullptr, nullptr);
+    if (n <= 0)
+    {
+      return false;
+    }
+    return ItchCodec::decode(buf, static_cast<size_t>(n), out);
+  }
+
+  int port() const noexcept { return port_; }
+
+  void close()
+  {
+    if (fd_ >= 0)
+    {
+      ::close(fd_);
+      fd_ = -1;
+    }
+  }
+  ~UdpMdSubscriber() { close(); }
+
+ private:
+  int fd_{-1};
+  int port_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/workload.h
+++ b/venue/include/flox-venue/workload.h
@@ -1,0 +1,66 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace flox::venue::workload
+{
+
+struct Params
+{
+  SymbolId symbol{1};
+  double mid{100.0};
+  double tick{0.01};
+  int spreadTicks{50};
+  uint64_t seed{0x1234abcdULL};
+  size_t count{1000};
+};
+
+// Symmetric buy/sell limit flow around `mid`. Symmetric so crossings are
+// frequent and resting depth stays bounded.
+inline std::vector<InboundCommand> symmetricLimits(const Params& p)
+{
+  const int64_t midRaw = Price::fromDouble(p.mid).raw();
+  const int64_t tickRaw = Price::fromDouble(p.tick).raw();
+  const uint64_t span = static_cast<uint64_t>(2 * p.spreadTicks + 1);
+
+  std::vector<InboundCommand> v;
+  v.reserve(p.count);
+  uint64_t s = p.seed;
+  auto next = [&]() noexcept
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  };
+
+  for (size_t i = 0; i < p.count; ++i)
+  {
+    const uint64_t r = next();
+    NewOrder o;
+    o.id = i + 1;
+    o.symbol = p.symbol;
+    o.side = (r & 1U) ? Side::BUY : Side::SELL;
+    o.type = OrderType::LIMIT;
+    const int ticks = static_cast<int>((r >> 1) % span) - p.spreadTicks;
+    o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+    o.quantity = Quantity::fromDouble(1.0 + static_cast<double>((r >> 10) % 5));
+    o.tif = TimeInForce::GTC;
+    o.accountId = 1 + ((r >> 20) % 64);
+    v.emplace_back(o);
+  }
+  return v;
+}
+
+}  // namespace flox::venue::workload

--- a/venue/include/flox-venue/ws_gateway.h
+++ b/venue/include/flox-venue/ws_gateway.h
@@ -1,0 +1,140 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+#include "flox-venue/cancel_on_disconnect.h"
+#include "flox-venue/messages.h"
+#include "flox-venue/session.h"
+#include "flox-venue/socket_acceptor.h"
+#include "flox/util/transport.h"
+#include "flox/util/websocket.h"
+
+#include <unistd.h>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+class WsGateway
+{
+ public:
+  using Responder = std::function<void(const uint8_t*, size_t)>;
+  using Handler = std::function<void(const InboundCommand&, const Responder&)>;
+
+  explicit WsGateway(GatewaySession::Decoder decoder) : decoder_(std::move(decoder)) {}
+
+  void setCancelOnDisconnect(bool on) noexcept { cancelOnDisconnect_.store(on); }
+
+  int start(uint16_t port, Handler handler)
+  {
+    handler_ = std::move(handler);
+    // connLoop runs as a per-connection thread body: an escaping exception would
+    // reach std::terminate and kill the whole venue, so contain it to this one
+    // connection (close the fd and let the thread exit cleanly).
+    return acceptor_.start(port, [this](int fd)
+                           {
+                             try { connLoop(fd); }
+                             catch (...) { ::close(fd); } });
+  }
+  void stop() { acceptor_.stop(); }
+  int port() const noexcept { return acceptor_.port(); }
+
+ private:
+  void connLoop(int fd)
+  {
+    // 1. HTTP Upgrade handshake.
+    std::string req;
+    uint8_t tmp[2048];
+    while (req.find("\r\n\r\n") == std::string::npos)
+    {
+      const ssize_t r = ::read(fd, tmp, sizeof tmp);
+      if (r <= 0 || req.size() > (1u << 16))
+      {
+        ::close(fd);
+        return;
+      }
+      req.append(reinterpret_cast<char*>(tmp), static_cast<size_t>(r));
+    }
+    const std::string resp = ws::handshakeResponse(req);
+    if (resp.empty())
+    {
+      ::close(fd);
+      return;
+    }
+    net::writeAll(fd, reinterpret_cast<const uint8_t*>(resp.data()), resp.size());
+
+    // 2. Frame loop.
+    GatewaySession session(0, decoder_);
+    session.authenticate(true);
+    const Responder responder = [fd](const uint8_t* p, size_t n)
+    {
+      const auto f = ws::buildFrame(ws::Opcode::Text, p, n);
+      net::writeAll(fd, f.data(), f.size());
+    };
+
+    std::vector<uint8_t> buf;
+    DisconnectCanceller cod(cancelOnDisconnect_.load());
+    while (acceptor_.running())
+    {
+      ws::Opcode op{};
+      std::vector<uint8_t> payload;
+      const size_t consumed = ws::parseFrame(buf.data(), buf.size(), op, payload);
+      if (consumed == ws::kParseError)
+      {
+        break;  // hostile/oversized frame: drop the connection
+      }
+      if (consumed == 0)
+      {
+        const ssize_t r = ::read(fd, tmp, sizeof tmp);
+        if (r <= 0)
+        {
+          break;
+        }
+        buf.insert(buf.end(), tmp, tmp + r);
+        continue;
+      }
+      buf.erase(buf.begin(), buf.begin() + static_cast<std::ptrdiff_t>(consumed));
+      if (op == ws::Opcode::Close)
+      {
+        break;
+      }
+      if (op == ws::Opcode::Ping)
+      {
+        const auto pong = ws::buildFrame(ws::Opcode::Pong, payload.data(), payload.size());
+        net::writeAll(fd, pong.data(), pong.size());
+        continue;
+      }
+      if (op == ws::Opcode::Text || op == ws::Opcode::Binary)
+      {
+        SessionReject rej{};
+        auto cmd = session.handle(payload.data(), payload.size(), ++clock_, rej);
+        if (cmd)
+        {
+          cod.track(*cmd);
+          handler_(*cmd, responder);
+        }
+      }
+    }
+    cod.flush(handler_);
+    ::close(fd);
+  }
+
+  GatewaySession::Decoder decoder_;
+  Handler handler_;
+  SocketAcceptor acceptor_;
+  std::atomic<bool> cancelOnDisconnect_{false};
+  std::atomic<int64_t> clock_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/scripts/run_sanitizers.sh
+++ b/venue/scripts/run_sanitizers.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# flox venue -- sanitizer verification.
+# Builds and runs the verification corpus under AddressSanitizer + Undefined-
+# BehaviorSanitizer (memory safety, UB) and the concurrent paths under Thread-
+# Sanitizer (data races). Run this before a release and in CI so regressions in
+# memory/UB/race safety are caught. Any sanitizer diagnostic fails the run.
+#
+# Usage:  venue/scripts/run_sanitizers.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."  # repo root (venue/scripts -> flox)
+ROOT="$(pwd)"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+CXX="${CXX:-g++}"
+STD="-std=c++23 -O1 -g"
+INC="-Iinclude -Ivenue/include -isystem include -isystem /opt/homebrew/include"
+GTEST="-L/opt/homebrew/lib -lgtest -lgtest_main"
+SRC="venue/src/reject_reason.cpp"
+
+# Halt on the first UBSan diagnostic (default is to print and continue).
+export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
+export ASAN_OPTIONS="detect_leaks=0"  # this corpus is arena/stack-oriented, not leak-focused
+
+fail=0
+
+run_asan() {
+  local name="$1"
+  echo "== ASAN+UBSAN: $name =="
+  if ! "$CXX" $STD -fsanitize=address,undefined $INC "venue/tests/$name.cpp" $SRC $GTEST -pthread -o "$OUT/$name" 2>"$OUT/$name.build"; then
+    echo "  BUILD FAILED"; cat "$OUT/$name.build"; fail=1; return
+  fi
+  if ! "$OUT/$name" >"$OUT/$name.log" 2>&1; then
+    echo "  RUN FAILED"; tail -20 "$OUT/$name.log"; fail=1; return
+  fi
+  tail -1 "$OUT/$name.log" | sed 's/^/  /'
+}
+
+run_tsan() {
+  local name="$1"
+  echo "== TSAN: $name =="
+  if ! "$CXX" $STD -fsanitize=thread $INC "venue/tests/$name.cpp" $SRC $GTEST -pthread -o "$OUT/$name" 2>"$OUT/$name.build"; then
+    echo "  BUILD FAILED"; cat "$OUT/$name.build"; fail=1; return
+  fi
+  if ! "$OUT/$name" >"$OUT/$name.log" 2>&1; then
+    echo "  RUN FAILED (race or assertion)"; tail -20 "$OUT/$name.log"; fail=1; return
+  fi
+  tail -1 "$OUT/$name.log" | sed 's/^/  /'
+}
+
+# Memory / UB: parsers (hostile network input) + the heavy engine fuzzes/harnesses
+# + the recovery/journal paths (spot + derivatives).
+for t in test_venue_parser_fuzz test_venue_differential_fuzz test_venue_conservation_fuzz test_venue_perp_venue test_venue_multi_symbol_soak \
+         test_venue_venue test_venue_perp_recovery test_venue_ledger test_venue_ledger_primitive test_venue_cross_margin; do
+  run_asan "$t"
+done
+
+# Data races: the single-writer sequenced core and the multi-threaded gateways.
+for t in test_venue_sequenced test_venue_network; do
+  run_tsan "$t"
+done
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "ALL SANITIZER RUNS CLEAN"
+else
+  echo "SANITIZER FAILURES DETECTED"
+fi
+exit "$fail"

--- a/venue/src/reject_reason.cpp
+++ b/venue/src/reject_reason.cpp
@@ -1,0 +1,81 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox-venue/reject_reason.h"
+
+namespace flox::venue
+{
+
+const char* toString(RejectReason r) noexcept
+{
+  switch (r)
+  {
+    case RejectReason::None:
+      return "None";
+    case RejectReason::UnknownSymbol:
+      return "UnknownSymbol";
+    case RejectReason::Halted:
+      return "Halted";
+    case RejectReason::InvalidQuantity:
+      return "InvalidQuantity";
+    case RejectReason::InvalidPrice:
+      return "InvalidPrice";
+    case RejectReason::TickSizeViolation:
+      return "TickSizeViolation";
+    case RejectReason::LotSizeViolation:
+      return "LotSizeViolation";
+    case RejectReason::DuplicateOrderId:
+      return "DuplicateOrderId";
+    case RejectReason::UnknownOrder:
+      return "UnknownOrder";
+    case RejectReason::PostOnlyWouldCross:
+      return "PostOnlyWouldCross";
+    case RejectReason::FillOrKillUnfulfillable:
+      return "FillOrKillUnfulfillable";
+    case RejectReason::OrderTooLarge:
+      return "OrderTooLarge";
+    case RejectReason::InsufficientFunds:
+      return "InsufficientFunds";
+    case RejectReason::LuldBreach:
+      return "LuldBreach";
+    case RejectReason::PositionLimitExceeded:
+      return "PositionLimitExceeded";
+    case RejectReason::TooManyOpenOrders:
+      return "TooManyOpenOrders";
+  }
+  return "?";
+}
+
+const char* toString(CancelReason r) noexcept
+{
+  switch (r)
+  {
+    case CancelReason::UserRequested:
+      return "UserRequested";
+    case CancelReason::ImmediateOrCancelResidual:
+      return "ImmediateOrCancelResidual";
+    case CancelReason::MarketResidual:
+      return "MarketResidual";
+    case CancelReason::SelfTradePrevention:
+      return "SelfTradePrevention";
+    case CancelReason::Expired:
+      return "Expired";
+    case CancelReason::OcoTriggered:
+      return "OcoTriggered";
+    case CancelReason::VenueHalt:
+      return "VenueHalt";
+    case CancelReason::Liquidation:
+      return "Liquidation";
+    case CancelReason::FillOrKillResidual:
+      return "FillOrKillResidual";
+  }
+  return "?";
+}
+
+}  // namespace flox::venue

--- a/venue/tests/test_venue_auction.cpp
+++ b/venue/tests/test_venue_auction.cpp
@@ -1,0 +1,150 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/matching_engine.h"
+#include "flox/book/ladder_book.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+const char* g_label = "";
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL [%s] line %d: %s\n", g_label, line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  return c;
+}
+LadderBook::Config lc() { return LadderBook::Config{0, px(0.01).raw(), 200000, 1 << 16}; }
+
+NewOrder limit(OrderId id, Side s, double p, double q)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = id;
+  return o;
+}
+
+struct Cap
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+  int trades() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<Trade>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  Quantity tradedQty() const
+  {
+    Quantity t{};
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<Trade>(&e))
+      {
+        t += x->quantity;
+      }
+    }
+    return t;
+  }
+  bool allTradesAt(double p) const
+  {
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<Trade>(&e))
+      {
+        if (!(x->price == px(p)))
+        {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+};
+
+template <class Book>
+void run(const std::function<Book()>& mk, const char* label)
+{
+  g_label = label;
+  std::printf("== auction book: %s ==\n", label);
+  Cap cap;
+  MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+  eng.beginPreOpen();
+  eng.submit(InboundCommand{limit(1, Side::BUY, 101, 5)}, 0);
+  eng.submit(InboundCommand{limit(2, Side::SELL, 99, 5)}, 1);
+  eng.submit(InboundCommand{limit(3, Side::BUY, 100, 3)}, 2);
+  eng.submit(InboundCommand{limit(4, Side::SELL, 100, 2)}, 3);
+  CHECK(cap.trades() == 0);  // no matching during pre-open
+
+  eng.openContinuous();  // uncross
+  // demand/supply is maximized at 100 -> 7 units executed, all at 100
+  CHECK(cap.tradedQty() == qty(7));
+  CHECK(cap.allTradesAt(100.0));
+
+  // residual: bid id3 has 1 left @100; continuous trading resumes
+  CHECK(eng.book().bestBid() == px(100));
+  eng.submit(InboundCommand{limit(5, Side::SELL, 100, 1)}, 4);
+  CHECK(cap.tradedQty() == qty(8));  // +1
+}
+
+}  // namespace
+
+TEST(Auction, EngineSuite)
+{
+  run<MatchingBook>([]
+                    { return MatchingBook{}; }, "map-reference");
+  run<LadderBook>([]
+                  { return LadderBook{lc()}; }, "ladder-o1");
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_collateral.cpp
+++ b/venue/tests/test_venue_collateral.cpp
@@ -1,0 +1,84 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/collateral.h"
+#include "flox-venue/ledger.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr AssetId USD = 1;
+constexpr AssetId BTC = 2;
+constexpr AssetId ETH = 3;
+constexpr AssetId DOGE = 4;  // not accepted as collateral
+Price px(double v) { return Price::fromDouble(v); }
+Amount units(double v) { return amountOf(Volume::fromDouble(v)); }
+Amount usd(double v) { return amountOf(Volume::fromDouble(v)); }
+
+void test_collateral()
+{
+  std::printf("test_collateral\n");
+  CollateralSchedule sched;
+  sched.configure(USD, px(1.0).raw(), /*haircut*/ 0);       // quote asset: par, no haircut
+  sched.configure(BTC, px(30000).raw(), /*haircut*/ 2000);  // 20% haircut
+  sched.configure(ETH, px(2000).raw(), /*haircut*/ 1000);   // 10% haircut
+
+  CHECK(sched.accepts(USD) && sched.accepts(BTC) && !sched.accepts(DOGE));
+
+  // Per-asset haircut-adjusted values.
+  CHECK(sched.value(USD, usd(1000)) == usd(1000));    // par
+  CHECK(sched.value(BTC, units(0.5)) == usd(12000));  // 0.5 * 30000 * 0.8
+  CHECK(sched.value(ETH, units(10)) == usd(18000));   // 10 * 2000 * 0.9
+  CHECK(sched.value(DOGE, units(100000)) == 0);       // not accepted -> 0 credit
+
+  // Whole-basket portfolio value from the ledger.
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(1, BTC, units(0.5));
+  led.deposit(1, ETH, units(10));
+  led.deposit(1, DOGE, units(100000));                                         // ignored
+  CHECK(sched.portfolioValue(led, 1) == usd(1000) + usd(12000) + usd(18000));  // 31000
+
+  // Reserved balances still count (collateral is locked but owned).
+  led.reserve(1, USD, usd(400));
+  CHECK(sched.portfolioValue(led, 1) == usd(31000));
+
+  // A BTC price drop re-values the basket.
+  sched.setPrice(BTC, px(20000).raw());
+  CHECK(sched.value(BTC, units(0.5)) == usd(8000));                           // 0.5 * 20000 * 0.8
+  CHECK(sched.portfolioValue(led, 1) == usd(1000) + usd(8000) + usd(18000));  // 27000
+}
+
+}  // namespace
+
+TEST(Collateral, EngineSuite)
+{
+  test_collateral();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_conservation_fuzz.cpp
+++ b/venue/tests/test_venue_conservation_fuzz.cpp
@@ -1,0 +1,522 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Money-conservation fuzz over the venue core. Value must never be created or
+ * destroyed across a random command stream (spot, perp, perp+ADL, cross-margin,
+ * multi-asset collateral), and after the book is drained every account's
+ * `reserved` must return to zero -- a stuck reservation is invisible to
+ * conservation-of-total but shows up in that second check.
+ */
+#include "flox-venue/collateral.h"
+#include "flox-venue/cross_margin.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include "flox/backtest/fee_schedule.h"
+
+#include <gtest/gtest.h>
+#include <array>
+#include <cstdint>
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 9;
+constexpr int NACCT = 8;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount base(double v) { return amountOf(qty(v)); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+
+struct Rng
+{
+  uint64_t s;
+  uint64_t next()
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  }
+};
+
+void test_spot_conservation()
+{
+  std::printf("test_spot_conservation\n");
+  Ledger led;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    led.deposit(a, BASE, base(1000));
+    led.deposit(a, QUOTE, quote(100000));
+  }
+  const Amount initBase = base(1000) * NACCT;
+  const Amount initQuote = quote(100000) * NACCT;
+
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50);
+  c.maxPrice = px(150);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
+  flox::FeeSchedule fs;
+  fs.addTier(0.0, -1.0, 2.0);  // maker rebate, taker fee -> venue nets fees
+  eng.setFeeSchedule(fs);
+  eng.setLedger(&led, VENUE);
+
+  auto sumAsset = [&](AssetId asset)
+  {
+    Amount t = 0;
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, asset);
+    }
+    t += led.total(VENUE, asset);
+    return t;
+  };
+
+  Rng rng{0xDEADBEEF12345ULL};
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  int breaches = 0;
+  OrderId nextId = 1;
+  for (int i = 0; i < 200000; ++i)
+  {
+    const uint64_t r = rng.next();
+    const uint32_t kind = r % 100;
+    if (kind < 20 && nextId > 1)
+    {
+      eng.submit(InboundCommand{CancelOrder{1 + (rng.next() % (nextId - 1)), SYM, 0}}, i);
+    }
+    else if (kind < 30 && nextId > 1)
+    {
+      // Modify a random existing order (reprice + resize) -- must adjust the
+      // ledger reservation, else buying power leaks/double-counts.
+      const OrderId vid = 1 + (rng.next() % (nextId - 1));
+      const int ticks = static_cast<int>((r >> 1) % 101) - 50;
+      const Price np = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+      const Quantity nq = qty(1.0 + static_cast<double>((r >> 24) % 5));
+      eng.submit(InboundCommand{ModifyOrder{vid, SYM, np, nq, 0}}, i);
+    }
+    else
+    {
+      NewOrder o;
+      o.id = nextId++;
+      o.symbol = SYM;
+      o.side = (r & 1) ? Side::BUY : Side::SELL;
+      o.accountId = 1 + (r >> 8) % NACCT;
+      const int ticks = static_cast<int>((r >> 1) % 101) - 50;
+      o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+      o.quantity = qty(1.0 + static_cast<double>((r >> 20) % 5));
+      o.type = (kind < 25) ? OrderType::MARKET : OrderType::LIMIT;
+      if (kind >= 25 && kind < 32)  // stop-market: reserve-at-trigger + settle path
+      {
+        o.type = OrderType::STOP_MARKET;
+        const int tt = static_cast<int>((r >> 33) % 61) - 30;
+        o.triggerPrice = Price::fromRaw(midRaw + static_cast<int64_t>(tt) * tickRaw);
+      }
+      // Exercise GTD expiry, OCO cancellation, and peg reprice under the ledger
+      // conservation invariant (each must release/re-reserve buying power).
+      if (o.type == OrderType::LIMIT)
+      {
+        const uint32_t t = static_cast<uint32_t>((r >> 32) % 100);
+        if (t < 15)
+        {
+          o.tif = TimeInForce::GTD;
+          o.expiryNs = i + 1 + static_cast<int64_t>((r >> 40) % 50);  // expires soon
+        }
+        else if (t < 25)
+        {
+          o.ocoGroup = 1 + ((r >> 44) % 5);
+        }
+        else if (t < 35)
+        {
+          const uint32_t pr = static_cast<uint32_t>((r >> 48) % 3);
+          o.peg = pr == 0 ? PegRef::Bid : (pr == 1 ? PegRef::Ask : PegRef::Mid);
+        }
+        else if (t < 45)
+        {
+          o.tif = TimeInForce::IOC;  // partial fill + residual cancel must release reserve
+        }
+        else if (t < 52)
+        {
+          o.tif = TimeInForce::FOK;  // all-or-nothing: full reserve released on kill
+        }
+        else if (t < 58)
+        {
+          o.postOnly = true;  // maker-only: rejected-on-cross must release reserve
+        }
+        else if (t < 66)
+        {
+          // Iceberg: reserves the FULL qty but shows only a peak. Adds peak
+          // refill + hidden-reserve matching to the fuzz. NOTE: a per-order
+          // reservation bug (over-release against the peak on modify) is NOT
+          // visible here -- the ledger aggregates `reserved` per account, so one
+          // order's over-release is masked by other orders. The precise guard is
+          // the single-order test_iceberg_modify_shrink in test_ledger.
+          o.visibleQuantity = qty(1.0 + static_cast<double>((r >> 52) % 2));
+        }
+      }
+      eng.submit(InboundCommand{o}, i);
+    }
+    if (sumAsset(BASE) != initBase || sumAsset(QUOTE) != initQuote)
+    {
+      ++breaches;
+      if (breaches == 1)
+      {
+        std::printf("  first breach at op %d\n", i);
+      }
+    }
+  }
+  CHECK(breaches == 0);
+
+  // Reserved-invariant: drain the whole book, then EVERY account's reserved must
+  // return to zero. A stuck reservation (leak) is invisible to conservation-of-
+  // total but shows up here as residual `reserved` after all orders are gone.
+  for (OrderId id = 1; id < nextId; ++id)
+  {
+    eng.submit(InboundCommand{CancelOrder{id, SYM, 0}}, 999999);
+  }
+  int reservedLeaks = 0;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    if (led.reserved(a, BASE) != 0 || led.reserved(a, QUOTE) != 0)
+    {
+      ++reservedLeaks;
+    }
+  }
+  CHECK(reservedLeaks == 0);
+  std::printf("  200000 ops, base/quote conserved (%d breaches); reserved drained clean (%d leaks)\n",
+              breaches, reservedLeaks);
+}
+
+void test_perp_conservation(bool adl)
+{
+  std::printf("test_perp_conservation%s\n", adl ? " (ADL)" : "");
+  Ledger led;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    led.deposit(a, QUOTE, quote(1000000));
+  }
+  if (adl)
+  {
+    led.deposit(VENUE, QUOTE, quote(1000000));  // seed insurance fund
+  }
+  Amount initQuote = quote(1000000) * NACCT;
+  if (adl)
+  {
+    initQuote += quote(1000000);
+  }
+
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50);
+  c.maxPrice = px(150);
+  c.quoteAsset = QUOTE;
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;
+  c.maintenanceMarginBps = 500;
+  c.autoDeleverage = adl;
+  MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+
+  auto sumQuote = [&]()
+  {
+    Amount t = 0;
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, QUOTE);
+    }
+    t += led.total(VENUE, QUOTE);
+    return t;
+  };
+
+  Rng rng{0x1234ABCDULL};
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  int breaches = 0;
+  OrderId nextId = 1;
+  for (int i = 0; i < 100000; ++i)
+  {
+    const uint64_t r = rng.next();
+    const uint32_t kind = r % 100;
+    if (kind < 15 && nextId > 1)
+    {
+      eng.submit(InboundCommand{CancelOrder{1 + (rng.next() % (nextId - 1)), SYM, 0}}, i);
+    }
+    else if (kind < 25)
+    {
+      // periodic mark move -> may trigger liquidations
+      const int ticks = static_cast<int>((r >> 1) % 61) - 30;
+      eng.setMarkPrice(Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw));
+    }
+    else
+    {
+      NewOrder o;
+      o.id = nextId++;
+      o.symbol = SYM;
+      o.side = (r & 1) ? Side::BUY : Side::SELL;
+      o.accountId = 1 + (r >> 8) % NACCT;
+      const int ticks = static_cast<int>((r >> 1) % 61) - 30;
+      o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+      o.quantity = qty(1.0 + static_cast<double>((r >> 20) % 5));
+      eng.submit(InboundCommand{o}, i);
+    }
+    if (sumQuote() != initQuote)
+    {
+      ++breaches;
+      if (breaches == 1)
+      {
+        std::printf("  first breach at op %d\n", i);
+      }
+    }
+  }
+  CHECK(breaches == 0);
+
+  // Perp reserved-invariant: drain resting orders, then every reserved quote
+  // unit must be backed by an open position's posted margin -- no IM leak.
+  for (OrderId id = 1; id < nextId; ++id)
+  {
+    eng.submit(InboundCommand{CancelOrder{id, SYM, 0}}, 999999);
+  }
+  Amount reservedSum = 0;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    reservedSum += led.reserved(a, QUOTE);
+  }
+  CHECK(reservedSum == eng.totalPositionMargin());
+  std::printf(
+      "  100000 ops (orders+marks+liquidations), collateral conserved (%d breaches); "
+      "reserved==position-margin (%s)\n",
+      breaches, reservedSum == eng.totalPositionMargin() ? "ok" : "LEAK");
+}
+
+void test_cross_margin_conservation()
+{
+  std::printf("test_cross_margin_conservation\n");
+  Ledger led;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    led.deposit(a, QUOTE, quote(1000000));
+  }
+  const Amount initQuote = quote(1000000) * NACCT;
+
+  CrossMarginManager m(led, QUOTE, VENUE);
+  constexpr SymbolId S1 = 1;
+  constexpr SymbolId S2 = 2;
+  m.configureSymbol(S1, /*im*/ 1000, /*mm*/ 500);
+  m.configureSymbol(S2, /*im*/ 2000, /*mm*/ 1000);
+  m.setMark(S1, px(100));
+  m.setMark(S2, px(100));
+
+  auto sumQuote = [&]()
+  {
+    Amount t = 0;
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, QUOTE);
+    }
+    t += led.total(VENUE, QUOTE);
+    return t;
+  };
+
+  Rng rng{0xC0FFEE99ULL};
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  int breaches = 0;
+  for (int i = 0; i < 100000; ++i)
+  {
+    const uint64_t r = rng.next();
+    const uint32_t kind = r % 100;
+    const SymbolId sym = (r & 2) ? S2 : S1;
+    if (kind < 20)
+    {
+      // mark move -> may liquidate underwater portfolios
+      const int ticks = static_cast<int>((r >> 1) % 61) - 30;
+      m.setMark(sym, Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw));
+    }
+    else if (kind < 25)
+    {
+      // periodic funding on the portfolio book -- must conserve
+      const int ticks = static_cast<int>((r >> 1) % 61) - 30;
+      m.applyFunding(sym, 0.0005, Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw));
+    }
+    else
+    {
+      uint64_t buyer = 1 + (r >> 8) % NACCT;
+      uint64_t seller = 1 + (r >> 16) % NACCT;
+      if (buyer == seller)
+      {
+        seller = 1 + (seller % NACCT);
+      }
+      const int ticks = static_cast<int>((r >> 1) % 61) - 30;
+      const int64_t priceRaw = midRaw + static_cast<int64_t>(ticks) * tickRaw;
+      const int64_t q = qty(1.0 + static_cast<double>((r >> 24) % 5)).raw();
+      // Both sides settle through the same pool -> value conserved by construction.
+      m.applyFill(buyer, sym, Side::BUY, q, priceRaw);
+      m.applyFill(seller, sym, Side::SELL, q, priceRaw);
+    }
+    if (sumQuote() != initQuote)
+    {
+      ++breaches;
+      if (breaches == 1)
+      {
+        std::printf("  first breach at op %d\n", i);
+      }
+    }
+  }
+  CHECK(breaches == 0);
+  std::printf(
+      "  100000 ops (2-symbol cross-margin fills+marks+funding+liquidations), collateral "
+      "conserved (%d breaches)\n",
+      breaches);
+}
+
+void test_multi_collateral_conservation()
+{
+  std::printf("test_multi_collateral_conservation\n");
+  constexpr AssetId BTC_COL = 2;  // collateral asset (distinct from the perp symbol)
+  Ledger led;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    led.deposit(a, QUOTE, quote(500));                           // thin quote
+    led.deposit(a, BTC_COL, amountOf(Quantity::fromDouble(2)));  // + coin collateral
+  }
+  led.deposit(VENUE, QUOTE, quote(100000000));  // deep insurance
+  const Amount initQuote = quote(500) * NACCT + quote(100000000);
+  const Amount initBtc = amountOf(Quantity::fromDouble(2)) * NACCT;
+
+  CollateralSchedule sched;
+  sched.configure(QUOTE, px(1.0).raw(), 0);
+  sched.configure(BTC_COL, px(300).raw(), 1500);  // coin priced at 300, 15% haircut
+
+  CrossMarginManager m(led, QUOTE, VENUE, [](const Liquidation&) {}, /*adl*/ false);
+  m.setCollateralSchedule(&sched);
+  m.configureSymbol(SYM, /*im*/ 1000, /*mm*/ 500);
+  m.setMark(SYM, px(100));
+
+  auto sumAsset = [&](AssetId asset)
+  {
+    Amount t = led.total(VENUE, asset);
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, asset);
+    }
+    return t;
+  };
+
+  Rng rng{0xC01A7E5ULL};
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  int breaches = 0;
+  for (int i = 0; i < 100000; ++i)
+  {
+    const uint64_t r = rng.next();
+    const uint32_t kind = r % 100;
+    if (kind < 20)
+    {
+      const int ticks = static_cast<int>((r >> 1) % 61) - 30;
+      m.setMark(SYM, Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw));
+    }
+    else if (kind < 25)
+    {
+      // re-price the coin collateral (revaluation shifts who is liquidatable)
+      const int d = static_cast<int>((r >> 3) % 201) - 100;  // +/- 100
+      sched.setPrice(BTC_COL, px(300 + d).raw());
+    }
+    else
+    {
+      uint64_t buyer = 1 + (r >> 8) % NACCT;
+      uint64_t seller = 1 + (r >> 16) % NACCT;
+      if (buyer == seller)
+      {
+        seller = 1 + (seller % NACCT);
+      }
+      const int ticks = static_cast<int>((r >> 1) % 61) - 30;
+      const int64_t priceRaw = midRaw + static_cast<int64_t>(ticks) * tickRaw;
+      const int64_t q = qty(1.0 + static_cast<double>((r >> 24) % 5)).raw();
+      m.applyFill(buyer, SYM, Side::BUY, q, priceRaw);
+      m.applyFill(seller, SYM, Side::SELL, q, priceRaw);
+    }
+    if (sumAsset(QUOTE) != initQuote || sumAsset(BTC_COL) != initBtc)
+    {
+      ++breaches;
+      if (breaches == 1)
+      {
+        std::printf("  first breach at op %d\n", i);
+      }
+    }
+  }
+  CHECK(breaches == 0);
+  std::printf(
+      "  100000 ops (2-asset collateral: fills+marks+revaluation+collateral-liquidation), "
+      "quote+coin conserved (%d breaches)\n",
+      breaches);
+}
+
+}  // namespace
+
+TEST(VenueConservationFuzz, SpotValueAndReservationsConserved)
+{
+  g_failures = 0;  // independent baseline: a prior scenario must not taint this one
+  test_spot_conservation();
+  EXPECT_EQ(g_failures, 0);
+}
+
+TEST(VenueConservationFuzz, PerpCollateralConserved)
+{
+  g_failures = 0;  // independent baseline: a prior scenario must not taint this one
+  test_perp_conservation(/*adl=*/false);
+  EXPECT_EQ(g_failures, 0);
+}
+
+TEST(VenueConservationFuzz, PerpWithAdlConserved)
+{
+  g_failures = 0;  // independent baseline: a prior scenario must not taint this one
+  test_perp_conservation(/*adl=*/true);
+  EXPECT_EQ(g_failures, 0);
+}
+
+TEST(VenueConservationFuzz, CrossMarginConserved)
+{
+  g_failures = 0;  // independent baseline: a prior scenario must not taint this one
+  test_cross_margin_conservation();
+  EXPECT_EQ(g_failures, 0);
+}
+
+TEST(VenueConservationFuzz, MultiCollateralConserved)
+{
+  g_failures = 0;  // independent baseline: a prior scenario must not taint this one
+  test_multi_collateral_conservation();
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_control_plane.cpp
+++ b/venue/tests/test_venue_control_plane.cpp
@@ -1,0 +1,138 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/control_api.h"
+#include "flox-venue/control_plane.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig mk(SymbolId id)
+{
+  SymbolConfig c;
+  c.id = id;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+NewOrder limit(OrderId id, SymbolId sym, Side s, double p, double q)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = sym;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  return o;
+}
+
+}  // namespace
+
+TEST(ControlPlane, EngineSuite)
+{
+  std::printf("test_control_plane\n");
+  InstrumentRegistry reg;
+  CHECK(reg.listInstrument(mk(1)));
+  CHECK(reg.listInstrument(mk(2)));
+  CHECK(!reg.listInstrument(mk(1)));  // duplicate id rejected
+  CHECK(reg.size() == 2);
+  CHECK(reg.has(1) && reg.get(2) != nullptr);
+  CHECK(reg.get(2)->tickSize == px(0.01));
+
+  CHECK(reg.setPriceBand(1, px(90), px(110)));
+  CHECK(reg.get(1)->minPrice == px(90));
+
+  CHECK(reg.halt(1, true));
+  CHECK(reg.get(1)->halted);
+  CHECK(reg.setTriggerRef(2, TriggerRef::Mark));
+  CHECK(reg.get(2)->triggerRef == TriggerRef::Mark);
+
+  // Halt applied to a live shard: orders on a halted instrument are rejected.
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(*reg.get(1), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setHalted(true);
+  eng.submit(limit(1, 1, Side::SELL, 100, 5));
+  bool rejected = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e); r && r->reason == RejectReason::Halted)
+    {
+      rejected = true;
+    }
+  }
+  CHECK(rejected);
+
+  // Resume: trading works again.
+  ev.clear();
+  eng.setHalted(false);
+  eng.submit(limit(1, 1, Side::SELL, 100, 5));
+  eng.submit(limit(2, 1, Side::BUY, 100, 3));
+  bool traded = false;
+  for (auto& e : ev)
+  {
+    if (std::get_if<Trade>(&e))
+    {
+      traded = true;
+    }
+  }
+  CHECK(traded);
+
+  // Control-plane API (the gRPC/MCP surface): JSON request -> JSON result.
+  std::printf("test_control_api\n");
+  InstrumentRegistry reg2;
+  ControlApi api(reg2);
+  auto has = [](const std::string& s, const char* sub)
+  { return s.find(sub) != std::string::npos; };
+  CHECK(has(api.handle(R"({"method":"listInstrument","symbol":1,"tick":0.01,"minPrice":50,"maxPrice":150})"),
+            "\"ok\":true"));
+  CHECK(has(api.handle(R"({"method":"listInstrument","symbol":2,"tick":0.01})"), "\"ok\":true"));
+  CHECK(has(api.handle(R"({"method":"listInstrument","symbol":1})"), "exists"));
+  CHECK(has(api.handle(R"({"method":"halt","symbol":1,"halted":true})"), "\"ok\":true"));
+  CHECK(reg2.get(1)->halted);
+  CHECK(has(api.handle(R"({"method":"get","symbol":1})"), "\"halted\":true"));
+  CHECK(has(api.handle(R"({"method":"setTriggerRef","symbol":2,"ref":"mark"})"), "\"ok\":true"));
+  CHECK(reg2.get(2)->triggerRef == TriggerRef::Mark);
+  CHECK(has(api.handle(R"({"method":"list"})"), "\"instruments\":["));
+  CHECK(has(api.handle(R"({"method":"bogus"})"), "unknown_method"));
+  CHECK(has(api.handle(R"({"method":"halt","symbol":99,"halted":true})"), "unknown_symbol"));
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_cross_margin.cpp
+++ b/venue/tests/test_venue_cross_margin.cpp
@@ -1,0 +1,533 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/collateral.h"
+#include "flox-venue/cross_margin.h"
+#include "flox-venue/ledger.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr AssetId USD = 1;
+constexpr uint64_t VENUE = 999;
+constexpr SymbolId BTC = 1;
+constexpr SymbolId ETH = 2;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount usd(double v) { return amountOf(Volume::fromDouble(v)); }
+
+// Cross a fill through the manager for BOTH counterparties so the clearing pool
+// stays balanced (every long has a short), exactly as two symbol shards would
+// report their two sides to the risk consumer.
+void crossFill(CrossMarginManager& m, SymbolId s, uint64_t buyer, uint64_t seller, double p, double q)
+{
+  m.applyFill(buyer, s, Side::BUY, qty(q).raw(), px(p).raw());
+  m.applyFill(seller, s, Side::SELL, qty(q).raw(), px(p).raw());
+}
+
+void test_portfolio_im_gate()
+{
+  std::printf("test_cross_margin_im_gate\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  CrossMarginManager m(led, USD, VENUE);
+  m.configureSymbol(BTC, /*im*/ 1000, /*mm*/ 500);  // 10% IM
+  m.configureSymbol(ETH, /*im*/ 1000, /*mm*/ 500);
+  m.setMark(BTC, px(100));
+  m.setMark(ETH, px(100));
+
+  // 1000 equity, 10% IM -> can carry 10000 notional total.
+  CHECK(m.canOpen(1, BTC, Side::BUY, qty(50).raw(), px(100).raw()));  // 5000 notional -> IM 500 <= 1000
+  crossFill(m, BTC, 1, 2, 100, 50);
+  CHECK(m.initialMargin(1) == usd(500));
+
+  // Add ETH 40@100 = 4000 notional -> total IM 900 <= 1000: allowed.
+  CHECK(m.canOpen(1, ETH, Side::BUY, qty(40).raw(), px(100).raw()));
+  crossFill(m, ETH, 1, 2, 100, 40);
+  CHECK(m.initialMargin(1) == usd(900));
+
+  // One more big BTC clip would push IM past equity -> rejected.
+  CHECK(!m.canOpen(1, BTC, Side::BUY, qty(30).raw(), px(100).raw()));  // +3000 -> IM 1200 > 1000
+}
+
+void test_cross_offset()
+{
+  std::printf("test_cross_margin_offset\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(2, USD, usd(100000));  // deep counterparty
+  const Amount init = led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD);
+
+  CrossMarginManager m(led, USD, VENUE);
+  m.configureSymbol(BTC, 1000, 500);
+  m.configureSymbol(ETH, 1000, 500);
+  m.setMark(BTC, px(100));
+  m.setMark(ETH, px(100));
+
+  // Account 1: long BTC 20, short ETH 20 (both entered at 100).
+  crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 20);
+  crossFill(m, ETH, /*buyer*/ 2, /*seller*/ 1, 100, 20);
+  CHECK(m.positionQty(1, BTC) == qty(20).raw());
+  CHECK(m.positionQty(1, ETH) == -qty(20).raw());
+
+  // BTC +10 (long gains 200), ETH +10 (short loses 200): equity unchanged.
+  m.setMark(BTC, px(110));
+  m.setMark(ETH, px(110));
+  CHECK(m.equity(1) == usd(1000));  // +200 and -200 net to zero across the portfolio
+  // No liquidation happened (positions still open).
+  CHECK(m.positionQty(1, BTC) == qty(20).raw());
+  CHECK(m.positionQty(1, ETH) == -qty(20).raw());
+
+  // Close both at the marks -> realized PnL nets to zero, wallet back to 1000.
+  crossFill(m, BTC, /*buyer*/ 2, /*seller*/ 1, 110, 20);
+  crossFill(m, ETH, /*buyer*/ 1, /*seller*/ 2, 110, 20);
+  CHECK(m.positionQty(1, BTC) == 0 && m.positionQty(1, ETH) == 0);
+  CHECK(led.available(1, USD) == usd(1000));
+  CHECK(led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD) == init);
+}
+
+void test_cross_liquidation()
+{
+  std::printf("test_cross_margin_liquidation\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(2, USD, usd(100000));
+  const Amount init = led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD);
+
+  std::vector<Liquidation> liqs;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { liqs.push_back(l); });
+  m.configureSymbol(BTC, 1000, 500);
+  m.configureSymbol(ETH, 1000, 500);
+  m.setMark(BTC, px(100));
+  m.setMark(ETH, px(100));
+
+  // Account 1 goes long BTC 50 and long ETH 50 (both directions same-way -> no
+  // internal offset). Notional 10000, IM 1000 = full equity, MM 500.
+  crossFill(m, BTC, 1, 2, 100, 50);
+  crossFill(m, ETH, 1, 2, 100, 50);
+  CHECK(m.maintenanceMargin(1) == usd(500));
+
+  // BTC drops to 95: uPnl = -250 on BTC. equity = 1000 - 250 = 750.
+  // MM = (95*50 + 100*50)*5% = (4750+5000)*0.05 = 487.5 -> still solvent.
+  m.setMark(BTC, px(95));
+  CHECK(liqs.empty());
+  CHECK(m.positionQty(1, BTC) == qty(50).raw());
+
+  // BTC crashes to 85: uPnl = -750. equity = 250. MM = (85*50+100*50)*5% = 462.5
+  // -> 250 < 462.5 -> whole portfolio liquidated (both legs).
+  m.setMark(BTC, px(85));
+  CHECK(m.positionQty(1, BTC) == 0 && m.positionQty(1, ETH) == 0);
+  CHECK(liqs.size() == 2);  // both symbols closed
+
+  // Conservation across accounts + venue pool.
+  CHECK(led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD) == init);
+}
+
+void test_bankruptcy_insurance()
+{
+  std::printf("test_cross_margin_bankruptcy\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(2, USD, usd(100000));
+  const Amount init = led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD);
+
+  bool sawBankrupt = false;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { sawBankrupt = sawBankrupt || l.bankrupt; });
+  m.configureSymbol(BTC, 1000, 500);
+  m.setMark(BTC, px(100));
+
+  crossFill(m, BTC, 1, 2, 100, 100);  // long 100 @ 100, notional 10000, IM 1000 = equity
+
+  // Mark collapses to 80: uPnl = -2000 -> equity -1000 (negative). Liquidate;
+  // wallet goes negative and insurance (venue) tops it up to zero.
+  m.setMark(BTC, px(80));
+  CHECK(m.positionQty(1, BTC) == 0);
+  CHECK(led.available(1, USD) == 0);  // wiped out, insurance covered the deficit
+  // Value conserved: the venue pool absorbed the loss (insurance drawdown).
+  CHECK(led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD) == init);
+}
+
+// Auto-deleveraging: when a bankruptcy would drain the insurance fund, the
+// deficit is instead clawed back from the most profitable opposite-side trader
+// (their winning position is closed and their gain haircut). Insurance is spared.
+void test_adl()
+{
+  std::printf("test_cross_margin_adl\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(2, USD, usd(100000));
+  const Amount init = led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD);
+
+  std::vector<Liquidation> liqs;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { liqs.push_back(l); },
+                       /*autoDeleverage*/ true);
+  m.configureSymbol(BTC, 1000, 500);
+  m.setMark(BTC, px(100));
+
+  // Account 1 long 100 @ 100 (IM 1000 = full wallet); account 2 short 100 @ 100.
+  crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 100);
+  const Amount venueBefore = led.total(VENUE, USD);  // insurance fund level
+
+  // Mark crashes to 80: acct1 equity = 1000 - 2000 = -1000 (bankrupt, deficit 1000).
+  m.setMark(BTC, px(80));
+  CHECK(m.positionQty(1, BTC) == 0);
+  CHECK(m.positionQty(2, BTC) == 0);  // winner was auto-deleveraged (closed)
+
+  // Insurance fund untouched: the 1000 deficit was clawed from acct2's profit.
+  CHECK(led.total(VENUE, USD) == venueBefore);
+  // acct2's gain is capped at +1000 (to bankruptcy price) instead of +2000 (mark).
+  CHECK(led.available(2, USD) == usd(100000) + usd(1000));
+
+  bool sawAdl = false, sawBankrupt = false;
+  for (const auto& l : liqs)
+  {
+    if (l.adl)
+    {
+      sawAdl = true;
+    }
+    if (l.bankrupt)
+    {
+      sawBankrupt = true;
+    }
+  }
+  CHECK(sawAdl);
+  CHECK(sawBankrupt);
+  CHECK(led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD) == init);
+}
+
+// ADL victim selection must be a pure function of logical state: with two
+// equal-uPnl winners and a deficit only one is needed to cover, the SAME winner
+// (deterministic total order -> lowest account id) is deleveraged regardless of
+// the order fills arrived in. Otherwise a replica rebuilt with a different
+// insertion history would pick the other victim -> divergent balances + event
+// hash, forking HA state. `winnersInReverse` flips the fill/insertion order.
+uint64_t adl_victim(bool winnersInReverse)
+{
+  Ledger led;
+  led.deposit(1, USD, usd(1000));    // bankrupt-to-be: long 100 @ 100, IM = wallet
+  led.deposit(2, USD, usd(100000));  // deep winner A
+  led.deposit(3, USD, usd(100000));  // deep winner B (identical position -> equal uPnl)
+  std::vector<Liquidation> liqs;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { liqs.push_back(l); },
+                       /*autoDeleverage*/ true);
+  m.configureSymbol(BTC, 1000, 500);
+  m.setMark(BTC, px(100));
+  // Acct1 long 100 is matched by two 50-lot shorts (acct2, acct3). Fill order
+  // (hence pos_ insertion order) is flipped by the flag.
+  if (!winnersInReverse)
+  {
+    crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 50);
+    crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 3, 100, 50);
+  }
+  else
+  {
+    crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 3, 100, 50);
+    crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 50);
+  }
+  // Mark -> 80: acct1 equity = 1000 - 2000 = -1000 (deficit 1000). Each short
+  // winner has uPnl = (100-80)*50 = +1000, so exactly ONE covers the deficit.
+  m.setMark(BTC, px(80));
+  uint64_t victim = 0;
+  for (const auto& l : liqs)
+  {
+    if (l.adl)
+    {
+      victim = l.account;
+    }
+  }
+  return victim;
+}
+
+void test_adl_deterministic_victim()
+{
+  std::printf("test_cross_margin_adl_deterministic_victim\n");
+  const uint64_t v1 = adl_victim(/*winnersInReverse*/ false);
+  const uint64_t v2 = adl_victim(/*winnersInReverse*/ true);
+  CHECK(v1 == 2);   // lowest account id, per the total order
+  CHECK(v2 == 2);   // same victim under the reversed insertion order
+  CHECK(v1 == v2);  // insertion-order independent -> HA-safe
+}
+
+// ADL claw-back must never mint money. The confiscation debit is all-or-nothing
+// and an ADL winner can have negative cash `available` (funding drives it there),
+// so crediting the insurance fund the full haircut while the debit no-ops would
+// create phantom money -- conservation must hold, with any uncovered remainder
+// borne by insurance (the normal waterfall), not conjured.
+void test_adl_negative_available_conserves()
+{
+  std::printf("test_cross_margin_adl_negative_available_conserves\n");
+  Ledger led;
+  led.deposit(1, USD, usd(100));     // B: bankrupt-to-be long
+  led.deposit(2, USD, usd(120));     // W: ADL winner, about to be driven cash-negative
+  led.deposit(3, USD, usd(100000));  // Z: ETH funding sink (isolates W's drain from B)
+  auto total = [&]
+  { return led.total(1, USD) + led.total(2, USD) + led.total(3, USD) + led.total(VENUE, USD); };
+  const Amount init = total();
+
+  std::vector<Liquidation> liqs;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { liqs.push_back(l); },
+                       /*autoDeleverage*/ true);
+  m.configureSymbol(BTC, 1000, 500);
+  m.configureSymbol(ETH, 1000, 500);
+  m.setMark(BTC, px(100));
+  m.setMark(ETH, px(100));
+  crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 10);  // B long 10, W short 10
+  crossFill(m, ETH, /*buyer*/ 2, /*seller*/ 3, 100, 2);   // W long 2 ETH, Z short 2 ETH
+
+  // Drive W's cash negative via ETH funding, with liquidations paused so the
+  // transient sub-maintenance state doesn't liquidate W before it becomes the
+  // ADL winner. (Absurd rate -- we only need to reach the negative-cash state.)
+  m.setLiquidationsPaused(true);
+  m.applyFunding(ETH, /*rate*/ 1.15, px(100));  // W pays 230 -> available 120 - 230 = -110
+  CHECK(led.available(2, USD) < 0);
+  m.setLiquidationsPaused(false);
+
+  // Crash BTC: B (long 10) goes bankrupt (loss 200 > deposit 100 -> deficit 100),
+  // ADL claws from W (short 10, +200 uPnl). After the +200 credit W has 90 cash <
+  // the 100 haircut, so the all-or-nothing debit is short.
+  m.setMark(BTC, px(80));
+
+  bool sawAdl = false;
+  for (auto& l : liqs)
+  {
+    if (l.adl)
+    {
+      sawAdl = true;
+    }
+  }
+  CHECK(sawAdl);
+  CHECK(total() == init);  // no phantom money minted by the claw-back
+}
+
+// A trader must not withdraw collateral that backs open positions.
+void test_withdrawal_gate()
+{
+  std::printf("test_cross_margin_withdrawal_gate\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  CrossMarginManager m(led, USD, VENUE);
+  m.configureSymbol(BTC, /*im*/ 1000, /*mm*/ 500);
+  m.setMark(BTC, px(100));
+
+  // Flat: the whole wallet is withdrawable.
+  CHECK(m.withdrawable(1) == usd(1000));
+  CHECK(m.canWithdraw(1, usd(1000)));
+  CHECK(!m.canWithdraw(1, usd(1001)));
+
+  // Open long 50 @ 100: notional 5000, IM 500. Free = equity 1000 - IM 500 = 500.
+  crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 50);
+  CHECK(m.withdrawable(1) == usd(500));
+  CHECK(m.canWithdraw(1, usd(500)));
+  CHECK(!m.canWithdraw(1, usd(600)));  // would leave IM uncovered
+
+  // A gain lifts equity and thus the withdrawable amount.
+  m.setMark(BTC, px(110));  // uPnl = 50*(110-100) = +500; IM = 110*50*10% = 550
+  CHECK(m.equity(1) == usd(1500));
+  CHECK(m.withdrawable(1) == usd(1500) - usd(550));
+
+  // A negative amount is never valid.
+  CHECK(!m.canWithdraw(1, -usd(1)));
+}
+
+// Liquidations paused (feed outage): a bad mark must not liquidate the book.
+void test_liquidations_paused()
+{
+  std::printf("test_cross_margin_liquidations_paused\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(2, USD, usd(100000));
+  std::vector<Liquidation> liqs;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { liqs.push_back(l); });
+  m.configureSymbol(BTC, 1000, 500);
+  m.setMark(BTC, px(100));
+  crossFill(m, BTC, 1, 2, 100, 100);  // acct1 long 100, IM 1000 = wallet
+
+  // Feed goes bad; operator pauses liquidations. A crash mark does NOT liquidate.
+  m.setLiquidationsPaused(true);
+  m.setMark(BTC, px(80));  // equity would be -1000
+  CHECK(liqs.empty());
+  CHECK(m.positionQty(1, BTC) == qty(100).raw());  // still open
+  CHECK(m.equity(1) < 0);                          // PnL still reflects the mark
+
+  // Feed recovers, liquidations resume; the next mark update sweeps.
+  m.setLiquidationsPaused(false);
+  m.setMark(BTC, px(80));
+  CHECK(!liqs.empty());
+  CHECK(m.positionQty(1, BTC) == 0);
+}
+
+// Multi-asset collateral: BTC posted as margin gives quote-denominated buying
+// power (after haircut), so a trader with no quote can still open a position.
+void test_multi_collateral()
+{
+  std::printf("test_cross_margin_multi_collateral\n");
+  constexpr AssetId BTC_ASSET = 5;  // collateral asset (distinct from the perp symbol)
+  Ledger led;
+  led.deposit(1, BTC_ASSET, amountOf(Volume::fromDouble(1.0)));  // 1 BTC, zero USD
+
+  CollateralSchedule sched;
+  sched.configure(USD, px(1.0).raw(), /*haircut*/ 0);
+  sched.configure(BTC_ASSET, px(30000).raw(), /*haircut*/ 2000);  // 20% -> 24000 credit
+
+  CrossMarginManager m(led, USD, VENUE);
+  m.setCollateralSchedule(&sched);
+  m.configureSymbol(BTC, /*im*/ 1000, /*mm*/ 500);
+  m.setMark(BTC, px(100));
+
+  // Equity comes entirely from the haircut-adjusted BTC collateral.
+  CHECK(m.equity(1) == usd(24000));
+  CHECK(m.withdrawable(1) == usd(24000));  // flat -> all withdrawable
+
+  // Buying power reflects the BTC-backed equity: 200000 notional (IM 20000) fits;
+  // 250000 (IM 25000) exceeds the 24000 equity.
+  CHECK(m.canOpen(1, BTC, Side::BUY, qty(2000).raw(), px(100).raw()));
+  CHECK(!m.canOpen(1, BTC, Side::BUY, qty(2500).raw(), px(100).raw()));
+}
+
+// On liquidation, a non-quote collateral basket is sold to the venue to cover
+// the quote loss before the insurance fund is tapped; value stays conserved
+// per asset (the venue ends up holding the coin).
+void test_collateral_liquidation()
+{
+  std::printf("test_cross_margin_collateral_liquidation\n");
+  constexpr AssetId BTC_ASSET = 5;
+  const Amount half = amountOf(Volume::fromDouble(0.05));  // 0.05 BTC = 1500 USD @ 30000
+  Ledger led;
+  led.deposit(1, BTC_ASSET, half);
+  led.deposit(2, USD, usd(100000));
+  const Amount initBtc = led.total(1, BTC_ASSET) + led.total(2, BTC_ASSET) + led.total(VENUE, BTC_ASSET);
+  const Amount initUsd = led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD);
+
+  CollateralSchedule sched;
+  sched.configure(USD, px(1.0).raw(), 0);
+  sched.configure(BTC_ASSET, px(30000).raw(), 0);  // 0 haircut -> clean math
+
+  std::vector<Liquidation> liqs;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { liqs.push_back(l); });
+  m.setCollateralSchedule(&sched);
+  m.configureSymbol(BTC, /*im*/ 1000, /*mm*/ 500);
+  m.setMark(BTC, px(100));
+  CHECK(m.equity(1) == usd(1500));
+
+  crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 100);  // acct1 long 100 (IM 1000 < 1500)
+
+  // Crash to 80: acct1 uPnl -2000, equity -500 -> liquidate. The 2000 loss is
+  // covered first by selling the 1500 of BTC collateral, then 500 by insurance.
+  m.setMark(BTC, px(80));
+  CHECK(m.positionQty(1, BTC) == 0);
+  CHECK(led.total(1, BTC_ASSET) == 0);         // collateral fully sold
+  CHECK(led.total(VENUE, BTC_ASSET) == half);  // venue now holds the coin
+  CHECK(led.available(1, USD) == 0);           // wallet topped to zero
+
+  // Value conserved per asset.
+  CHECK(led.total(1, BTC_ASSET) + led.total(2, BTC_ASSET) + led.total(VENUE, BTC_ASSET) == initBtc);
+  CHECK(led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD) == initUsd);
+
+  bool bankrupt = false;
+  for (const auto& l : liqs)
+  {
+    if (l.bankrupt)
+    {
+      bankrupt = true;
+    }
+  }
+  CHECK(bankrupt);  // collateral covered 1500, insurance the residual 500
+}
+
+// Funding across the portfolio book: longs pay shorts, pool nets zero, conserved.
+void test_funding()
+{
+  std::printf("test_cross_margin_funding\n");
+  Ledger led;
+  led.deposit(1, USD, usd(100000));
+  led.deposit(2, USD, usd(100000));
+  const Amount init = led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD);
+  CrossMarginManager m(led, USD, VENUE);
+  m.configureSymbol(BTC, 1000, 500);
+  m.setMark(BTC, px(100));
+  crossFill(m, BTC, /*buyer*/ 1, /*seller*/ 2, 100, 100);  // acct1 long, acct2 short, notional 10000
+
+  const Amount a1 = led.available(1, USD);
+  const Amount a2 = led.available(2, USD);
+  m.applyFunding(BTC, /*rate*/ 0.01, px(100));    // 1% of 10000 = 100
+  CHECK(led.available(1, USD) == a1 - usd(100));  // long paid 100
+  CHECK(led.available(2, USD) == a2 + usd(100));  // short received 100
+  CHECK(led.total(VENUE, USD) == 0);              // pool net zero (balanced book)
+  CHECK(led.total(1, USD) + led.total(2, USD) + led.total(VENUE, USD) == init);
+}
+
+// Funding that drains a thin wallet below maintenance triggers a liquidation in
+// the same applyFunding call (the sweep the fix added).
+void test_funding_liquidation()
+{
+  std::printf("test_cross_margin_funding_liquidation\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));  // long: wallet == IM, thin
+  led.deposit(2, USD, usd(100000));
+  std::vector<Liquidation> liqs;
+  CrossMarginManager m(led, USD, VENUE, [&](const Liquidation& l)
+                       { liqs.push_back(l); });
+  m.configureSymbol(BTC, /*im*/ 1000, /*mm*/ 500);
+  m.setMark(BTC, px(100));
+  crossFill(m, BTC, 1, 2, 100, 100);  // acct1 long 100 @ 100, notional 10000, MM 500
+  CHECK(m.equity(1) == usd(1000));
+
+  // A steep 6% funding: long pays 600 -> equity 400 < MM 500 -> liquidated.
+  m.applyFunding(BTC, 0.06, px(100));
+  CHECK(!liqs.empty());
+  CHECK(m.positionQty(1, BTC) == 0);
+}
+
+}  // namespace
+
+TEST(CrossMargin, EngineSuite)
+{
+  test_portfolio_im_gate();
+  test_multi_collateral();
+  test_collateral_liquidation();
+  test_funding();
+  test_funding_liquidation();
+  test_cross_offset();
+  test_cross_liquidation();
+  test_bankruptcy_insurance();
+  test_adl();
+  test_adl_deterministic_victim();
+  test_adl_negative_available_conserves();
+  test_withdrawal_gate();
+  test_liquidations_paused();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_crypto.cpp
+++ b/venue/tests/test_venue_crypto.cpp
@@ -1,0 +1,62 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox/util/crypto.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+using namespace flox::crypto;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+std::string h(const std::string& s)
+{
+  auto d = sha256(reinterpret_cast<const uint8_t*>(s.data()), s.size());
+  return toHex(d.data(), d.size());
+}
+}  // namespace
+
+TEST(Crypto, EngineSuite)
+{
+  std::printf("test_crypto\n");
+  {
+    auto s = sha1(reinterpret_cast<const uint8_t*>("abc"), 3);
+    CHECK(toHex(s.data(), s.size()) == "a9993e364706816aba3e25717850c26c9cd0d89d");
+  }
+  CHECK(h("abc") == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  CHECK(h("") == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  {
+    const std::string key = "key", msg = "The quick brown fox jumps over the lazy dog";
+    auto mac = hmacSha256(reinterpret_cast<const uint8_t*>(key.data()), key.size(),
+                          reinterpret_cast<const uint8_t*>(msg.data()), msg.size());
+    CHECK(toHex(mac.data(), mac.size()) ==
+          "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8");
+  }
+  CHECK(base64(reinterpret_cast<const uint8_t*>("Man"), 3) == "TWFu");
+  CHECK(base64(reinterpret_cast<const uint8_t*>("Ma"), 2) == "TWE=");
+  CHECK(base64(reinterpret_cast<const uint8_t*>("M"), 1) == "TQ==");
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_derivatives.cpp
+++ b/venue/tests/test_venue_derivatives.cpp
@@ -1,0 +1,159 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/liquidation_monitor.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg(TriggerRef ref = TriggerRef::Last)
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  c.triggerRef = ref;
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+struct Cap
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+  int triggers() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<OrderTriggered>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  bool tradedBy(OrderId taker, double price) const
+  {
+    for (auto& e : ev)
+    {
+      if (auto* t = std::get_if<Trade>(&e))
+      {
+        if (t->takerId == taker && t->price == px(price))
+        {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+};
+
+void test_mark_trigger()
+{
+  std::printf("test_mark_trigger\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(TriggerRef::Mark), cap.sink());
+  eng.submit(limit(1, Side::SELL, 105, 10, 1));  // liquidity for the stop to hit
+
+  NewOrder st;
+  st.id = 2;
+  st.symbol = SYM;
+  st.side = Side::BUY;
+  st.type = OrderType::STOP_MARKET;
+  st.quantity = qty(3);
+  st.triggerPrice = px(105);
+  st.accountId = 2;
+  eng.submit(st);
+  CHECK(cap.triggers() == 0);  // no mark yet -> pending
+
+  eng.setMarkPrice(px(104));  // below trigger
+  CHECK(cap.triggers() == 0);
+
+  eng.setMarkPrice(px(105));  // mark hits trigger -> fires (independent of last trade)
+  CHECK(cap.triggers() == 1);
+  CHECK(cap.tradedBy(2, 105.0));
+}
+
+void test_liquidation()
+{
+  std::printf("test_liquidation\n");
+  // A long position, tiny equity: underwater as the mark drops.
+  LiquidationMonitor mon(SYM, /*mmFraction*/ 0.005, /*insurance*/ 1e9);
+  mon.openPosition(/*account*/ 9, /*signedQty*/ +10.0, /*entry*/ 100.0, /*equity*/ 5.0);
+  CHECK(mon.openPositions() == 1);
+
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  eng.submit(limit(100, Side::BUY, 60, 20, 3));  // bids to absorb the forced sell
+
+  const auto orders = mon.onMark(60.0);  // long entry 100 -> deeply underwater at 60
+  CHECK(orders.size() == 1);
+  CHECK(mon.openPositions() == 0);
+  if (!orders.empty())
+  {
+    CHECK(orders[0].side == Side::SELL);
+    CHECK(orders[0].quantity == qty(10));
+    eng.submit(orders[0]);                    // route the liquidation order to matching
+    CHECK(cap.tradedBy(orders[0].id, 60.0));  // filled against the bid
+  }
+}
+
+}  // namespace
+
+TEST(Derivatives, EngineSuite)
+{
+  test_mark_trigger();
+  test_liquidation();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_differential_fuzz.cpp
+++ b/venue/tests/test_venue_differential_fuzz.cpp
@@ -1,0 +1,214 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Differential fuzz over the two order-level matching books. Drives a large
+ * mixed random command stream (limits both sides, markets, IOC, post-only,
+ * cancels, modifies, pegs) through the std::map reference book and the O(1)
+ * ladder book in lockstep, asserting after every command that:
+ *   - both engines emitted an identical event stream (rolling hash), and
+ *   - neither book is crossed (best bid < best ask).
+ * The reference book is the oracle; any ladder divergence fails with the command
+ * index. Reproducible: fixed xorshift seed, no wall-clock / RNG.
+ *
+ * Depth defaults to a CI-friendly size; set FLOX_FUZZ_OPS for a deep run
+ * (the venue application gates 2M under ASAN/UBSAN before release).
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/ladder_book.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+constexpr SymbolId SYM = 1;
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = Price::fromDouble(0.01);
+  c.minPrice = Price::fromDouble(50.0);
+  c.maxPrice = Price::fromDouble(150.0);
+  return c;
+}
+
+LadderBook::Config ladderCfg()
+{
+  return LadderBook::Config{/*base*/ 0, /*tick*/ Price::fromDouble(0.01).raw(),
+                            /*levels*/ 16000, /*maxOrders*/ 1 << 20};
+}
+
+template <class Book>
+bool crossed(const Book& b)
+{
+  const auto bid = b.bestBid();
+  const auto ask = b.bestAsk();
+  return bid.has_value() && ask.has_value() && !(bid.value() < ask.value());
+}
+
+InboundCommand genCommand(uint64_t& s, uint64_t seq, OrderId& nextId)
+{
+  auto next = [&]() noexcept
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  };
+  const uint64_t r = next();
+  const int64_t midRaw = Price::fromDouble(100.0).raw();
+  const int64_t tickRaw = Price::fromDouble(0.01).raw();
+  const uint32_t kind = r % 100;
+
+  if (kind < 15 && nextId > 1)
+  {
+    // cancel a random earlier id (may be live or already gone -- both books
+    // must agree either way)
+    const OrderId victim = 1 + (next() % (nextId - 1));
+    return CancelOrder{victim, SYM, 1};
+  }
+  if (kind < 25 && nextId > 1)
+  {
+    // modify a random earlier id: new price within band, new qty 1..6
+    const OrderId victim = 1 + (next() % (nextId - 1));
+    const int ticks = static_cast<int>((next() % 101)) - 50;
+    const Price newPrice = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+    const Quantity newQty = Quantity::fromDouble(1.0 + static_cast<double>(next() % 6));
+    return ModifyOrder{victim, SYM, newPrice, newQty, 1};
+  }
+
+  NewOrder o;
+  o.id = nextId++;
+  o.symbol = SYM;
+  o.side = (r & 1U) ? Side::BUY : Side::SELL;
+  o.quantity = Quantity::fromDouble(1.0 + static_cast<double>((r >> 10) % 5));
+  o.accountId = 1 + ((r >> 20) % 8);
+
+  if (kind < 30)
+  {
+    o.type = OrderType::MARKET;
+  }
+  else if (kind < 40)
+  {
+    // stop-market with a random in-band trigger (engine-level, deterministic;
+    // both books must still agree, and cascades are exercised)
+    o.type = OrderType::STOP_MARKET;
+    const int ticks = static_cast<int>((r >> 1) % 101) - 50;
+    o.triggerPrice = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+  }
+  else
+  {
+    o.type = OrderType::LIMIT;
+    const int ticks = static_cast<int>((r >> 1) % 101) - 50;  // +/-50 ticks
+    o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+    const uint32_t t = (r >> 32) % 100;
+    if (t < 12)
+    {
+      o.tif = TimeInForce::IOC;
+    }
+    else if (t < 17)
+    {
+      o.postOnly = true;
+    }
+    else if (t < 30)
+    {
+      o.visibleQuantity = Quantity::fromDouble(1.0);  // iceberg peak 1 (if qty > 1)
+    }
+    else if (t < 42)
+    {
+      o.tif = TimeInForce::GTD;  // some expire, some never
+      o.expiryNs = static_cast<int64_t>((r >> 40) % 2'000'000);
+    }
+    else if (t < 50)
+    {
+      o.ocoGroup = 1 + ((r >> 44) % 6);  // small set -> siblings collide
+    }
+    else if (t < 60)
+    {
+      const uint32_t pr = static_cast<uint32_t>((r >> 48) % 3);
+      o.peg = pr == 0 ? PegRef::Bid : (pr == 1 ? PegRef::Ask : PegRef::Mid);
+    }
+  }
+  (void)seq;
+  return InboundCommand{o};
+}
+
+int g_failures = 0;
+}  // namespace
+
+TEST(VenueDifferentialFuzz, LadderMatchesReferenceBook)
+{
+  uint64_t hRef = 1469598103934665603ULL;
+  uint64_t hLad = hRef;
+  std::vector<OutboundEvent> evRef;
+  std::vector<OutboundEvent> evLad;
+
+  MatchingEngine<MatchingBook> refE(cfg(), [&](const OutboundEvent& e)
+                                    { evRef.push_back(e); });
+  MatchingEngine<LadderBook> ladE(cfg(), [&](const OutboundEvent& e)
+                                  { evLad.push_back(e); }, LadderBook{ladderCfg()});
+
+  const char* env = std::getenv("FLOX_FUZZ_OPS");
+  const uint64_t N = env != nullptr ? std::strtoull(env, nullptr, 10) : 200'000;
+  uint64_t s = 0xC0FFEE123456789ULL;
+  OrderId nextId = 1;
+
+  for (uint64_t i = 0; i < N; ++i)
+  {
+    const InboundCommand cmd = genCommand(s, i, nextId);
+    evRef.clear();
+    evLad.clear();
+    refE.submit(cmd);
+    ladE.submit(cmd);
+
+    if (evRef.size() != evLad.size())
+    {
+      std::printf("FAIL cmd %llu: event count %zu != %zu\n",
+                  static_cast<unsigned long long>(i), evRef.size(), evLad.size());
+      ++g_failures;
+      break;
+    }
+    for (size_t k = 0; k < evRef.size(); ++k)
+    {
+      hRef = hashEvent(hRef, evRef[k]);
+      hLad = hashEvent(hLad, evLad[k]);
+    }
+    if (hRef != hLad)
+    {
+      std::printf("FAIL cmd %llu: event hash diverged\n", static_cast<unsigned long long>(i));
+      ++g_failures;
+      break;
+    }
+    if (crossed(refE.book()) || crossed(ladE.book()))
+    {
+      std::printf("FAIL cmd %llu: crossed book\n", static_cast<unsigned long long>(i));
+      ++g_failures;
+      break;
+    }
+  }
+
+  if (g_failures == 0)
+  {
+    std::printf("differential: %llu commands, ladder == reference, no crossed book\n",
+                static_cast<unsigned long long>(N));
+    std::printf("final event-stream hash: %016llx\n", static_cast<unsigned long long>(hRef));
+  }
+
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_engine.cpp
+++ b/venue/tests/test_venue_engine.cpp
@@ -1,0 +1,154 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox-venue/matching_engine.h"
+
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/ledger.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE_ACCT = 900;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount base(double v) { return amountOf(qty(v)); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+int64_t i64(Amount a) { return static_cast<int64_t>(a); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1);
+  c.maxPrice = px(1000);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  return c;
+}
+
+NewOrder limitOrder(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+}  // namespace
+
+// End-to-end venue: orders match through the engine, settle against the ledger,
+// and value is conserved per asset (the property that makes it a real venue).
+TEST(VenueEngine, MatchSettlesAndConservesValue)
+{
+  Ledger led;
+  led.deposit(1, BASE, base(10));       // seller
+  led.deposit(2, QUOTE, quote(10000));  // buyer
+  const Amount initBase = led.total(1, BASE) + led.total(2, BASE);
+  const Amount initQuote = led.total(1, QUOTE) + led.total(2, QUOTE);
+
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+
+  eng.submit(InboundCommand{limitOrder(1, Side::SELL, 100, 5, 1)}, 0);
+  eng.submit(InboundCommand{limitOrder(2, Side::BUY, 100, 3, 2)}, 1);  // trades 3 @ 100
+
+  EXPECT_EQ(i64(led.available(2, BASE)), i64(base(3)));      // buyer got base
+  EXPECT_EQ(i64(led.available(1, QUOTE)), i64(quote(300)));  // seller got quote
+  // Conservation per asset across both accounts + the venue fee account.
+  EXPECT_EQ(i64(led.total(1, BASE) + led.total(2, BASE) + led.total(VENUE_ACCT, BASE)),
+            i64(initBase));
+  EXPECT_EQ(i64(led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE_ACCT, QUOTE)),
+            i64(initQuote));
+}
+
+// Cancelling the unfilled remainder must return the reservation to available,
+// leaving no buying power stranded in `reserved`.
+TEST(VenueEngine, CancelReleasesReservation)
+{
+  Ledger led;
+  led.deposit(1, BASE, base(10));
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+
+  eng.submit(InboundCommand{limitOrder(1, Side::SELL, 100, 4, 1)}, 0);
+  EXPECT_EQ(i64(led.reserved(1, BASE)), i64(base(4)));
+
+  eng.submit(InboundCommand{CancelOrder{1, SYM, 1}}, 1);
+  EXPECT_EQ(i64(led.reserved(1, BASE)), 0);
+  EXPECT_EQ(i64(led.available(1, BASE)), i64(base(10)));
+}
+
+// Deterministic recovery: replaying the journal into a fresh engine reproduces
+// the event stream bit-for-bit and the same ledger state.
+TEST(VenueEngine, JournalReplayIsDeterministic)
+{
+  const std::string path = "/tmp/flox_venue_journal_test.bin";
+  std::vector<std::pair<int64_t, InboundCommand>> cmds{
+      {10, InboundCommand{limitOrder(1, Side::SELL, 100, 5, 1)}},
+      {20, InboundCommand{limitOrder(2, Side::BUY, 100, 3, 2)}},
+      {30, InboundCommand{CancelOrder{1, SYM, 1}}},
+  };
+
+  auto run = [&](Ledger& led, const std::vector<std::pair<int64_t, InboundCommand>>& in)
+  {
+    led.deposit(1, BASE, base(10));
+    led.deposit(2, QUOTE, quote(10000));
+    uint64_t h = 1469598103934665603ULL;
+    MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                     { h = hashEvent(h, e); });
+    eng.setLedger(&led, VENUE_ACCT);
+    for (const auto& [ts, c] : in)
+    {
+      eng.submit(c, ts);
+    }
+    return h;
+  };
+
+  // Live run, journalling every command.
+  Ledger liveLed;
+  {
+    Journal j(path);
+    for (const auto& [ts, c] : cmds)
+    {
+      j.append(c, ts);
+    }
+    j.flush();
+  }
+  const uint64_t liveHash = run(liveLed, cmds);
+
+  // Recovery run from the journal.
+  const auto replayed = Journal::loadTimed(path);
+  ASSERT_EQ(replayed.size(), cmds.size());
+  Ledger recLed;
+  const uint64_t recHash = run(recLed, replayed);
+
+  EXPECT_EQ(recHash, liveHash);  // identical event stream
+  EXPECT_EQ(i64(recLed.available(2, BASE)), i64(liveLed.available(2, BASE)));
+  EXPECT_EQ(i64(recLed.available(1, QUOTE)), i64(liveLed.available(1, QUOTE)));
+  std::remove(path.c_str());
+}

--- a/venue/tests/test_venue_funding.cpp
+++ b/venue/tests/test_venue_funding.cpp
@@ -1,0 +1,89 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/funding_rate.h"
+
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+bool near(double a, double b, double eps = 1e-9) { return std::fabs(a - b) < eps; }
+}  // namespace
+
+TEST(VenueFunding, EngineSuite)
+{
+  std::printf("test_funding\n");
+  FundingCalculator fc;  // defaults: interest 1bp, band 5bp, cap 0.75%
+
+  CHECK(fc.rate(101, 100) > 0);            // mark above index -> longs pay
+  CHECK(fc.rate(99, 100) < 0);             // mark below index -> shorts pay
+  CHECK(near(fc.rate(100, 100), 0.0001));  // premium 0 -> interest component
+  CHECK(near(fc.rate(200, 100), 0.0075));  // huge premium -> capped
+  CHECK(near(fc.rate(1, 100), -0.0075));   // huge negative -> capped
+  CHECK(near(fc.rate(100, 0), 0.0));       // no index -> no funding
+
+  // Settlement: balanced long/short book nets to zero; long pays when rate > 0.
+  std::vector<PerpPosition> pos = {{1, +10.0}, {2, -10.0}};
+  const auto pays = fc.settle(pos, 101.0, 100.0);
+  CHECK(pays.size() == 2);
+  CHECK(pays[0].account == 1 && pays[0].amount < 0);  // long pays
+  CHECK(pays[1].account == 2 && pays[1].amount > 0);  // short receives
+  CHECK(near(pays[0].amount + pays[1].amount, 0.0));  // zero-sum
+
+  // --- interval TWAP (manipulation-resistant) ---
+  // A single manipulated snapshot swings the naive rate to the cap; the interval
+  // average over many honest samples dilutes the spike back toward the floor.
+  FundingCalculator tw;
+  for (int i = 0; i < 1000; ++i)
+  {
+    tw.sample(100.0, 100.0);  // 1000 honest samples @ premium 0
+  }
+  tw.sample(200.0, 100.0);  // one manipulative print (premium +100%)
+  CHECK(tw.sampleCount() == 1001);
+  const double snapRate = tw.rate(200.0, 100.0);  // naive single snapshot -> capped
+  const double twapRate = tw.intervalRate();      // averaged -> near the floor
+  CHECK(near(snapRate, 0.0075));                  // capped
+  CHECK(twapRate < 0.002);                        // spike diluted, nowhere near the cap
+  CHECK(twapRate < snapRate);
+
+  // A sustained premium (every sample above index) produces a real positive rate.
+  FundingCalculator sus;
+  for (int i = 0; i < 50; ++i)
+  {
+    sus.sample(100.5, 100.0);  // steady +0.5% premium
+  }
+  CHECK(sus.intervalRate() > 0.004);  // meaningful positive funding
+
+  // Reset clears the accumulator back to the interest floor.
+  sus.resetSamples();
+  CHECK(sus.sampleCount() == 0);
+  CHECK(near(sus.intervalRate(), 0.0001));
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_funding_rate.cpp
+++ b/venue/tests/test_venue_funding_rate.cpp
@@ -1,0 +1,84 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox-venue/funding_rate.h"
+
+#include <gtest/gtest.h>
+
+using namespace flox;
+using namespace flox::venue;
+
+TEST(FundingRate, PremiumDrivesSignMarkAboveIndexIsPositive)
+{
+  FundingCalculator f;  // interest 1bp, clamp 5bp, cap 0.75%
+  // mark > index: longs pay (positive rate); mark < index: shorts pay.
+  EXPECT_GT(f.rate(/*mark=*/101.0, /*index=*/100.0), 0.0);
+  EXPECT_LT(f.rate(/*mark=*/99.0, /*index=*/100.0), 0.0);
+  // Flat market: rate collapses to the interest component.
+  EXPECT_NEAR(f.rate(100.0, 100.0), 0.0001, 1e-12);
+}
+
+TEST(FundingRate, CapBoundsExtremeDislocation)
+{
+  FundingCalculator f;
+  // A 50% premium must still clamp to the ±0.75% cap.
+  EXPECT_NEAR(f.rate(150.0, 100.0), 0.0075, 1e-12);
+  EXPECT_NEAR(f.rate(50.0, 100.0), -0.0075, 1e-12);
+}
+
+TEST(FundingRate, InvalidIndexYieldsZero)
+{
+  FundingCalculator f;
+  EXPECT_DOUBLE_EQ(f.rate(100.0, 0.0), 0.0);
+  EXPECT_DOUBLE_EQ(f.rate(100.0, -1.0), 0.0);
+}
+
+// The TWAP path is the manipulation-resistant one: a single dislocated print
+// must not swing the settled rate the way a snapshot would.
+TEST(FundingRate, IntervalTwapResistsSingleSpike)
+{
+  FundingCalculator f;
+  for (int i = 0; i < 99; ++i)
+  {
+    f.sample(100.0, 100.0);  // flat
+  }
+  f.sample(150.0, 100.0);  // one 50% spike
+  EXPECT_EQ(f.sampleCount(), 100u);
+
+  const double twap = f.intervalRate();
+  const double snapshot = f.rate(150.0, 100.0);
+  EXPECT_LT(twap, snapshot);  // averaged away, not the capped snapshot
+  // avg premium = 0.5% -> clamp(interest 0.01% - 0.5%, ±0.05%) = -0.05%
+  // -> rate = 0.5% - 0.05% = 0.45% (below the 0.75% cap the snapshot hits).
+  EXPECT_NEAR(twap, 0.0045, 1e-9);
+
+  f.resetSamples();
+  EXPECT_EQ(f.sampleCount(), 0u);
+  // No samples -> falls back to the interest-only rate.
+  EXPECT_NEAR(f.intervalRate(), 0.0001, 1e-12);
+}
+
+// Funding is a transfer between longs and shorts: on a balanced book the
+// charges must net to zero (no money created by the settlement).
+TEST(FundingRate, SettleIsZeroSumOnBalancedBook)
+{
+  FundingCalculator f;
+  const std::vector<PerpPosition> pos{{/*account=*/1, +10.0}, {/*account=*/2, -4.0}, {/*account=*/3, -6.0}};
+  const auto charges = f.settle(pos, /*mark=*/101.0, /*index=*/100.0);
+  ASSERT_EQ(charges.size(), 3u);
+
+  double sum = 0.0;
+  for (const auto& c : charges)
+  {
+    sum += c.amount;
+  }
+  EXPECT_NEAR(sum, 0.0, 1e-9);        // zero-sum across the book
+  EXPECT_LT(charges[0].amount, 0.0);  // long pays when mark > index
+  EXPECT_GT(charges[1].amount, 0.0);  // shorts receive
+}

--- a/venue/tests/test_venue_funding_scheduler.cpp
+++ b/venue/tests/test_venue_funding_scheduler.cpp
@@ -1,0 +1,122 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/funding_scheduler.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 999;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+constexpr int64_t SEC = 1'000'000'000LL;
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  c.quoteAsset = QUOTE;
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;
+  return c;
+}
+NewOrder ord(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+void test_scheduler()
+{
+  std::printf("test_funding_scheduler\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(1000));
+  led.deposit(2, QUOTE, quote(1000));
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);   // long 10 @ 100
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);  // short 10 @ 100
+
+  // Funding interval 8h (in ns here just a window); sample every "hour".
+  const int64_t interval = 8 * SEC;
+  FundingScheduler<MatchingEngine<MatchingBook>> sched(eng, interval);
+
+  // Perp trades at a persistent 0.5% premium over the index across the interval.
+  std::optional<double> settled;
+  for (int h = 0; h <= 8; ++h)
+  {
+    auto r = sched.onTick(h * SEC, /*mark*/ px(100.5), /*index*/ px(100.0));
+    if (r)
+    {
+      settled = r;
+    }
+  }
+
+  CHECK(sched.settlements() == 1);
+  CHECK(settled.has_value());
+  CHECK(*settled > 0.0);  // positive premium -> positive funding -> longs pay
+
+  // Long (acct1) paid, short (acct2) received; pool nets zero.
+  CHECK(led.available(1, QUOTE) < quote(900));  // < 900 (margin 100 reserved + paid funding)
+  CHECK(led.available(2, QUOTE) > quote(900));
+  CHECK(led.total(VENUE, QUOTE) == 0);
+
+  // A second interval with mark == index settles ~the interest floor, and the
+  // accumulator reset means the prior 0.5% premium does not carry over.
+  for (int h = 9; h <= 16; ++h)
+  {
+    sched.onTick(h * SEC, px(100.0), px(100.0));
+  }
+  CHECK(sched.settlements() == 2);
+  CHECK(sched.lastRate() < *settled);  // second rate near the floor, below the first
+}
+
+}  // namespace
+
+TEST(FundingScheduler, EngineSuite)
+{
+  test_scheduler();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_gateway.cpp
+++ b/venue/tests/test_venue_gateway.cpp
@@ -1,0 +1,296 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/fix_codec.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/ouch_codec.h"
+#include "flox-venue/rest_json.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+std::string fixJoin(std::initializer_list<std::pair<int, std::string>> fields)
+{
+  std::string s;
+  for (const auto& [t, v] : fields)
+  {
+    s += std::to_string(t) + "=" + v + FixCodec::SOH;
+  }
+  return s;
+}
+
+void test_ouch_roundtrip()
+{
+  std::printf("test_ouch_roundtrip\n");
+  NewOrder o;
+  o.id = 42;
+  o.symbol = SYM;
+  o.side = Side::SELL;
+  o.type = OrderType::STOP_LIMIT;
+  o.price = px(101.25);
+  o.quantity = qty(9);
+  o.tif = TimeInForce::IOC;
+  o.postOnly = true;
+  o.stp = STPMode::CancelBoth;
+  o.visibleQuantity = qty(2);
+  o.triggerPrice = px(105.5);
+  o.trailingOffset = px(0.5);
+  o.accountId = 77;
+  o.clientOrderId = 12345;
+  o.reduceOnly = true;
+  o.lastLook = true;
+  o.peg = PegRef::Mid;
+  o.expiryNs = 1'700'000'000'000;
+  o.ocoGroup = 99;
+  o.pegOffsetRaw = -250;
+
+  std::vector<uint8_t> buf;
+  OuchCodec::encode(InboundCommand{o}, buf);
+  auto back = OuchCodec::decode(buf.data(), buf.size());
+  CHECK(back.has_value());
+  const auto* n = std::get_if<NewOrder>(&*back);
+  CHECK(n != nullptr);
+  CHECK(n->id == 42 && n->symbol == SYM && n->side == Side::SELL);
+  CHECK(n->type == OrderType::STOP_LIMIT && n->tif == TimeInForce::IOC && n->postOnly);
+  CHECK(n->stp == STPMode::CancelBoth);
+  CHECK(n->price == px(101.25) && n->quantity == qty(9) && n->visibleQuantity == qty(2));
+  CHECK(n->triggerPrice == px(105.5) && n->trailingOffset == px(0.5));
+  CHECK(n->accountId == 77 && n->clientOrderId == 12345);
+  // Derivatives / MM / advanced-order fields survive the wire round-trip.
+  CHECK(n->reduceOnly && n->lastLook && n->peg == PegRef::Mid);
+  CHECK(n->expiryNs == 1'700'000'000'000 && n->ocoGroup == 99 && n->pegOffsetRaw == -250);
+
+  OuchCodec::encode(InboundCommand{CancelOrder{42, SYM, 77}}, buf);
+  auto bc = OuchCodec::decode(buf.data(), buf.size());
+  CHECK(bc && std::get_if<CancelOrder>(&*bc) && std::get<CancelOrder>(*bc).id == 42);
+
+  OuchCodec::encode(InboundCommand{ModifyOrder{42, SYM, px(102), qty(4), 77}}, buf);
+  auto bm = OuchCodec::decode(buf.data(), buf.size());
+  CHECK(bm && std::get_if<ModifyOrder>(&*bm));
+  CHECK(std::get<ModifyOrder>(*bm).newPrice == px(102) && std::get<ModifyOrder>(*bm).newQty == qty(4));
+}
+
+void test_fix_parse()
+{
+  std::printf("test_fix_parse\n");
+  const std::string d = fixJoin({{35, "D"}, {11, "7"}, {55, "1"}, {54, "1"}, {40, "2"}, {38, "5"}, {44, "100"}, {59, "3"}, {1, "3"}});
+  auto cd = FixCodec::decode(d);
+  CHECK(cd && std::get_if<NewOrder>(&*cd));
+  const auto& n = std::get<NewOrder>(*cd);
+  CHECK(n.id == 7 && n.symbol == 1 && n.side == Side::BUY);
+  CHECK(n.type == OrderType::LIMIT && n.tif == TimeInForce::IOC);
+  CHECK(n.quantity == qty(5) && n.price == px(100) && n.accountId == 3);
+
+  const std::string fcancel = fixJoin({{35, "F"}, {41, "7"}, {55, "1"}, {1, "3"}});
+  auto cc = FixCodec::decode(fcancel);
+  CHECK(cc && std::get_if<CancelOrder>(&*cc) && std::get<CancelOrder>(*cc).id == 7);
+
+  const std::string g = fixJoin({{35, "G"}, {41, "7"}, {55, "1"}, {44, "101"}, {38, "3"}, {1, "3"}});
+  auto cg = FixCodec::decode(g);
+  CHECK(cg && std::get_if<ModifyOrder>(&*cg));
+  CHECK(std::get<ModifyOrder>(*cg).newPrice == px(101) && std::get<ModifyOrder>(*cg).newQty == qty(3));
+
+  // CheckSum (tag 10) integrity: a correct checksum is accepted, a wrong one is
+  // rejected. Checksum = sum of bytes through the SOH before "10=", mod 256.
+  const std::string body = fixJoin({{35, "D"}, {11, "8"}, {55, "1"}, {54, "1"}, {38, "5"}, {44, "100"}});
+  unsigned sum = 0;
+  for (char ch : body)
+  {
+    sum += static_cast<unsigned char>(ch);
+  }
+  char cs[8];
+  std::snprintf(cs, sizeof cs, "%03u", sum % 256);
+  const std::string good = body + "10=" + cs + FixCodec::SOH;
+  CHECK(FixCodec::decode(good).has_value());  // valid checksum -> accepted
+  const std::string bad = body + "10=999" + FixCodec::SOH;
+  CHECK(!FixCodec::decode(bad).has_value() || std::string("999") == cs);  // wrong checksum -> rejected
+
+  // reduce-only via ExecInst=E (DoNotIncrease) must survive -- a derivatives
+  // reduce-only order that lost the flag would open a position.
+  const std::string ro = fixJoin({{35, "D"}, {11, "9"}, {55, "1"}, {54, "1"}, {38, "5"}, {44, "100"}, {18, "E"}});
+  auto cro = FixCodec::decode(ro);
+  CHECK(cro && std::get_if<NewOrder>(&*cro) && std::get<NewOrder>(*cro).reduceOnly);
+  // Without ExecInst=E, reduceOnly stays false.
+  auto cno = FixCodec::decode(fixJoin({{35, "D"}, {11, "9"}, {55, "1"}, {54, "1"}, {38, "5"}, {44, "100"}}));
+  CHECK(cno && !std::get<NewOrder>(*cno).reduceOnly);
+}
+
+void test_ouch_endtoend()
+{
+  std::printf("test_ouch_endtoend\n");
+  std::vector<uint8_t> reportTags;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     std::vector<uint8_t> b;
+                                     OuchCodec::encode(e, b);
+                                     if (!b.empty()){ reportTags.push_back(b[0]);
+} });
+
+  auto submitWire = [&](const InboundCommand& c)
+  {
+    std::vector<uint8_t> b;
+    OuchCodec::encode(c, b);
+    auto decoded = OuchCodec::decode(b.data(), b.size());
+    CHECK(decoded.has_value());
+    eng.submit(*decoded);
+  };
+
+  NewOrder s;
+  s.id = 1;
+  s.symbol = SYM;
+  s.side = Side::SELL;
+  s.type = OrderType::LIMIT;
+  s.price = px(100);
+  s.quantity = qty(5);
+  submitWire(InboundCommand{s});
+
+  NewOrder b;
+  b.id = 2;
+  b.symbol = SYM;
+  b.side = Side::BUY;
+  b.type = OrderType::LIMIT;
+  b.price = px(100);
+  b.quantity = qty(3);
+  b.accountId = 2;
+  submitWire(InboundCommand{b});
+
+  bool sawAccepted = false, sawTrade = false, sawExec = false;
+  for (uint8_t t : reportTags)
+  {
+    sawAccepted |= (t == static_cast<uint8_t>(OuchOut::Accepted));
+    sawTrade |= (t == static_cast<uint8_t>(OuchOut::Trade));
+    sawExec |= (t == static_cast<uint8_t>(OuchOut::Executed));
+  }
+  CHECK(sawAccepted && sawTrade && sawExec);
+}
+
+void test_fix_execreport()
+{
+  std::printf("test_fix_execreport\n");
+  OrderAccepted a{7, SYM, Side::BUY, px(100), qty(5), true};
+  const std::string er = FixCodec::encode(OutboundEvent{a});
+  CHECK(er.rfind("8=FIX.4.4", 0) == 0);  // starts with BeginString
+  CHECK(er.find("\x01"
+                "35=8\x01") != std::string::npos);  // ExecutionReport
+  CHECK(er.find("\x01"
+                "39=0\x01") != std::string::npos);  // OrdStatus New
+  CHECK(er.find("\x01"
+                "10=") != std::string::npos);  // CheckSum present
+
+  // A fill report carries the fill price (LastPx 31 + AvgPx 6) -- a client must
+  // be able to see at what price it traded, not just how much.
+  OrderExecuted x{};
+  x.id = 7;
+  x.symbol = SYM;
+  x.lastQty = qty(3);
+  x.leavesQty = qty(2);
+  x.lastPx = px(100.5);
+  const std::string fr = FixCodec::encode(OutboundEvent{x});
+  CHECK(fr.find("\x01"
+                "150=F\x01") != std::string::npos);  // ExecType Trade
+  CHECK(fr.find("\x01"
+                "31=") != std::string::npos);  // LastPx present
+  CHECK(fr.find("\x01"
+                "6=") != std::string::npos);  // AvgPx present
+}
+
+void test_rest_json()
+{
+  std::printf("test_rest_json\n");
+  auto cd = RestJson::decode(
+      R"({"action":"new","id":7,"symbol":1,"side":"buy","ordType":"limit","qty":5,"price":100.25,"tif":"ioc","postOnly":true})");
+  CHECK(cd && std::get_if<NewOrder>(&*cd));
+  const auto& n = std::get<NewOrder>(*cd);
+  CHECK(n.id == 7 && n.symbol == 1 && n.side == Side::BUY && n.type == OrderType::LIMIT);
+  CHECK(n.quantity == qty(5) && n.price == px(100.25) && n.tif == TimeInForce::IOC && n.postOnly);
+  CHECK(!n.reduceOnly);  // not requested -> false
+
+  // reduceOnly must be honored for derivatives (else the order would open).
+  auto crd = RestJson::decode(
+      R"({"action":"new","id":8,"symbol":1,"side":"sell","ordType":"limit","qty":5,"price":100,"reduceOnly":true})");
+  CHECK(crd && std::get<NewOrder>(*crd).reduceOnly);
+
+  // self-trade-prevention mode carried over REST.
+  auto cst = RestJson::decode(
+      R"({"action":"new","id":9,"symbol":1,"side":"buy","ordType":"limit","qty":5,"price":100,"stp":"cancelOldest"})");
+  CHECK(cst && std::get<NewOrder>(*cst).stp == STPMode::CancelOldest);
+
+  auto cc = RestJson::decode(R"({"action":"cancel","id":7,"symbol":1,"account":3})");
+  CHECK(cc && std::get_if<CancelOrder>(&*cc) && std::get<CancelOrder>(*cc).id == 7);
+
+  auto cm = RestJson::decode(R"({"action":"modify","id":7,"symbol":1,"price":101,"qty":3})");
+  CHECK(cm && std::get_if<ModifyOrder>(&*cm) && std::get<ModifyOrder>(*cm).newQty == qty(3));
+
+  // end-to-end: JSON orders -> engine -> JSON events
+  std::vector<std::string> out;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { out.push_back(RestJson::encode(e)); });
+  eng.submit(*RestJson::decode(
+      R"({"action":"new","id":1,"symbol":1,"side":"sell","ordType":"limit","qty":5,"price":100})"));
+  eng.submit(*RestJson::decode(
+      R"({"action":"new","id":2,"symbol":1,"side":"buy","ordType":"limit","qty":3,"price":100,"account":2})"));
+  bool sawTrade = false;
+  for (const auto& j : out)
+  {
+    if (j.find("\"type\":\"trade\"") != std::string::npos)
+    {
+      sawTrade = true;
+    }
+  }
+  CHECK(sawTrade);
+}
+
+}  // namespace
+
+TEST(Gateway, EngineSuite)
+{
+  test_ouch_roundtrip();
+  test_fix_parse();
+  test_ouch_endtoend();
+  test_fix_execreport();
+  test_rest_json();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_gauge_sampler.cpp
+++ b/venue/tests/test_venue_gauge_sampler.cpp
@@ -1,0 +1,122 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/cross_margin.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/prometheus.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+bool contains(const std::string& h, const std::string& n) { return h.find(n) != std::string::npos; }
+
+constexpr AssetId USD = 1;
+constexpr uint64_t VENUE = 999;
+constexpr SymbolId SPOT_SYM = 5;
+constexpr AssetId SPOT_BASE = 2;
+constexpr SymbolId PERP = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount usd(double v) { return amountOf(Volume::fromDouble(v)); }
+
+// Sample live venue state into the observability Gauges struct.
+Gauges sampleGauges(const Ledger& led, const CrossMarginManager& cm,
+                    const MatchingEngine<MatchingBook>& spot, double lastFundingRate)
+{
+  Gauges g;
+  g.insuranceFundRaw = led.total(VENUE, USD);
+  g.openInterestRaw = cm.openInterestRaw();
+  g.openPositions = cm.openPositionCount();
+  g.restingOrders = spot.restingOrderCount();
+  g.fundingRate = lastFundingRate;
+  return g;
+}
+
+void test_sampler()
+{
+  std::printf("test_gauge_sampler\n");
+  Ledger led;
+  led.deposit(VENUE, USD, usd(100000));  // seed insurance fund
+  led.deposit(1, USD, usd(100000));
+  led.deposit(2, USD, usd(100000));
+  led.deposit(1, SPOT_BASE, amountOf(qty(1000)));
+
+  // Cross-margin perp positions -> open interest.
+  CrossMarginManager cm(led, USD, VENUE);
+  cm.configureSymbol(PERP, 1000, 500);
+  cm.setMark(PERP, px(100));
+  cm.applyFill(1, PERP, Side::BUY, qty(30).raw(), px(100).raw());
+  cm.applyFill(2, PERP, Side::SELL, qty(30).raw(), px(100).raw());
+  CHECK(cm.openPositionCount() == 2);
+  CHECK(cm.openInterestRaw() == usd(6000));  // 2 * 30 * 100
+
+  // A spot engine with two resting orders.
+  SymbolConfig sc;
+  sc.id = SPOT_SYM;
+  sc.tickSize = px(0.01);
+  sc.baseAsset = SPOT_BASE;
+  sc.quoteAsset = USD;
+  MatchingEngine<MatchingBook> spot(sc, [](const OutboundEvent&) {});
+  spot.setLedger(&led, VENUE);
+  NewOrder a;
+  a.id = 1;
+  a.symbol = SPOT_SYM;
+  a.side = Side::SELL;
+  a.type = OrderType::LIMIT;
+  a.price = px(101);
+  a.quantity = qty(3);
+  a.accountId = 1;
+  spot.submit(InboundCommand{a}, 0);
+  NewOrder b = a;
+  b.id = 2;
+  b.price = px(102);
+  spot.submit(InboundCommand{b}, 1);
+  CHECK(spot.restingOrderCount() == 2);
+
+  const Gauges g = sampleGauges(led, cm, spot, /*fundingRate*/ 0.00013);
+  Metrics metrics;
+  const std::string page = prom::render(metrics, g);
+
+  CHECK(contains(page, "fme_insurance_fund_raw 10000000000000"));  // 100000 * 1e8
+  CHECK(contains(page, "fme_open_interest_raw 600000000000"));     // 6000 * 1e8
+  CHECK(contains(page, "fme_open_positions 2"));
+  CHECK(contains(page, "fme_resting_orders 2"));
+  CHECK(contains(page, "fme_funding_rate"));
+}
+
+}  // namespace
+
+TEST(GaugeSampler, EngineSuite)
+{
+  test_sampler();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_ha.cpp
+++ b/venue/tests/test_venue_ha.cpp
@@ -1,0 +1,170 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/workload.h"
+#include "flox/book/ladder_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+LadderBook::Config lc() { return LadderBook::Config{0, px(0.01).raw(), 16000, 1 << 20}; }
+
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 1000;
+constexpr int NACCT = 64;  // matches the workload's account spread
+
+// Ledger-backed engine: settlement runs, so replicas must reconstruct not just
+// the event stream but the exact per-account balances.
+struct HashEng
+{
+  uint64_t h = 1469598103934665603ULL;
+  Ledger led;
+  MatchingEngine<LadderBook> eng;
+  explicit HashEng()
+      : eng(cfg(), [this](const OutboundEvent& e)
+            { h = hashEvent(h, e); }, LadderBook{lc()})
+  {
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      led.deposit(a, BASE, amountOf(Quantity::fromDouble(10000)));
+      led.deposit(a, QUOTE, amountOf(Volume::fromDouble(1000000)));
+    }
+    eng.setLedger(&led, VENUE);
+  }
+  void submit(const InboundCommand& c) { eng.submit(c); }
+};
+
+// Every balance (per account + venue, base + quote, available + reserved) equal.
+bool ledgersEqual(const Ledger& a, const Ledger& b)
+{
+  for (int acct = 1; acct <= NACCT; ++acct)
+  {
+    if (a.available(acct, BASE) != b.available(acct, BASE))
+    {
+      return false;
+    }
+    if (a.reserved(acct, BASE) != b.reserved(acct, BASE))
+    {
+      return false;
+    }
+    if (a.available(acct, QUOTE) != b.available(acct, QUOTE))
+    {
+      return false;
+    }
+    if (a.reserved(acct, QUOTE) != b.reserved(acct, QUOTE))
+    {
+      return false;
+    }
+  }
+  return a.total(VENUE, BASE) == b.total(VENUE, BASE) &&
+         a.total(VENUE, QUOTE) == b.total(VENUE, QUOTE);
+}
+
+}  // namespace
+
+TEST(Ha, EngineSuite)
+{
+  workload::Params p;
+  p.symbol = SYM;
+  p.count = 200'000;
+  const auto cmds = workload::symmetricLimits(p);
+
+  const std::string path = "/tmp/flox_test_venue_ha_ha_journal.bin";
+
+  // 1 + 2: live replication -- primary and standby fed the same stream.
+  HashEng primary, standby;
+  {
+    Journal journal(path);
+    for (const auto& c : cmds)
+    {
+      journal.append(c);  // WAL on the primary ingress
+      primary.submit(c);
+      standby.submit(c);  // replicated ingress
+    }
+    journal.flush();
+  }
+  CHECK(primary.h == standby.h);  // identical event streams
+  CHECK(primary.eng.book().bestBid() == standby.eng.book().bestBid());
+  CHECK(primary.eng.book().bestAsk() == standby.eng.book().bestAsk());
+  CHECK(ledgersEqual(primary.led, standby.led));  // standby balances match primary exactly
+
+  // 3: journal recovery -- a fresh replica rebuilt from the WAL.
+  const auto replayed = Journal::load(path);
+  CHECK(replayed.size() == cmds.size());
+  HashEng recovered;
+  for (const auto& c : replayed)
+  {
+    recovered.submit(c);
+  }
+  CHECK(recovered.h == primary.h);
+  CHECK(ledgersEqual(recovered.led, primary.led));  // WAL-recovered balances match too
+
+  // 4: mid-stream failover at command K. Standby took over having applied 0..K,
+  // then receives K..N; a primary that saw 0..N must match.
+  const size_t K = cmds.size() / 2;
+  HashEng full;  // sees everything 0..N
+  for (const auto& c : cmds)
+  {
+    full.submit(c);
+  }
+  HashEng failover;  // "standby": also sees 0..N (took over cleanly at K)
+  for (size_t i = 0; i < cmds.size(); ++i)
+  {
+    if (i == K)
+    {
+      // failover point: no state transfer needed -- deterministic replay guarantees
+      // the standby already equals the primary here.
+    }
+    failover.submit(cmds[i]);
+  }
+  CHECK(full.h == failover.h);
+  CHECK(full.eng.book().bestBid() == failover.eng.book().bestBid());
+  CHECK(ledgersEqual(full.led, failover.led));  // post-failover balances match
+
+  std::printf("HA: replication + recovery + failover over %zu commands\n", cmds.size());
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_ledger.cpp
+++ b/venue/tests/test_venue_ledger.cpp
@@ -1,0 +1,377 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include "flox/backtest/fee_schedule.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;   // BTC
+constexpr AssetId QUOTE = 1;  // USD
+constexpr uint64_t VENUE = 999;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount base(double v) { return amountOf(qty(v)); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+void test_settlement()
+{
+  std::printf("test_settlement\n");
+  Ledger led;
+  led.deposit(1, BASE, base(10));       // seller holds 10 base
+  led.deposit(2, QUOTE, quote(10000));  // buyer holds 10000 quote
+
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5, 1)}, 0);  // reserve 5 base
+  CHECK(led.available(1, BASE) == base(5));
+  CHECK(led.reserved(1, BASE) == base(5));
+
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // trade 3 @100 = 300 quote
+
+  // Buyer: paid 300 quote, received 3 base.
+  CHECK(led.available(2, BASE) == base(3));
+  CHECK(led.available(2, QUOTE) == quote(9700));
+  CHECK(led.reserved(2, QUOTE) == 0);
+  // Seller: delivered 3 base, received 300 quote; 2 base still reserved on the rest.
+  CHECK(led.available(1, QUOTE) == quote(300));
+  CHECK(led.reserved(1, BASE) == base(2));
+  CHECK(led.total(1, BASE) == base(7));  // sold 3 of 10
+
+  // Conservation: base and quote totals unchanged.
+  CHECK(led.total(1, BASE) + led.total(2, BASE) == base(10));
+  CHECK(led.total(1, QUOTE) + led.total(2, QUOTE) == quote(10000));
+
+  // Cancel the seller remainder -> 2 base released.
+  eng.submit(InboundCommand{CancelOrder{1, SYM, 1}}, 2);
+  CHECK(led.available(1, BASE) == base(7));
+  CHECK(led.reserved(1, BASE) == 0);
+}
+
+void test_insufficient()
+{
+  std::printf("test_insufficient\n");
+  Ledger led;
+  led.deposit(2, QUOTE, quote(100));  // only 100 quote
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 0);  // needs 300 quote
+  bool rejected = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e); r && r->reason == RejectReason::InsufficientFunds)
+    {
+      rejected = true;
+    }
+  }
+  CHECK(rejected);
+  CHECK(led.available(2, QUOTE) == quote(100));  // nothing reserved
+}
+
+// A modify must re-check buying power: repricing up beyond funds is rejected,
+// and shrinking frees the released reservation back to available.
+void test_modify_reservation()
+{
+  std::printf("test_modify_reservation\n");
+  Ledger led;
+  led.deposit(2, QUOTE, quote(1000));  // funds a 10-lot bid at 100 (=1000)
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  eng.submit(InboundCommand{limit(1, Side::BUY, 100, 10, 2)}, 0);  // reserves 1000
+  CHECK(led.available(2, QUOTE) == 0 && led.reserved(2, QUOTE) == quote(1000));
+
+  // Shrink to 4 lots: reservation drops to 400, 600 returns to available.
+  eng.submit(InboundCommand{ModifyOrder{1, SYM, px(100), qty(4), 2}}, 1);
+  CHECK(led.reserved(2, QUOTE) == quote(400));
+  CHECK(led.available(2, QUOTE) == quote(600));
+
+  // Reprice up to 100 @ 200 = 20000 needed, but only 1000 total -> rejected.
+  ev.clear();
+  eng.submit(InboundCommand{ModifyOrder{1, SYM, px(200), qty(100), 2}}, 2);
+  bool rejected = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e); r && r->reason == RejectReason::InsufficientFunds)
+    {
+      rejected = true;
+    }
+  }
+  CHECK(rejected);
+  // Value conserved throughout (avail + reserved unchanged total).
+  CHECK(led.available(2, QUOTE) + led.reserved(2, QUOTE) == quote(1000));
+}
+
+// Iceberg + modify-shrink: an iceberg's `leaves` is only the displayed peak,
+// but reserveFunds reserves the FULL quantity. The same-price in-place shrink
+// path must NOT proportionally release against the peak (it would over-release
+// buying power) nor leave the hidden reserve resting. Icebergs re-enter, so a
+// shrink to N leaves exactly N resting and reserves exactly N * price.
+void test_iceberg_modify_shrink()
+{
+  std::printf("test_iceberg_modify_shrink\n");
+  Ledger led;
+  led.deposit(2, QUOTE, quote(1000));  // funds a 10-lot bid at 100
+  led.deposit(1, BASE, base(10));      // a seller to fill against later
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+
+  NewOrder ice = limit(1, Side::BUY, 100, 10, 2);
+  ice.visibleQuantity = qty(2);  // show 2, hide 8; reserves the full 10 * 100
+  eng.submit(InboundCommand{ice}, 0);
+  CHECK(led.available(2, QUOTE) == 0 && led.reserved(2, QUOTE) == quote(1000));
+
+  // Shrink to 1 lot. Buggy path freed 1000*(2-1)/2 = 500 (peak-relative) and left
+  // 9 lots resting. Correct: full release + re-reserve 1 * 100 = 100.
+  eng.submit(InboundCommand{ModifyOrder{1, SYM, px(100), qty(1), 2}}, 1);
+  CHECK(led.reserved(2, QUOTE) == quote(100));
+  CHECK(led.available(2, QUOTE) == quote(900));
+  CHECK(led.available(2, QUOTE) + led.reserved(2, QUOTE) == quote(1000));
+
+  // True remaining is 1, not 9: a seller dumping 10 @ 100 fills exactly 1.
+  eng.submit(InboundCommand{limit(2, Side::SELL, 100, 10, 1)}, 2);
+  CHECK(led.available(2, BASE) == base(1));      // bought exactly 1
+  CHECK(led.reserved(2, QUOTE) == 0);            // reservation fully consumed/released
+  CHECK(led.available(2, QUOTE) == quote(900));  // paid exactly 100
+  // Conservation: no quote or base created.
+  CHECK(led.total(1, QUOTE) + led.total(2, QUOTE) == quote(1000));
+  CHECK(led.total(1, BASE) + led.total(2, BASE) == base(10));
+}
+
+// An IOC buy that partially fills must release the reservation for its UNFILLED
+// residual -- otherwise buying power leaks (stuck in `reserved` forever).
+void test_ioc_residual_release()
+{
+  std::printf("test_ioc_residual_release\n");
+  Ledger led;
+  led.deposit(1, BASE, base(3));       // seller: 3 base
+  led.deposit(2, QUOTE, quote(1000));  // buyer: 1000 quote
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 3, 1)}, 0);  // rests 3 @ 100
+  NewOrder b = limit(2, Side::BUY, 100, 10, 2);
+  b.tif = TimeInForce::IOC;
+  eng.submit(InboundCommand{b}, 1);  // reserves 1000, fills 3 (=300), residual 7 canceled
+
+  // 300 spent on the fill; the 700 residual reservation must be back in available.
+  CHECK(led.reserved(2, QUOTE) == 0);            // no leak
+  CHECK(led.available(2, QUOTE) == quote(700));  // 1000 - 300 settled
+}
+
+// A triggered stop settles via the unreserved-debit path. If the taker can't
+// afford the fill, value must NOT be created (buyer must not receive base it
+// didn't pay for). Conservation must hold even for underfunded triggered stops.
+void test_stop_underfunded()
+{
+  std::printf("test_stop_underfunded\n");
+  Ledger led;
+  led.deposit(1, BASE, base(100));       // seller: plenty of base
+  led.deposit(3, QUOTE, quote(50));      // stop buyer: only 50 quote (can't afford 10@100=1000)
+  led.deposit(9, QUOTE, quote(100000));  // a funded taker to set the last price
+  led.deposit(9, BASE, base(100));
+  const Amount initBase = led.total(1, BASE) + led.total(3, BASE) + led.total(9, BASE) + led.total(VENUE, BASE);
+  const Amount initQuote =
+      led.total(1, QUOTE) + led.total(3, QUOTE) + led.total(9, QUOTE) + led.total(VENUE, QUOTE);
+
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 100, 1)}, 0);  // resting sell 100 @ 100
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 1, 9)}, 1);     // funded buy 1 -> last = 100
+
+  // Underfunded stop-market buy, trigger 99 (last=100 >= 99 -> fires immediately).
+  NewOrder st;
+  st.id = 3;
+  st.symbol = SYM;
+  st.side = Side::BUY;
+  st.type = OrderType::STOP_MARKET;
+  st.triggerPrice = px(99);
+  st.quantity = qty(10);
+  st.accountId = 3;
+  eng.submit(InboundCommand{st}, 2);
+
+  // Whatever filled, value is conserved: the buyer never receives base it didn't
+  // pay for (no money created), across all accounts + venue.
+  const Amount endBase = led.total(1, BASE) + led.total(3, BASE) + led.total(9, BASE) + led.total(VENUE, BASE);
+  const Amount endQuote =
+      led.total(1, QUOTE) + led.total(3, QUOTE) + led.total(9, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(endBase == initBase);
+  CHECK(endQuote == initQuote);
+  CHECK(led.available(3, QUOTE) >= 0);  // buyer never goes negative
+}
+
+void test_fees_to_venue()
+{
+  std::printf("test_fees_to_venue\n");
+  Ledger led;
+  led.deposit(1, BASE, base(10));
+  led.deposit(2, QUOTE, quote(10000));
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+  flox::FeeSchedule fs;
+  fs.addTier(0.0, /*makerBps*/ 1.0, /*takerBps*/ 2.0);  // both pay
+  eng.setFeeSchedule(fs);
+
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 3, 1)}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // notional 300
+
+  // maker fee 300*1bp=0.03, taker fee 300*2bp=0.06 -> venue gets 0.09 quote.
+  CHECK(led.available(VENUE, QUOTE) == quote(0.09));
+  // Value conserved across participants + venue.
+  const Amount totalQuote =
+      led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(totalQuote == quote(10000));
+}
+
+// Fee policy: the buying-power gate reserves the NOTIONAL; the taker fee is
+// charged post-settlement. A taker funded to exactly the notional therefore
+// ends in a fee-sized deficit (which blocks further trading until topped up),
+// rather than being pre-rejected -- a standard post-fill-fee model. The hard
+// invariants that MUST hold: value is conserved, the venue receives the fee,
+// and any deficit is bounded by the fee (never an unbounded overdraw).
+void test_taker_fee_policy()
+{
+  std::printf("test_taker_fee_policy\n");
+  Ledger led;
+  led.deposit(1, BASE, base(3));
+  led.deposit(2, QUOTE, quote(300));  // buyer: EXACTLY the 3@100 notional, nothing spare
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+  flox::FeeSchedule fs;
+  fs.addTier(0.0, /*maker*/ 0.0, /*taker*/ 2.0);  // 2bp taker fee = 0.06 on 300
+  eng.setFeeSchedule(fs);
+
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 3, 1)}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+
+  const Amount fee = quote(0.06);
+  CHECK(led.total(VENUE, QUOTE) == fee);   // venue captured the taker fee
+  CHECK(led.available(2, QUOTE) == -fee);  // deficit bounded by the fee, not unbounded
+  // Conservation across buyer + seller + venue (base and quote).
+  CHECK(led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE) == quote(300));
+  CHECK(led.total(1, BASE) + led.total(2, BASE) == base(3));
+}
+
+// Opening-auction settlement with a ledger: orders reserve during pre-open,
+// then the uncross settles through the same ledger. Value must be conserved and
+// no reservation may leak after the book is drained.
+void test_auction_settlement()
+{
+  std::printf("test_auction_settlement\n");
+  Ledger led;
+  led.deposit(1, BASE, base(100));
+  led.deposit(2, QUOTE, quote(100000));
+  led.deposit(3, QUOTE, quote(100000));
+  const Amount initBase = led.total(1, BASE) + led.total(2, BASE) + led.total(3, BASE) + led.total(VENUE, BASE);
+  const Amount initQuote =
+      led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(3, QUOTE) + led.total(VENUE, QUOTE);
+
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+  eng.beginPreOpen();
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 10, 1)}, 0);  // accumulate (reserve base)
+  eng.submit(InboundCommand{limit(2, Side::BUY, 101, 6, 2)}, 1);    // crosses, but only accumulates
+  eng.submit(InboundCommand{limit(3, Side::BUY, 100, 8, 3)}, 2);
+  eng.openContinuous();  // uncross at the single price -> settles through the ledger
+
+  // Value conserved across all participants + venue after the uncross.
+  const Amount endBase = led.total(1, BASE) + led.total(2, BASE) + led.total(3, BASE) + led.total(VENUE, BASE);
+  const Amount endQuote =
+      led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(3, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(endBase == initBase);
+  CHECK(endQuote == initQuote);
+
+  // Drain the book; no reservation may leak.
+  for (OrderId id = 1; id <= 3; ++id)
+  {
+    eng.submit(InboundCommand{CancelOrder{id, SYM, 0}}, 3);
+  }
+  int leaks = 0;
+  for (uint64_t a = 1; a <= 3; ++a)
+  {
+    if (led.reserved(a, BASE) != 0 || led.reserved(a, QUOTE) != 0)
+    {
+      ++leaks;
+    }
+  }
+  CHECK(leaks == 0);
+}
+
+}  // namespace
+
+TEST(VenueLedger, EngineSuite)
+{
+  test_settlement();
+  test_taker_fee_policy();
+  test_auction_settlement();
+  test_insufficient();
+  test_modify_reservation();
+  test_iceberg_modify_shrink();
+  test_ioc_residual_release();
+  test_stop_underfunded();
+  test_fees_to_venue();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_ledger_primitive.cpp
+++ b/venue/tests/test_venue_ledger_primitive.cpp
@@ -1,0 +1,102 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox-venue/ledger.h"
+
+#include <gtest/gtest.h>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+constexpr AssetId USD = 1;
+constexpr AssetId BTC = 0;
+Amount amt(double v) { return amountOf(Volume::fromDouble(v)); }
+// __int128 is not gtest-printable; compare the low 64 bits (test values fit).
+int64_t i64(Amount a) { return static_cast<int64_t>(a); }
+}  // namespace
+
+TEST(Ledger, ReserveReleaseConservesTotal)
+{
+  Ledger l;
+  l.deposit(1, USD, amt(1000));
+  EXPECT_EQ(i64(l.available(1, USD)), i64(amt(1000)));
+
+  EXPECT_TRUE(l.reserve(1, USD, amt(400)));
+  EXPECT_EQ(i64(l.available(1, USD)), i64(amt(600)));
+  EXPECT_EQ(i64(l.reserved(1, USD)), i64(amt(400)));
+  EXPECT_EQ(i64(l.total(1, USD)), i64(amt(1000)));  // avail+rsvd conserved
+
+  EXPECT_FALSE(l.reserve(1, USD, amt(700)));  // insufficient available -> no change
+  EXPECT_EQ(i64(l.available(1, USD)), i64(amt(600)));
+
+  l.release(1, USD, amt(400));
+  EXPECT_EQ(i64(l.reserved(1, USD)), 0);
+  EXPECT_EQ(i64(l.available(1, USD)), i64(amt(1000)));
+}
+
+TEST(Ledger, FillSettlementConservesAcrossAccounts)
+{
+  Ledger l;
+  l.deposit(2, USD, amt(300));  // buyer: 300 USD
+  l.deposit(1, BTC, amt(5));    // seller: 5 BTC
+
+  // Pre-trade reservations for a 3 BTC @ 100 fill.
+  ASSERT_TRUE(l.reserve(2, USD, amt(300)));
+  ASSERT_TRUE(l.reserve(1, BTC, amt(3)));
+  const Amount initUsd = l.total(2, USD) + l.total(1, USD);
+  const Amount initBtc = l.total(2, BTC) + l.total(1, BTC);
+
+  // Settle: buyer pays 300 USD from reserved, seller delivers 3 BTC from reserved.
+  l.spendReserved(2, USD, amt(300));
+  l.credit(1, USD, amt(300));
+  l.spendReserved(1, BTC, amt(3));
+  l.credit(2, BTC, amt(3));
+
+  // Conservation across both accounts, per asset.
+  EXPECT_EQ(i64(l.total(2, USD) + l.total(1, USD)), i64(initUsd));
+  EXPECT_EQ(i64(l.total(2, BTC) + l.total(1, BTC)), i64(initBtc));
+  // Buyer received base, seller received quote.
+  EXPECT_EQ(i64(l.available(2, BTC)), i64(amt(3)));
+  EXPECT_EQ(i64(l.available(1, USD)), i64(amt(300)));
+  EXPECT_EQ(i64(l.reserved(2, USD)), 0);
+  EXPECT_EQ(i64(l.reserved(1, BTC)), 0);             // all 3 reserved BTC delivered
+  EXPECT_EQ(i64(l.available(1, BTC)), i64(amt(2)));  // 2 never-reserved BTC untouched
+}
+
+TEST(Ledger, DebitIsAllOrNothing)
+{
+  Ledger l;
+  l.deposit(1, USD, amt(100));
+  EXPECT_FALSE(l.debit(1, USD, amt(150)));  // insufficient -> no-op
+  EXPECT_EQ(i64(l.available(1, USD)), i64(amt(100)));
+  EXPECT_TRUE(l.debit(1, USD, amt(40)));
+  EXPECT_EQ(i64(l.available(1, USD)), i64(amt(60)));
+}
+
+TEST(Ledger, ForEachBalanceEnumeratesTotals)
+{
+  Ledger l;
+  l.deposit(7, USD, amt(500));
+  l.reserve(7, USD, amt(200));  // 300 avail + 200 rsvd = 500 total
+  Amount seen = 0;
+  bool found = false;
+  l.forEachBalance(
+      [&](uint64_t acct, AssetId asset, Amount tot)
+      {
+        if (acct == 7 && asset == USD)
+        {
+          found = true;
+          seen = tot;
+        }
+      });
+  EXPECT_TRUE(found);
+  EXPECT_EQ(i64(seen), i64(amt(500)));  // total = avail + reserved
+}

--- a/venue/tests/test_venue_luld.cpp
+++ b/venue/tests/test_venue_luld.cpp
@@ -1,0 +1,147 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  c.luldBps = 500;      // +/- 5%
+  c.luldHaltNs = 1000;  // 1000 ns pause
+  return c;
+}
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+struct Cap
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+  int trades() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<Trade>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  int rejects(RejectReason r) const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<OrderRejected>(&e); x && x->reason == r)
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+};
+
+}  // namespace
+
+TEST(Luld, EngineSuite)
+{
+  std::printf("test_luld\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5, 1)}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // trade @100 -> last=100, band [95,105]
+  CHECK(cap.trades() == 1);
+
+  eng.submit(InboundCommand{limit(3, Side::BUY, 110, 1, 2)}, 2);  // 110 > 105 -> breach
+  CHECK(cap.rejects(RejectReason::LuldBreach) == 1);
+
+  eng.submit(InboundCommand{limit(4, Side::BUY, 100, 1, 2)}, 5);  // still in the pause
+  CHECK(cap.rejects(RejectReason::Halted) == 1);
+
+  eng.submit(InboundCommand{limit(5, Side::BUY, 100, 1, 2)}, 2000);  // pause elapsed -> resumes
+  CHECK(cap.trades() == 2);                                          // trades against the resting ask @100
+
+  // High-priced instrument + wide band: last raw = 1e7 * 1e8 = 1e15, luldBps 9999.
+  // The old `lastPrice_.raw() * luldBps` (int64) = 1e15 * 9999 ~ 1e19 overflows
+  // INT64_MAX (~9.2e18) -> signed-overflow UB and a garbage band. The 128-bit
+  // computation must yield a correct band: [1000, ~1.9999e7].
+  {
+    Cap hc;
+    SymbolConfig c;
+    c.id = SYM;
+    c.tickSize = px(0.01);
+    c.minPrice = px(1.0);
+    c.maxPrice = px(5e7);
+    c.luldBps = 9999;  // +/- 99.99%
+    c.luldHaltNs = 1000;
+    MatchingEngine<MatchingBook> heng(c, hc.sink());
+    heng.submit(InboundCommand{limit(1, Side::SELL, 1e7, 5, 1)}, 0);
+    heng.submit(InboundCommand{limit(2, Side::BUY, 1e7, 3, 2)}, 1);  // trade @1e7 -> last=1e7
+    CHECK(hc.trades() == 1);
+    // Within the band (upper ~1.9999e7): must NOT breach.
+    heng.submit(InboundCommand{limit(3, Side::BUY, 1.5e7, 1, 2)}, 2);
+    CHECK(hc.rejects(RejectReason::LuldBreach) == 0);
+    // Above the band but below maxPrice: must breach (proves band is correct,
+    // not a garbage value from the overflow).
+    heng.submit(InboundCommand{limit(4, Side::BUY, 3e7, 1, 2)}, 3);
+    CHECK(hc.rejects(RejectReason::LuldBreach) == 1);
+  }
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_mark_feed_driver.cpp
+++ b/venue/tests/test_venue_mark_feed_driver.cpp
@@ -1,0 +1,103 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/cross_margin.h"
+#include "flox-venue/index_feed.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/mark_feed_driver.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr AssetId USD = 1;
+constexpr uint64_t VENUE = 999;
+constexpr SymbolId BTC = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount usd(double v) { return amountOf(Volume::fromDouble(v)); }
+constexpr int64_t SEC = 1'000'000'000LL;
+
+void feedSources(IndexAggregator& idx, double p, int64_t now)
+{
+  idx.update(1, px(p), now);
+  idx.update(2, px(p + 0.01), now);
+  idx.update(3, px(p - 0.01), now);
+}
+
+void test_driver()
+{
+  std::printf("test_mark_feed_driver\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(2, USD, usd(100000));
+  std::vector<Liquidation> liqs;
+  CrossMarginManager cm(led, USD, VENUE, [&](const Liquidation& l)
+                        { liqs.push_back(l); });
+  cm.configureSymbol(BTC, 1000, 500);
+  cm.setMark(BTC, px(100));
+  cm.applyFill(1, BTC, Side::BUY, qty(100).raw(), px(100).raw());
+  cm.applyFill(2, BTC, Side::SELL, qty(100).raw(), px(100).raw());
+
+  IndexAggregator idx(/*staleness*/ 5 * SEC, /*maxDevBps*/ 200, /*minSources*/ 3);
+  MarkPrice mark(/*clampBps*/ 500);
+  MarkFeedDriver<CrossMarginManager> drv(idx, mark, cm, BTC, 500);
+
+  // Fresh feed at 100 -> mark published, not paused, no liquidation.
+  feedSources(idx, 100.0, 1 * SEC);
+  CHECK(drv.onTick(1 * SEC, px(100).raw(), px(100).raw()));
+  CHECK(!drv.paused());
+  CHECK(liqs.empty());
+  CHECK(drv.markAgeNs(1 * SEC) == 0);                          // just published
+  CHECK(drv.markAgeNs(1 * SEC + 500'000'000) == 500'000'000);  // 500ms later
+
+  // Feed goes stale: no source refresh, and time advances past the TTL. A crash
+  // would liquidate, but the driver freezes liquidations instead.
+  const int64_t t = 10 * SEC;  // last sources were at 1s, TTL 5s -> stale
+  const bool published = drv.onTick(t, px(80).raw(), px(80).raw());
+  CHECK(!published);
+  CHECK(drv.paused());
+  CHECK(liqs.empty());                              // NOT liquidated on a stale feed
+  CHECK(cm.positionQty(1, BTC) == qty(100).raw());  // still open
+
+  // Feed recovers at the real (crashed) price -> resume and liquidate.
+  feedSources(idx, 80.0, 11 * SEC);
+  CHECK(drv.onTick(11 * SEC, px(80).raw(), px(80).raw()));
+  CHECK(!drv.paused());
+  CHECK(!liqs.empty());
+  CHECK(cm.positionQty(1, BTC) == 0);
+}
+
+}  // namespace
+
+TEST(MarkFeedDriver, EngineSuite)
+{
+  test_driver();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_mark_price.cpp
+++ b/venue/tests/test_venue_mark_price.cpp
@@ -1,0 +1,248 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/cross_margin.h"
+#include "flox-venue/index_feed.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+constexpr int64_t SEC = 1'000'000'000LL;
+
+void test_index_median()
+{
+  std::printf("test_index_median\n");
+  IndexAggregator idx(/*staleness*/ 5 * SEC, /*maxDevBps*/ 100, /*minSources*/ 3);
+
+  idx.update(1, px(100.0), 1 * SEC);
+  idx.update(2, px(100.2), 1 * SEC);
+  CHECK(!idx.hasIndex(1 * SEC));  // only 2 sources < min 3
+
+  idx.update(3, px(99.8), 1 * SEC);
+  CHECK(idx.hasIndex(1 * SEC));
+  CHECK(idx.index(1 * SEC) == px(100.0));  // median of {99.8, 100.0, 100.2}
+}
+
+void test_stale_source_ignored()
+{
+  std::printf("test_stale_source_ignored\n");
+  IndexAggregator idx(5 * SEC, 100, 3);
+  idx.update(1, px(100.0), 1 * SEC);
+  idx.update(2, px(100.0), 1 * SEC);
+  idx.update(3, px(100.0), 1 * SEC);
+  idx.update(4, px(500.0), 1 * SEC);  // 4th source, wildly off but...
+
+  // At t = 8s, sources from t=1s are stale (>5s). All four stale -> no index.
+  CHECK(!idx.hasIndex(8 * SEC));
+  // Refresh three good sources at t=8s; the bad one stays stale and is dropped.
+  idx.update(1, px(101.0), 8 * SEC);
+  idx.update(2, px(101.0), 8 * SEC);
+  idx.update(3, px(101.0), 8 * SEC);
+  CHECK(idx.hasIndex(8 * SEC));
+  CHECK(idx.index(8 * SEC) == px(101.0));  // stale 500.0 ignored
+}
+
+void test_outlier_rejected()
+{
+  std::printf("test_outlier_rejected\n");
+  IndexAggregator idx(5 * SEC, /*maxDevBps*/ 100 /*=1%*/, 3);
+  idx.update(1, px(100.0), 1 * SEC);
+  idx.update(2, px(100.0), 1 * SEC);
+  idx.update(3, px(100.1), 1 * SEC);
+  idx.update(4, px(150.0), 1 * SEC);  // fresh but +50% -> gross outlier
+
+  // Median of all four raw would be pulled up; outlier filter drops 150.0.
+  CHECK(idx.index(1 * SEC) == px(100.0));
+}
+
+void test_broad_move_tracked()
+{
+  std::printf("test_broad_move_tracked\n");
+  IndexAggregator idx(5 * SEC, 100, 3);
+  // All sources move together by ~5% -> this is a real move, not an outlier.
+  idx.update(1, px(105.0), 1 * SEC);
+  idx.update(2, px(105.1), 1 * SEC);
+  idx.update(3, px(104.9), 1 * SEC);
+  CHECK(idx.index(1 * SEC) == px(105.0));  // tracked, not suppressed
+}
+
+void test_mark_clamp()
+{
+  std::printf("test_mark_clamp\n");
+  MarkPrice mark(/*clampBps*/ 50);  // 0.5% band
+  CHECK(!mark.valid());
+
+  mark.setIndex(px(100.0));
+  CHECK(mark.valid());
+  CHECK(mark.value() == px(100.0));  // only index -> mark = index
+
+  // A modest last print within band + mid: median of {100, 100.1, 100.05}.
+  mark.setLast(px(100.1));
+  mark.setMid(px(100.05));
+  CHECK(mark.value() == px(100.05));
+
+  // A manipulative print far above: mark clamps to index + 0.5% = 100.5.
+  mark.setLast(px(120.0));
+  mark.setMid(px(120.0));
+  CHECK(mark.value() == px(100.5));
+
+  // And far below clamps to index - 0.5% = 99.5.
+  mark.setLast(px(1.0));
+  mark.setMid(px(1.0));
+  CHECK(mark.value() == px(99.5));
+}
+
+void test_impact_price()
+{
+  std::printf("test_impact_price\n");
+  // A spoofy dust ask at 90, real depth at 100. Naive best ask = 90; the impact
+  // price to fill a real size walks past the dust to the true ~100.
+  std::vector<DepthLevel> asks = {{px(90).raw(), qty(0.01).raw()}, {px(100).raw(), qty(100).raw()}};
+  const int64_t ip = impactPriceRaw(asks, qty(10).raw());
+  CHECK(Price::fromRaw(ip) > px(99));  // not dragged down to the 90 dust
+  CHECK(Price::fromRaw(ip) < px(100.1));
+
+  // Symmetric real depth -> impact mid exactly at 100.
+  std::vector<DepthLevel> bids = {{px(99.98).raw(), qty(1).raw()}, {px(99.90).raw(), qty(100).raw()}};
+  std::vector<DepthLevel> asks2 = {{px(100.02).raw(), qty(1).raw()}, {px(100.10).raw(), qty(100).raw()}};
+  CHECK(Price::fromRaw(impactMidRaw(bids, asks2, qty(10).raw())) == px(100.0));
+
+  // Insufficient depth -> VWAP of what's available; empty -> 0 (no crash).
+  std::vector<DepthLevel> thin = {{px(100).raw(), qty(2).raw()}};
+  CHECK(impactPriceRaw(thin, qty(10).raw()) == px(100).raw());
+  CHECK(impactPriceRaw({}, qty(10).raw()) == 0);
+
+  // Impact mid feeds the mark: a thin manipulated top can't move it.
+  MarkPrice mark(/*clampBps*/ 200);
+  mark.setIndex(px(100));
+  mark.setMid(Price::fromRaw(impactMidRaw(bids, asks2, qty(10).raw())));
+  CHECK(mark.value() == px(100.0));
+}
+
+// The impact-mid adapter runs on a real engine book, not synthetic levels.
+void test_book_impact_mid()
+{
+  std::printf("test_book_impact_mid\n");
+  SymbolConfig sc;
+  sc.id = 1;
+  sc.tickSize = px(0.01);
+  sc.minPrice = px(50);
+  sc.maxPrice = px(150);
+  MatchingEngine<MatchingBook> eng(sc, [](const OutboundEvent&) {});
+
+  auto rest = [&](OrderId id, Side s, double p, double q)
+  {
+    NewOrder o;
+    o.id = id;
+    o.symbol = 1;
+    o.side = s;
+    o.type = OrderType::LIMIT;
+    o.price = px(p);
+    o.quantity = qty(q);
+    o.accountId = 1;
+    eng.submit(InboundCommand{o}, 0);
+  };
+  // Thin top-of-book (1 lot each side) over real depth further out.
+  rest(1, Side::BUY, 99.98, 1);
+  rest(2, Side::BUY, 99.90, 100);
+  rest(3, Side::SELL, 100.02, 1);
+  rest(4, Side::SELL, 100.10, 100);
+
+  // Impact mid for a 10-lot walks past the thin top into the real depth and
+  // lands symmetrically at 100; a raw top-of-book mid would also be ~100 here,
+  // but the impact mid is what resists a one-lot top-of-book manipulation.
+  const int64_t mid = bookImpactMidRaw(eng.book(), qty(10).raw());
+  CHECK(Price::fromRaw(mid) == px(100.0));
+  // With a 1-lot impact size it only sees the thin top: still 100 here.
+  CHECK(Price::fromRaw(bookImpactMidRaw(eng.book(), qty(1).raw())) == px(100.0));
+}
+
+// End-to-end: a manipulative perp print must not liquidate a healthy account,
+// because the mark fed to the risk engine is clamped to the index band.
+void test_clamp_prevents_liquidation()
+{
+  std::printf("test_clamp_prevents_liquidation\n");
+  constexpr AssetId USD = 1;
+  constexpr uint64_t VENUE = 999;
+  constexpr SymbolId BTC = 1;
+
+  Ledger led;
+  led.deposit(1, USD, amountOf(Volume::fromDouble(1000)));
+  led.deposit(2, USD, amountOf(Volume::fromDouble(100000)));
+
+  std::vector<Liquidation> liqs;
+  CrossMarginManager risk(led, USD, VENUE, [&](const Liquidation& l)
+                          { liqs.push_back(l); });
+  risk.configureSymbol(BTC, /*im*/ 1000, /*mm*/ 500);
+  risk.setMark(BTC, px(100));
+  // Account 1 long 100 @ 100: notional 10000, IM 1000 = equity, MM 500.
+  risk.applyFill(1, BTC, Side::BUY, Quantity::fromDouble(100).raw(), px(100).raw());
+  risk.applyFill(2, BTC, Side::SELL, Quantity::fromDouble(100).raw(), px(100).raw());
+
+  // Index (external spot) is steady at 100; an attacker slams the thin perp book
+  // to 80. Raw 80 would give equity 1000 + (80-100)*100 = -1000 -> liquidation.
+  IndexAggregator idx(5 * SEC, 100, 3);
+  idx.update(1, px(100.0), 1 * SEC);
+  idx.update(2, px(100.0), 1 * SEC);
+  idx.update(3, px(100.0), 1 * SEC);
+
+  MarkPrice mark(/*clampBps*/ 200);  // 2% band
+  mark.setIndex(idx.index(1 * SEC));
+  mark.setLast(px(80));  // the manipulated print
+  mark.setMid(px(80));
+
+  const Price clamped = mark.value();
+  CHECK(clamped == px(98));  // clamped to index - 2%
+  risk.setMark(BTC, clamped);
+
+  // equity = 1000 + (98-100)*100 = 800; MM = 98*100*5% = 490 -> solvent, no liq.
+  CHECK(liqs.empty());
+  CHECK(risk.positionQty(1, BTC) == Quantity::fromDouble(100).raw());
+}
+
+}  // namespace
+
+TEST(MarkPrice, EngineSuite)
+{
+  test_index_median();
+  test_stale_source_ignored();
+  test_outlier_rejected();
+  test_broad_move_tracked();
+  test_mark_clamp();
+  test_impact_price();
+  test_book_impact_mid();
+  test_clamp_prevents_liquidation();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_marketdata.cpp
+++ b/venue/tests/test_venue_marketdata.cpp
@@ -1,0 +1,261 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/itch_codec.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/workload.h"
+#include "flox/book/ladder_book.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+LadderBook::Config ladderCfg()
+{
+  return LadderBook::Config{0, px(0.01).raw(), 16000, 1 << 20};
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+bool sameMd(const MdMessage& a, const MdMessage& b)
+{
+  return a.type == b.type && a.seq == b.seq && a.symbol == b.symbol && a.id == b.id &&
+         a.side == b.side && a.price == b.price && a.qty == b.qty && a.makerId == b.makerId;
+}
+
+void test_l2_and_codec()
+{
+  std::printf("test_l2_and_codec\n");
+  std::vector<MdMessage> feed;
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { feed.push_back(m); }, px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e); });
+
+  eng.submit(limit(1, Side::SELL, 100, 5));
+  eng.submit(limit(2, Side::SELL, 101, 3));
+  eng.submit(limit(3, Side::BUY, 99, 4));
+  CHECK(md.book().bestAsk() == px(100));
+  CHECK(md.book().askAtPrice(px(100)) == qty(5));
+  CHECK(md.book().askAtPrice(px(101)) == qty(3));
+  CHECK(md.book().bestBid() == px(99));
+  CHECK(md.book().bidAtPrice(px(99)) == qty(4));
+
+  eng.submit(limit(4, Side::BUY, 100, 2));  // crosses id1: trade 2 @100, id1 leaves 3
+  CHECK(md.book().askAtPrice(px(100)) == qty(3));
+
+  eng.submit(CancelOrder{2, SYM, 1});  // remove the 101 level
+  CHECK(md.book().askAtPrice(px(101)) == qty(0));
+
+  eng.submit(ModifyOrder{1, SYM, px(102), qty(3), 1});  // reprice 100->102
+  CHECK(md.book().askAtPrice(px(100)) == qty(0));
+  CHECK(md.book().bestAsk() == px(102));
+  CHECK(md.book().askAtPrice(px(102)) == qty(3));
+
+  // ITCH round-trip on the whole feed
+  std::vector<uint8_t> buf;
+  int rt = 0;
+  for (const auto& m : feed)
+  {
+    ItchCodec::encode(m, buf);
+    MdMessage back;
+    CHECK(ItchCodec::decode(buf.data(), buf.size(), back));
+    CHECK(sameMd(m, back));
+    ++rt;
+  }
+  CHECK(rt > 0);
+}
+
+void test_book_agreement()
+{
+  std::printf("test_book_agreement\n");
+  MarketDataPublisher<> md([](const MdMessage&) {}, px(0.01), SYM);
+  MatchingEngine<LadderBook> eng(cfg(), [&](const OutboundEvent& e)
+                                 { md.onEvent(e); }, LadderBook{ladderCfg()});
+
+  workload::Params p;
+  p.symbol = SYM;
+  p.count = 300'000;
+  const auto cmds = workload::symmetricLimits(p);
+
+  // Full-depth agreement: compare EVERY price level's aggregate, not just the
+  // touch -- MD drift at deeper levels (from modify / partial-fill / cancel)
+  // would be invisible to a top-of-book-only check. Sampled periodically (a
+  // full-depth walk every command over 300k would be too slow) plus always at
+  // the touch.
+  int mismatches = 0;
+  std::vector<std::pair<Price, Quantity>> bl, al;
+  for (size_t k = 0; k < cmds.size(); ++k)
+  {
+    eng.submit(cmds[k]);
+    if (eng.book().bestBid() != md.book().bestBid() ||
+        eng.book().bestAsk() != md.book().bestAsk())
+    {
+      ++mismatches;
+    }
+    if ((k % 500) == 0)  // periodic full-depth reconciliation
+    {
+      eng.book().levels(Side::BUY, bl);
+      eng.book().levels(Side::SELL, al);
+      for (const auto& [p, q] : bl)
+      {
+        if (md.book().bidAtPrice(p) != q)
+        {
+          ++mismatches;
+        }
+      }
+      for (const auto& [p, q] : al)
+      {
+        if (md.book().askAtPrice(p) != q)
+        {
+          ++mismatches;
+        }
+      }
+    }
+  }
+  CHECK(mismatches == 0);  // the feed never drifts from the engine book, at any level
+  std::printf("  checked %zu commands (top + periodic full-depth), %d mismatches\n", cmds.size(),
+              mismatches);
+}
+
+// The public depth must show only an iceberg's displayed peak, never its hidden
+// reserve -- otherwise the book could be probed to reveal iceberg size.
+void test_iceberg_hidden_from_md()
+{
+  std::printf("test_iceberg_hidden_from_md\n");
+  std::vector<MdMessage> feed;
+  std::vector<OrderExecuted> execs;
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { feed.push_back(m); }, px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(),
+                                   [&](const OutboundEvent& e)
+                                   {
+                                     if (auto* x = std::get_if<OrderExecuted>(&e))
+                                     {
+                                       execs.push_back(*x);
+                                     }
+                                     md.onEvent(e);
+                                   });
+
+  NewOrder ice = limit(1, Side::SELL, 100, 20, 1);
+  ice.visibleQuantity = qty(3);  // 20 total, only 3 displayed
+  eng.submit(ice);
+  // Public depth at 100 shows only the 3-lot peak, not the 20 total.
+  CHECK(md.book().askAtPrice(px(100)) == qty(3));
+  // The AddOrder message also carried the peak, not the reserve.
+  bool sawAdd = false;
+  for (const auto& m : feed)
+  {
+    if (m.type == MdType::AddOrder && m.id == 1)
+    {
+      sawAdd = true;
+      CHECK(m.qty == qty(3));
+    }
+  }
+  CHECK(sawAdd);
+
+  // A plain (non-iceberg) order still shows its full size.
+  eng.submit(limit(2, Side::SELL, 101, 7, 1));
+  CHECK(md.book().askAtPrice(px(101)) == qty(7));
+
+  // Refill: a buy lifts the whole 3-lot peak. The iceberg refills a fresh 3-lot
+  // peak from its reserve -> public depth must still show 3 (17 remain hidden),
+  // never the total. This checks the Executed-driven MD path, not just Accept.
+  eng.submit(limit(3, Side::BUY, 100, 3, 2));
+  CHECK(md.book().askAtPrice(px(100)) == qty(3));  // refilled peak, reserve stays hidden
+
+  // PARTIAL peak fill (aggressor smaller than the peak): buy 2 of the 3-lot peak.
+  // The peak is not exhausted, so no refill and no fresh Accept -- only Executed.
+  // Public depth must drop to the new displayed peak (1), and the public Executed
+  // message must publish the DISPLAYED remaining (1), never the whole 15
+  // (1 shown + 14 hidden) -- else the hidden reserve leaks and depth underflows.
+  execs.clear();
+  eng.submit(limit(4, Side::BUY, 100, 2, 2));
+  CHECK(md.book().askAtPrice(px(100)) == qty(1));  // displayed peak, not 15
+  Quantity lastPubExec{};
+  bool sawExec = false;
+  for (const auto& m : feed)
+  {
+    if (m.type == MdType::Executed && m.id == 1)
+    {
+      sawExec = true;
+      lastPubExec = m.qty;
+    }
+  }
+  CHECK(sawExec);
+  CHECK(lastPubExec == qty(1));  // public feed shows displayed remaining, not the reserve
+  // The OWNER's exec report still reports the WHOLE remaining (1 + 14 = 15).
+  bool sawMakerExec = false;
+  for (const auto& x : execs)
+  {
+    if (x.id == 1 && !x.aggressor)
+    {
+      sawMakerExec = true;
+      CHECK(x.leavesQty == qty(15));     // whole remaining for the owner
+      CHECK(x.displayLeaves == qty(1));  // displayed peak for the public feed
+    }
+  }
+  CHECK(sawMakerExec);
+}
+
+}  // namespace
+
+TEST(Marketdata, EngineSuite)
+{
+  test_l2_and_codec();
+  test_book_agreement();
+  test_iceberg_hidden_from_md();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_matcher.cpp
+++ b/venue/tests/test_venue_matcher.cpp
@@ -1,0 +1,754 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/matching_engine.h"
+#include "flox/book/ladder_book.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+const char* g_label = "";
+
+void checkImpl(bool ok, const char* expr, const char* file, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL [%s] %s:%d  %s\n", g_label, file, line, expr);
+  }
+}
+#define CHECK(x) checkImpl((x), #x, __FILE__, __LINE__)
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+constexpr SymbolId SYM = 1;
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(0.01);
+  c.maxPrice = px(119);
+  return c;
+}
+
+LadderBook::Config ladderCfg()
+{
+  return LadderBook::Config{/*base*/ 0, /*tick*/ px(0.01).raw(), /*levels*/ 12000,
+                            /*maxOrders*/ 1024};
+}
+
+struct Capture
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+
+  int trades() const
+  {
+    int n = 0;
+    for (const auto& e : ev)
+    {
+      if (std::get_if<Trade>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  const Trade* firstTrade() const
+  {
+    for (const auto& e : ev)
+    {
+      if (const auto* t = std::get_if<Trade>(&e))
+      {
+        return t;
+      }
+    }
+    return nullptr;
+  }
+  int rejects(RejectReason r) const
+  {
+    int n = 0;
+    for (const auto& e : ev)
+    {
+      if (const auto* x = std::get_if<OrderRejected>(&e); x && x->reason == r)
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  int cancels(CancelReason r) const
+  {
+    int n = 0;
+    for (const auto& e : ev)
+    {
+      if (const auto* x = std::get_if<OrderCanceled>(&e); x && x->reason == r)
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  int accepts() const
+  {
+    int n = 0;
+    for (const auto& e : ev)
+    {
+      if (std::get_if<OrderAccepted>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  int triggers() const
+  {
+    int n = 0;
+    for (const auto& e : ev)
+    {
+      if (std::get_if<OrderTriggered>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  int modifies() const
+  {
+    int n = 0;
+    for (const auto& e : ev)
+    {
+      if (std::get_if<OrderModified>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+};
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1,
+               TimeInForce tif = TimeInForce::GTC)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.tif = tif;
+  o.accountId = acct;
+  return o;
+}
+
+NewOrder market(OrderId id, Side s, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::MARKET;
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+NewOrder iceberg(OrderId id, Side s, double p, double total, double vis, uint64_t acct = 1)
+{
+  NewOrder o = limit(id, s, p, total, acct);
+  o.visibleQuantity = qty(vis);
+  return o;
+}
+
+Quantity tradedTotal(const Capture& cap)
+{
+  Quantity t{};
+  for (const auto& e : cap.ev)
+  {
+    if (const auto* x = std::get_if<Trade>(&e))
+    {
+      t += x->quantity;
+    }
+  }
+  return t;
+}
+
+NewOrder stopMarket(OrderId id, Side s, double q, double trigger, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::STOP_MARKET;
+  o.quantity = qty(q);
+  o.triggerPrice = px(trigger);
+  o.accountId = acct;
+  return o;
+}
+
+NewOrder trailingStop(OrderId id, Side s, double q, double offset, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::TRAILING_STOP;
+  o.quantity = qty(q);
+  o.trailingOffset = px(offset);
+  o.accountId = acct;
+  return o;
+}
+
+bool tradedBy(const Capture& cap, OrderId taker, double price)
+{
+  for (const auto& e : cap.ev)
+  {
+    if (const auto* t = std::get_if<Trade>(&e))
+    {
+      if (t->takerId == taker && t->price == px(price))
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+template <class Book>
+void runAll(const std::function<Book()>& mk, const char* label)
+{
+  g_label = label;
+  std::printf("== book: %s ==\n", label);
+
+  {  // basic cross
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    CHECK(cap.accepts() == 1);
+    CHECK(cap.trades() == 0);
+    eng.submit(limit(2, Side::BUY, 100, 3, 2));
+    CHECK(cap.trades() == 1);
+    CHECK(cap.firstTrade() && cap.firstTrade()->quantity == qty(3));
+    CHECK(cap.firstTrade() && cap.firstTrade()->price == px(100));
+    CHECK(cap.firstTrade() && cap.firstTrade()->makerId == 1 && cap.firstTrade()->takerId == 2);
+    CHECK(eng.tradesGenerated() == 1);
+  }
+  {  // price-time priority: lower ask fills first, remainder sweeps up
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 2, 1));
+    eng.submit(limit(2, Side::SELL, 101, 2, 1));
+    eng.submit(limit(3, Side::BUY, 101, 3, 2));  // takes 2@100 then 1@101
+    CHECK(cap.trades() == 2);
+    // first fill at the better (lower) ask
+    CHECK(cap.firstTrade() && cap.firstTrade()->price == px(100));
+    CHECK(eng.book().bestAsk().has_value() && eng.book().bestAsk().value() == px(101));
+  }
+  {  // FIFO within a level: earlier order at same price fills first
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(10, Side::SELL, 100, 2, 1));
+    eng.submit(limit(11, Side::SELL, 100, 2, 1));
+    eng.submit(limit(12, Side::BUY, 100, 1, 2));
+    CHECK(cap.firstTrade() && cap.firstTrade()->makerId == 10);
+  }
+  {  // market residual canceled
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    eng.submit(market(2, Side::BUY, 8, 2));
+    CHECK(cap.trades() == 1);
+    CHECK(cap.firstTrade() && cap.firstTrade()->quantity == qty(5));
+    CHECK(cap.cancels(CancelReason::MarketResidual) == 1);
+  }
+  {  // post-only reject
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    NewOrder p = limit(2, Side::BUY, 101, 2, 2);
+    p.postOnly = true;
+    eng.submit(p);
+    CHECK(cap.trades() == 0);
+    CHECK(cap.rejects(RejectReason::PostOnlyWouldCross) == 1);
+  }
+  {  // FOK
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    eng.submit(limit(2, Side::BUY, 100, 10, 2, TimeInForce::FOK));
+    CHECK(cap.trades() == 0);
+    CHECK(cap.rejects(RejectReason::FillOrKillUnfulfillable) == 1);
+    eng.submit(limit(3, Side::BUY, 100, 4, 2, TimeInForce::FOK));
+    CHECK(cap.trades() == 1);
+    CHECK(cap.firstTrade() && cap.firstTrade()->quantity == qty(4));
+  }
+  {  // IOC residual canceled
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 2, 1));
+    eng.submit(limit(2, Side::BUY, 100, 5, 2, TimeInForce::IOC));
+    CHECK(cap.trades() == 1);
+    CHECK(cap.firstTrade() && cap.firstTrade()->quantity == qty(2));
+    CHECK(cap.cancels(CancelReason::ImmediateOrCancelResidual) == 1);
+    CHECK(cap.accepts() == 1);
+  }
+  {  // STP cancel-newest
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 7));
+    NewOrder o = limit(2, Side::BUY, 100, 3, 7);
+    o.stp = STPMode::CancelNewest;
+    eng.submit(o);
+    CHECK(cap.trades() == 0);
+    CHECK(cap.cancels(CancelReason::SelfTradePrevention) == 1);
+  }
+  {  // cancel + unknown-order reject
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    eng.submit(CancelOrder{1, SYM, 1});
+    CHECK(cap.cancels(CancelReason::UserRequested) == 1);
+    CHECK(eng.book().empty());
+    eng.submit(CancelOrder{999, SYM, 1});
+    CHECK(cap.rejects(RejectReason::UnknownOrder) == 1);
+  }
+  {  // duplicate order id reject
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    eng.submit(limit(1, Side::SELL, 101, 5, 1));
+    CHECK(cap.rejects(RejectReason::DuplicateOrderId) == 1);
+  }
+  {  // modify: shrink at same price keeps priority (in place, no trade)
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    eng.submit(ModifyOrder{1, SYM, Price{}, qty(2), 1});  // keep price, shrink 5->2
+    CHECK(cap.trades() == 0);
+    // only 2 left resting: a buy for 3 takes 2 and leaves 1 unmatched
+    eng.submit(limit(2, Side::BUY, 100, 3, 2));
+    CHECK(cap.trades() == 1);
+    CHECK(cap.firstTrade() && cap.firstTrade()->quantity == qty(2));
+  }
+  {  // modify: reprice into a cross matches immediately (loses priority)
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::BUY, 99, 5, 1));    // resting bid @99
+    eng.submit(limit(2, Side::SELL, 100, 5, 2));  // resting ask @100 (no cross)
+    CHECK(cap.trades() == 0);
+    eng.submit(ModifyOrder{1, SYM, px(100), qty(5), 1});  // reprice bid 99->100, crosses ask
+    CHECK(cap.trades() == 1);
+    CHECK(cap.firstTrade() && cap.firstTrade()->price == px(100));
+  }
+  {  // modify unknown order rejects
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(ModifyOrder{42, SYM, px(100), qty(1), 1});
+    CHECK(cap.rejects(RejectReason::UnknownOrder) == 1);
+  }
+  {  // iceberg fully consumed via peak refills
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(iceberg(1, Side::SELL, 100, 10, 2, 1));  // total 10, peak 2
+    eng.submit(limit(2, Side::BUY, 100, 10, 2));
+    CHECK(cap.trades() == 5);  // 5 refilled bites of 2
+    CHECK(tradedTotal(cap) == qty(10));
+    CHECK(eng.book().empty());
+  }
+  {  // iceberg refill loses priority to a same-price displayed order
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(iceberg(1, Side::SELL, 100, 10, 2, 1));
+    eng.submit(limit(2, Side::SELL, 100, 2, 1));
+    eng.submit(limit(3, Side::BUY, 100, 4, 2));
+    CHECK(cap.trades() == 2);
+    std::vector<OrderId> makers;
+    for (const auto& e : cap.ev)
+    {
+      if (const auto* t = std::get_if<Trade>(&e))
+      {
+        makers.push_back(t->makerId);
+      }
+    }
+    CHECK(makers.size() == 2 && makers[0] == 1 && makers[1] == 2);  // id1 peak, then id2
+  }
+  {  // FOK counts the iceberg hidden reserve as available liquidity
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(iceberg(1, Side::SELL, 100, 10, 2, 1));
+    eng.submit(limit(2, Side::BUY, 100, 8, 2, TimeInForce::FOK));
+    CHECK(cap.rejects(RejectReason::FillOrKillUnfulfillable) == 0);
+    CHECK(tradedTotal(cap) == qty(8));
+  }
+  {  // buy stop-market fires when the last price rises to the trigger
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 1));
+    eng.submit(limit(2, Side::BUY, 100, 5, 2));  // trade @100 -> last=100
+    eng.submit(stopMarket(3, Side::BUY, 2, 105, 2));
+    CHECK(cap.trades() == 1);
+    CHECK(cap.triggers() == 0);  // 100 < 105, still pending
+    eng.submit(limit(4, Side::SELL, 105, 10, 1));
+    eng.submit(limit(5, Side::BUY, 105, 1, 2));  // trade @105 -> last=105 -> stop fires
+    CHECK(cap.triggers() == 1);
+    CHECK(tradedBy(cap, 3, 105.0));  // the triggered stop (taker 3) traded at 105
+  }
+  {  // sell trailing-stop ratchets up, then fires on the pullback
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 1, 1));
+    eng.submit(limit(2, Side::BUY, 100, 1, 2));        // trade @100 -> last=100
+    eng.submit(trailingStop(3, Side::SELL, 2, 5, 1));  // trigger starts 95
+    eng.submit(limit(4, Side::SELL, 110, 1, 5));
+    eng.submit(limit(5, Side::BUY, 110, 1, 6));  // trade @110 -> trigger ratchets to 105
+    CHECK(cap.triggers() == 0);                  // 110 > 105, not fired
+    eng.submit(limit(6, Side::BUY, 105, 10, 7));
+    eng.submit(limit(7, Side::SELL, 105, 1, 8));  // trade @105 -> last<=trigger -> fires
+    CHECK(cap.triggers() == 1);
+    CHECK(tradedBy(cap, 3, 105.0));
+  }
+  {  // STP Decrement: incoming smaller -> reduce resting, cancel incoming, no trade
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 7));
+    NewOrder o = limit(2, Side::BUY, 100, 3, 7);
+    o.stp = STPMode::Decrement;
+    eng.submit(o);
+    CHECK(cap.trades() == 0);
+    CHECK(cap.cancels(CancelReason::SelfTradePrevention) == 1);
+    eng.submit(limit(3, Side::BUY, 100, 5, 2));  // resting was reduced 5->2
+    CHECK(cap.trades() == 1);
+    CHECK(cap.firstTrade() && cap.firstTrade()->quantity == qty(2));
+  }
+  {  // STP Decrement: incoming larger -> cancel resting, incoming rests
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 3, 7));
+    NewOrder o = limit(2, Side::BUY, 100, 5, 7);
+    o.stp = STPMode::Decrement;
+    eng.submit(o);
+    CHECK(cap.trades() == 0);
+    CHECK(cap.cancels(CancelReason::SelfTradePrevention) == 1);
+    CHECK(cap.accepts() == 2);  // resting sell (later STP-canceled) + incoming residual rests
+  }
+  {  // fat-finger: max order qty
+    Capture cap;
+    auto fc = cfg();
+    fc.maxOrderQty = qty(100);
+    MatchingEngine<Book> eng(fc, cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 101, 1));  // 101 > 100
+    CHECK(cap.rejects(RejectReason::OrderTooLarge) == 1);
+  }
+  {  // fat-finger: max notional
+    Capture cap;
+    auto fc = cfg();
+    fc.maxOrderNotional = px(100) * qty(10);  // 1000
+    MatchingEngine<Book> eng(fc, cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 20, 1));  // notional 2000 > 1000
+    CHECK(cap.rejects(RejectReason::OrderTooLarge) == 1);
+    eng.submit(limit(2, Side::SELL, 100, 5, 1));  // notional 500 ok
+    CHECK(cap.accepts() == 1);
+  }
+  {  // max open orders per account: cap live resting orders, freed by cancel
+    Capture cap;
+    auto fc = cfg();
+    fc.maxOpenOrders = 2;
+    MatchingEngine<Book> eng(fc, cap.sink(), mk());
+    eng.submit(limit(1, Side::BUY, 99, 1, 5));  // rests (1 open)
+    eng.submit(limit(2, Side::BUY, 98, 1, 5));  // rests (2 open)
+    eng.submit(limit(3, Side::BUY, 97, 1, 5));  // at cap -> rejected
+    CHECK(cap.rejects(RejectReason::TooManyOpenOrders) == 1);
+    CHECK(cap.accepts() == 2);
+    eng.submit(CancelOrder{1, SYM, 5});         // free a slot
+    eng.submit(limit(4, Side::BUY, 96, 1, 5));  // now fits
+    CHECK(cap.accepts() == 3);
+    CHECK(cap.rejects(RejectReason::TooManyOpenOrders) == 1);  // still just the one
+    // A different account is unaffected by account 5's count.
+    eng.submit(limit(5, Side::BUY, 95, 1, 6));
+    CHECK(cap.accepts() == 4);
+  }
+  {  // GTD: a resting order auto-cancels once its expiry sequencer-ts passes
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    NewOrder o = limit(1, Side::BUY, 99, 5, 1);
+    o.tif = TimeInForce::GTD;
+    o.expiryNs = 1000;
+    eng.submit(InboundCommand{o}, 100);  // rests at t=100
+    CHECK(cap.accepts() == 1);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 98, 1, 2)}, 500);  // t=500, not expired
+    CHECK(!eng.book().empty());
+    CHECK(cap.cancels(CancelReason::Expired) == 0);
+    // A submit at t >= 1000 sweeps the expired GTD order before processing.
+    eng.submit(InboundCommand{limit(3, Side::BUY, 97, 1, 3)}, 1000);
+    CHECK(cap.cancels(CancelReason::Expired) == 1);
+    CHECK(eng.book().bestBid().value() == px(98));  // 99 gone, best is now 98
+    // GTC orders never expire.
+    Capture cap2;
+    MatchingEngine<Book> eng2(cfg(), cap2.sink(), mk());
+    eng2.submit(InboundCommand{limit(1, Side::BUY, 99, 5, 1)}, 100);
+    eng2.submit(InboundCommand{limit(2, Side::SELL, 105, 1, 2)}, 1000000);
+    CHECK(cap2.cancels(CancelReason::Expired) == 0);
+  }
+  {  // OCO: two resting sells linked; a fill on one cancels the other
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    NewOrder tp = limit(1, Side::SELL, 102, 5, 1);  // take-profit
+    tp.ocoGroup = 77;
+    NewOrder sl = limit(2, Side::SELL, 105, 5, 1);  // the linked sibling
+    sl.ocoGroup = 77;
+    eng.submit(tp);
+    eng.submit(sl);
+    CHECK(cap.accepts() == 2);
+    // A buy lifts the 102 sell -> that OCO order fills, its sibling (105) cancels.
+    eng.submit(limit(3, Side::BUY, 102, 5, 2));
+    CHECK(cap.trades() == 1);
+    CHECK(cap.cancels(CancelReason::OcoTriggered) == 1);
+    CHECK(eng.book().bestAsk().has_value() == false);  // 105 sibling gone, no asks left
+    // The winner's sibling truly gone: a cross at 105 finds nothing.
+    eng.submit(limit(4, Side::BUY, 106, 5, 2));
+    CHECK(cap.trades() == 1);  // no new trade -- 105 was canceled
+  }
+  {  // Peg: a bid-pegged buy re-prices to track the best bid as it moves
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::BUY, 99, 5, 1));    // best bid 99
+    eng.submit(limit(2, Side::SELL, 101, 5, 2));  // best ask 101
+    NewOrder pg = limit(3, Side::BUY, 0, 4, 3);
+    pg.peg = PegRef::Bid;  // peg to best bid
+    eng.submit(pg);
+    // Pegged buy joins the bid at 99 (it is not the top of a new level here).
+    CHECK(eng.book().bestBid().value() == px(99));
+    // A better bid arrives at 100 -> next submit re-pegs order 3 up to 100.
+    eng.submit(limit(4, Side::BUY, 100, 1, 4));   // best bid now 100
+    eng.submit(limit(5, Side::SELL, 105, 1, 5));  // a submit boundary to trigger repeg
+    CHECK(cap.modifies() >= 1);                   // order 3 was repriced
+    // The peg never crosses: with best ask 101, the peg sits at 100, not above.
+    CHECK(eng.book().bestBid().value() == px(100));
+    // Selling into 100 hits the repriced peg.
+    eng.submit(limit(6, Side::SELL, 100, 4, 6));
+    CHECK(cap.trades() >= 1);
+  }
+  {  // Peg self-reference: a Mid peg that BECOMES the touch must not ratchet
+     // toward the opposite side on repeat submits -- it must read the market
+     // excluding its own resting quantity, so a static market keeps it put.
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::BUY, 100, 5, 1));   // bid 100
+    eng.submit(limit(2, Side::SELL, 110, 5, 2));  // ask 110  -> true mid 105
+    NewOrder pg = limit(3, Side::BUY, 0, 4, 3);
+    pg.peg = PegRef::Mid;
+    eng.submit(pg);
+    CHECK(eng.book().bestBid().value() == px(105));  // rests at true mid, becomes best bid
+    const int modsBefore = cap.modifies();
+    // Two unrelated submits that rest away from the touch (best bid/ask unchanged),
+    // each triggering a repeg. The market mid never moves -> peg must STAY at 105.
+    eng.submit(limit(4, Side::SELL, 115, 1, 4));
+    eng.submit(limit(5, Side::SELL, 116, 1, 5));
+    CHECK(eng.book().bestBid().value() == px(105));  // no creep (bug: 105->107->108)
+    CHECK(cap.modifies() == modsBefore);             // no spurious reprice/priority churn
+  }
+  {  // Emergency halt-and-cancel: pull the whole resting book + pending stops
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::BUY, 99, 5, 1));
+    eng.submit(limit(2, Side::SELL, 101, 5, 2));
+    eng.submit(stopMarket(3, Side::BUY, 2, 105, 3));  // pending stop (no last price yet)
+    CHECK(!eng.book().empty());
+    eng.haltAndCancelAll();
+    CHECK(eng.book().empty());                         // resting book pulled
+    CHECK(cap.cancels(CancelReason::VenueHalt) == 3);  // 2 limits + 1 stop
+    // New orders are rejected while halted.
+    eng.submit(limit(4, Side::BUY, 100, 1, 4));
+    CHECK(cap.rejects(RejectReason::Halted) == 1);
+  }
+  {  // Resume after halt through a re-opening auction (not straight to continuous)
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setHalted(true);
+    eng.submit(limit(1, Side::BUY, 100, 5, 1));  // rejected while halted
+    CHECK(cap.rejects(RejectReason::Halted) == 1);
+    // Operator reopens via auction: orders accumulate without matching.
+    eng.resumeWithAuction();
+    eng.submit(limit(2, Side::SELL, 100, 5, 2));
+    eng.submit(limit(3, Side::BUY, 101, 8, 3));  // crosses, but only accumulates; leaves a remnant
+    CHECK(cap.trades() == 0);                    // no matching during the auction
+    eng.openContinuous();                        // uncross at the single price
+    const int afterAuction = cap.trades();
+    CHECK(afterAuction >= 1);    // the re-opening print
+    CHECK(!eng.book().empty());  // 3-lot buy remnant rests
+    // Continuous now: a fresh cross trades immediately.
+    eng.submit(limit(4, Side::SELL, 99, 1, 4));
+    CHECK(cap.trades() > afterAuction);
+  }
+  {  // Firm-group STP: two different accounts of the same firm can't self-trade
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setStpGroup(10, /*firm*/ 1);
+    eng.setStpGroup(11, /*firm*/ 1);                   // accounts 10 and 11 are the same firm
+    eng.submit(limit(1, Side::SELL, 100, 5, 10));      // resting, firm 1
+    NewOrder cross = limit(2, Side::BUY, 100, 5, 11);  // firm 1, different account
+    cross.stp = STPMode::CancelOldest;
+    eng.submit(cross);
+    CHECK(cap.trades() == 0);  // STP fired across the firm
+    CHECK(cap.cancels(CancelReason::SelfTradePrevention) == 1);
+    // A third-party account (different firm) trades normally against firm 1.
+    eng.submit(limit(3, Side::SELL, 100, 5, 20));  // account 20, no group
+    NewOrder ok = limit(4, Side::BUY, 100, 5, 11);
+    ok.stp = STPMode::CancelOldest;
+    eng.submit(ok);
+    CHECK(cap.trades() == 1);  // different firms -> allowed
+  }
+  {  // account snapshot for reconnect reconciliation: open orders + position
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::BUY, 99, 5, 5));
+    eng.submit(limit(2, Side::BUY, 98, 3, 5));
+    eng.submit(limit(3, Side::SELL, 101, 2, 6));  // different account
+    const auto snap = eng.snapshotAccount(5);
+    CHECK(snap.openOrders.size() == 2);
+    CHECK(snap.positionQty == 0);  // spot -> flat
+    bool has1 = false, has2 = false;
+    for (const auto& o : snap.openOrders)
+    {
+      if (o.id == 1)
+      {
+        has1 = true;
+        CHECK(o.price == px(99) && o.leaves == qty(5) && o.side == Side::BUY);
+      }
+      if (o.id == 2)
+      {
+        has2 = true;
+        CHECK(o.price == px(98) && o.leaves == qty(3));
+      }
+    }
+    CHECK(has1 && has2);
+    CHECK(eng.snapshotAccount(6).openOrders.size() == 1);  // account 6 sees only its own
+    CHECK(eng.snapshotAccount(999).openOrders.empty());    // unknown account -> empty
+    // A pending stop (in the stop book, not the visible book) shows up too.
+    eng.submit(stopMarket(7, Side::BUY, 4, 105, 5));  // acct 5 pending stop, trigger 105
+    const auto snap2 = eng.snapshotAccount(5);
+    CHECK(snap2.openOrders.size() == 2);    // limits unchanged
+    CHECK(snap2.pendingStops.size() == 1);  // the stop is surfaced
+    CHECK(snap2.pendingStops[0].id == 7 && snap2.pendingStops[0].trigger == px(105));
+  }
+  {  // live risk-limit adjustment: tighten max-open-orders at runtime
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::BUY, 99, 1, 5));
+    eng.submit(limit(2, Side::BUY, 98, 1, 5));  // both rest (no cap yet)
+    CHECK(cap.accepts() == 2);
+    eng.setMaxOpenOrders(2);                    // operator tightens the cap live
+    eng.submit(limit(3, Side::BUY, 97, 1, 5));  // account 5 already at 2 -> rejected
+    CHECK(cap.rejects(RejectReason::TooManyOpenOrders) == 1);
+  }
+  {  // Deterministic cancel order: mass-cancel emits OrderCanceled in ascending
+     // id order regardless of insertion order -- the emitted event stream must not
+     // depend on unordered-container layout (HA/replay equivalence across builds).
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(30, Side::BUY, 95, 1, 5));
+    eng.submit(limit(10, Side::BUY, 94, 1, 5));
+    eng.submit(limit(20, Side::BUY, 93, 1, 5));  // scrambled ids, same account
+    eng.submit(MassCancel{5, SYM});
+    std::vector<OrderId> canceled;
+    for (const auto& e : cap.ev)
+    {
+      if (const auto* c = std::get_if<OrderCanceled>(&e))
+      {
+        canceled.push_back(c->id);
+      }
+    }
+    CHECK(canceled.size() == 3);
+    CHECK(canceled.size() == 3 && canceled[0] == 10 && canceled[1] == 20 && canceled[2] == 30);
+  }
+  {  // OCO cleanup: a canceled leg must be unlinked from ocoMembers_ so a REUSED
+     // id is not wrongly canceled when the surviving sibling later resolves.
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    NewOrder a = limit(10, Side::SELL, 102, 1, 1);
+    a.ocoGroup = 1;
+    NewOrder b = limit(11, Side::SELL, 105, 1, 1);
+    b.ocoGroup = 1;
+    eng.submit(a);
+    eng.submit(b);                               // group 1 = [10, 11], both resting
+    eng.submit(CancelOrder{10, SYM, 1});         // cancel leg A -> must unlink 10 from group 1
+    eng.submit(limit(10, Side::BUY, 95, 1, 2));  // REUSE id 10: unrelated buy, no OCO
+    CHECK(eng.book().bestBid().has_value() && eng.book().bestBid().value() == px(95));
+    eng.submit(limit(12, Side::BUY, 105, 1, 3));  // lift leg B -> resolves group 1
+    CHECK(cap.trades() == 1);
+    // The reused id-10 buy must be untouched (a stale ocoMembers_[1] would cancel it).
+    CHECK(eng.book().bestBid().has_value() && eng.book().bestBid().value() == px(95));
+    CHECK(eng.snapshotAccount(2).openOrders.size() == 1);
+  }
+  {  // OCO cleanup on REJECT: a rejected OCO leg must be unlinked (scope guard),
+     // so a reused id is not wrongly canceled when the sibling resolves.
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    NewOrder a = limit(20, Side::SELL, 105, 1, 1);
+    a.ocoGroup = 2;
+    eng.submit(a);  // group 2 = [20], resting
+    NewOrder bad = limit(21, Side::SELL, 200, 1, 1);
+    bad.ocoGroup = 2;  // price > maxPrice(119)
+    eng.submit(bad);   // rejected by validate AFTER the OCO link
+    CHECK(cap.rejects(RejectReason::InvalidPrice) >= 1);
+    eng.submit(limit(21, Side::BUY, 95, 1, 2));                                         // REUSE the rejected id 21
+    eng.submit(limit(22, Side::BUY, 105, 1, 3));                                        // lift leg A -> resolves group 2
+    CHECK(eng.book().bestBid().has_value() && eng.book().bestBid().value() == px(95));  // reused id alive
+    CHECK(eng.snapshotAccount(2).openOrders.size() == 1);
+  }
+  {  // FOK + STP: self-liquidity must NOT let a FOK pass the precheck and rest.
+    // The only crossing liquidity is the account's own ask, which STP would
+    // cancel (never trade), so the FOK cannot fully fill -> it must be killed,
+    // all-or-none, and never become a resting GTC bid.
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(limit(1, Side::SELL, 100, 5, 7));                      // account 7 rests SELL 5 @ 100
+    NewOrder fok = limit(2, Side::BUY, 100, 5, 7, TimeInForce::FOK);  // same account
+    fok.stp = STPMode::CancelOldest;
+    eng.submit(fok);
+    CHECK(cap.trades() == 0);
+    CHECK(cap.rejects(RejectReason::FillOrKillUnfulfillable) == 1);                      // rejected pre-match
+    CHECK(!eng.book().bestBid().has_value());                                            // the FOK did NOT rest as a bid
+    CHECK(eng.book().bestAsk().has_value() && eng.book().bestAsk().value() == px(100));  // ask intact
+    CHECK(eng.snapshotAccount(7).openOrders.size() == 1);                                // only the original resting sell
+  }
+}
+
+}  // namespace
+
+TEST(Matcher, EngineSuite)
+{
+  runAll<MatchingBook>([]
+                       { return MatchingBook{}; }, "map-reference");
+  runAll<LadderBook>([]
+                     { return LadderBook{ladderCfg()}; }, "ladder-o1");
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_metrics.cpp
+++ b/venue/tests/test_venue_metrics.cpp
@@ -1,0 +1,207 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/ledger.h"
+#include "flox-venue/messages.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/metrics_server.h"
+#include "flox-venue/prometheus.h"
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <atomic>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+Metrics sampleMetrics()
+{
+  Metrics m;
+  OrderAccepted acc{};
+  acc.id = 1;
+  m.observe(OutboundEvent{acc});
+  Trade t{};
+  t.price = px(100);
+  t.quantity = qty(3);
+  m.observe(OutboundEvent{t});
+  OrderCanceled c{};
+  c.id = 1;
+  m.observe(OutboundEvent{c});
+  OrderRejected rej{};
+  rej.id = 9;
+  rej.reason = RejectReason::PositionLimitExceeded;
+  m.observe(OutboundEvent{rej});
+  m.submitLatency.record(1000);
+  m.submitLatency.record(5000);
+  m.submitLatency.record(20000);
+  return m;
+}
+
+bool contains(const std::string& hay, const std::string& needle)
+{
+  return hay.find(needle) != std::string::npos;
+}
+
+void test_renderer()
+{
+  std::printf("test_prometheus_renderer\n");
+  const Metrics m = sampleMetrics();
+  const std::string txt = prom::render(m);
+
+  CHECK(contains(txt, "# TYPE fme_trades_total counter"));
+  CHECK(contains(txt, "fme_trades_total 1"));
+  CHECK(contains(txt, "fme_orders_accepted_total 1"));
+  CHECK(contains(txt, "fme_cancels_total 1"));
+  CHECK(contains(txt, "# TYPE fme_submit_latency_ns summary"));
+  CHECK(contains(txt, "fme_submit_latency_ns{quantile=\"0.5\"}"));
+  CHECK(contains(txt, "fme_submit_latency_ns_count 3"));
+  CHECK(contains(txt, "fme_rejects_by_reason_total{reason=\"PositionLimitExceeded\"} 1"));
+  // 3 fills @ 3 qty @ 100 -> traded notional raw = 300 * 1e8 = 30000000000
+  CHECK(contains(txt, "fme_traded_volume_raw 30000000000"));
+
+  // i128 helpers: negative and large values.
+  CHECK(prom::i128ToStr(-50) == "-50");
+  CHECK(prom::i128ToStr(0) == "0");
+  unsigned __int128 big = static_cast<unsigned __int128>(1) << 100;
+  CHECK(prom::u128ToStr(big) == "1267650600228229401496703205376");
+}
+
+void test_gauges()
+{
+  std::printf("test_prometheus_gauges\n");
+  const Metrics m = sampleMetrics();
+  Gauges g;
+  g.insuranceFundRaw = amountOf(Volume::fromDouble(50000));
+  g.fundingRate = 0.0001;
+  g.openInterestRaw = amountOf(Volume::fromDouble(1200000));
+  g.openPositions = 7;
+  g.restingOrders = 42;
+  g.markPriceAgeNs = 250000000;  // 250ms feed lag
+  g.liquidationsPaused = 1;
+  const std::string txt = prom::render(m, g);
+
+  // Counters still present, plus the gauge blocks.
+  CHECK(contains(txt, "fme_trades_total 1"));
+  CHECK(contains(txt, "# TYPE fme_insurance_fund_raw gauge"));
+  CHECK(contains(txt, "fme_insurance_fund_raw 5000000000000"));  // 50000 * 1e8
+  CHECK(contains(txt, "# TYPE fme_funding_rate gauge"));
+  CHECK(contains(txt, "fme_open_positions 7"));
+  CHECK(contains(txt, "fme_resting_orders 42"));
+  CHECK(contains(txt, "fme_mark_price_age_ns 250000000"));
+  CHECK(contains(txt, "# TYPE fme_liquidations_paused gauge"));
+  CHECK(contains(txt, "fme_liquidations_paused 1"));
+}
+
+std::string httpGet(int port, const char* path, std::string& status)
+{
+  const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  if (::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) != 0)
+  {
+    ::close(fd);
+    status = "CONNFAIL";
+    return {};
+  }
+  std::string req = std::string("GET ") + path + " HTTP/1.1\r\nHost: x\r\n\r\n";
+  ::write(fd, req.data(), req.size());
+  timeval tv{1, 0};
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+  std::string resp;
+  char buf[4096];
+  for (;;)
+  {
+    const ssize_t r = ::read(fd, buf, sizeof buf);
+    if (r <= 0)
+    {
+      break;
+    }
+    resp.append(buf, static_cast<size_t>(r));
+  }
+  ::close(fd);
+  const size_t nl = resp.find("\r\n");
+  status = (nl == std::string::npos) ? resp : resp.substr(0, nl);
+  const size_t body = resp.find("\r\n\r\n");
+  return body == std::string::npos ? std::string{} : resp.substr(body + 4);
+}
+
+void test_server()
+{
+  std::printf("test_metrics_server\n");
+  const Metrics m = sampleMetrics();
+  std::atomic<bool> ready{false};
+  MetricsServer srv([&]
+                    { return prom::render(m); }, [&]
+                    { return ready.load(); });
+  const int port = srv.start(0);
+  CHECK(port > 0);
+
+  std::string st;
+  const std::string metrics = httpGet(port, "/metrics", st);
+  CHECK(contains(st, "200 OK"));
+  CHECK(contains(metrics, "fme_trades_total 1"));
+
+  const std::string health = httpGet(port, "/healthz", st);
+  CHECK(contains(st, "200 OK"));
+  CHECK(contains(health, "ok"));
+
+  // Not ready yet -> 503.
+  httpGet(port, "/readyz", st);
+  CHECK(contains(st, "503"));
+
+  // Flip to ready -> 200.
+  ready.store(true);
+  const std::string rz = httpGet(port, "/readyz", st);
+  CHECK(contains(st, "200 OK"));
+  CHECK(contains(rz, "ready"));
+
+  // Unknown path -> 404.
+  httpGet(port, "/nope", st);
+  CHECK(contains(st, "404"));
+
+  srv.stop();
+}
+
+}  // namespace
+
+TEST(Metrics, EngineSuite)
+{
+  test_renderer();
+  test_gauges();
+  test_server();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_mm.cpp
+++ b/venue/tests/test_venue_mm.cpp
@@ -1,0 +1,286 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include "flox/backtest/fee_schedule.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg(int64_t llWindow = 0)
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  c.lastLookWindowNs = llWindow;
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+struct Cap
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+  int trades() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<Trade>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  template <class T>
+  int count() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<T>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  const FillHeld* firstHeld() const
+  {
+    for (auto& e : ev)
+    {
+      if (auto* h = std::get_if<FillHeld>(&e))
+      {
+        return h;
+      }
+    }
+    return nullptr;
+  }
+};
+
+void test_last_look()
+{
+  std::printf("test_last_look\n");
+  {  // accept
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(/*window*/ 1000), cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+    CHECK(cap.trades() == 0);  // held, not traded
+    CHECK(cap.count<FillHeld>() == 1);
+    const auto* h = cap.firstHeld();
+    CHECK(h && h->qty == qty(3));
+    eng.submit(InboundCommand{LastLookDecision{h->heldId, SYM, true, 1}}, 2);
+    CHECK(cap.trades() == 1);  // accepted -> traded
+  }
+  {  // reject
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(1000), cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+    const auto* h = cap.firstHeld();
+    eng.submit(InboundCommand{LastLookDecision{h->heldId, SYM, false, 1}}, 2);
+    CHECK(cap.trades() == 0);
+    CHECK(cap.count<FillRejected>() == 1);
+  }
+  {  // timeout -> reject (acceptOnTimeout defaults false)
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(1000), cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // deadline 1001
+    eng.submit(InboundCommand{CancelOrder{999, SYM, 1}}, 5000);     // past deadline -> expire
+    CHECK(cap.trades() == 0);
+    CHECK(cap.count<FillRejected>() == 1);
+  }
+}
+
+// Last-look reject/timeout must return BOTH parties' held buying power to
+// available -- otherwise it is stranded in `reserved` forever and the taker is
+// never made whole for a fill that never happened.
+void test_last_look_reject_releases_reservation()
+{
+  std::printf("test_last_look_reject_releases_reservation\n");
+  constexpr AssetId BASE = 0, QUOTE = 1;
+  constexpr uint64_t VENUE = 999;
+  const Amount base3 = amountOf(qty(3));
+  const Amount usd300 = amountOf(Volume::fromDouble(300));
+  Ledger led;
+  led.deposit(1, BASE, base3);    // maker: 3 BTC
+  led.deposit(2, QUOTE, usd300);  // taker: 300 USD
+  auto c = cfg(/*window*/ 1000);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(c, cap.sink());
+  eng.setLedger(&led, VENUE);
+  NewOrder mk = limit(1, Side::SELL, 100, 3, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);                              // maker reserves 3 BTC
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // taker reserves 300 USD; held 3
+  const auto* h = cap.firstHeld();
+  CHECK(h != nullptr);
+  eng.submit(InboundCommand{LastLookDecision{h->heldId, SYM, false, 1}}, 2);  // reject
+  CHECK(cap.trades() == 0);
+  // Both parties fully made whole: reservations returned, no fill happened.
+  CHECK(led.available(1, BASE) == base3 && led.reserved(1, BASE) == 0);     // maker
+  CHECK(led.available(2, QUOTE) == usd300 && led.reserved(2, QUOTE) == 0);  // taker
+  // Conservation: nothing created or destroyed.
+  CHECK(led.total(1, BASE) == base3);
+  CHECK(led.total(2, QUOTE) == usd300);
+}
+
+void test_mmp()
+{
+  std::printf("test_mmp\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  eng.setMmp(/*account*/ 1, /*qtyLimit*/ qty(10), /*windowNs*/ 1000);
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 20, 1)}, 0);  // MM rests 20
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 11, 2)}, 1);   // fills 11 from acct 1 -> breach
+  CHECK(cap.count<MmpTriggered>() == 1);
+  CHECK(eng.book().empty());  // account 1's remaining 9 was pulled
+}
+
+void test_mass_cancel()
+{
+  std::printf("test_mass_cancel\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5, 1)}, 0);
+  eng.submit(InboundCommand{limit(2, Side::SELL, 101, 3, 1)}, 1);
+  eng.submit(InboundCommand{limit(3, Side::BUY, 99, 2, 1)}, 2);
+  eng.submit(InboundCommand{MassCancel{1, SYM}}, 3);
+  CHECK(cap.count<OrderCanceled>() == 3);
+  CHECK(eng.book().empty());
+}
+
+void test_quote()
+{
+  std::printf("test_quote\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  eng.submit(InboundCommand{Quote{10, 11, SYM, px(99), qty(5), px(101), qty(5), 1}}, 0);
+  CHECK(eng.book().bestBid() == px(99));
+  CHECK(eng.book().bestAsk() == px(101));
+  // replace: tighter quote
+  eng.submit(InboundCommand{Quote{10, 11, SYM, px(99.5), qty(4), px(100.5), qty(4), 1}}, 1);
+  CHECK(eng.book().bestBid() == px(99.5));
+  CHECK(eng.book().bestAsk() == px(100.5));
+}
+
+void test_fees()
+{
+  std::printf("test_fees\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  flox::FeeSchedule fs;
+  fs.addTier(0.0, /*makerBps*/ -1.0, /*takerBps*/ 5.0);  // maker rebate, taker fee
+  eng.setFeeSchedule(fs);
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5, 1)}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // trade notional 300
+  double makerFee = 1e18, takerFee = 1e18;
+  for (auto& e : cap.ev)
+  {
+    if (auto* f = std::get_if<FeeCharged>(&e))
+    {
+      if (f->maker)
+      {
+        makerFee = f->fee.toDouble();
+      }
+      else
+      {
+        takerFee = f->fee.toDouble();
+      }
+    }
+  }
+  CHECK(makerFee < 0.0);  // rebate
+  CHECK(takerFee > 0.0);  // fee
+}
+
+void test_credit()
+{
+  std::printf("test_credit\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  // Reject any order whose notional exceeds 1000 (toy buying-power gate).
+  eng.setCreditCheck([](uint64_t, Side, Price p, Quantity q)
+                     { return (p * q).toDouble() <= 1000.0; });
+  eng.submit(InboundCommand{limit(1, Side::BUY, 100, 20, 1)}, 0);  // notional 2000 -> reject
+  CHECK(cap.count<OrderRejected>() == 1);
+  cap.ev.clear();
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 5, 1)}, 1);  // notional 500 -> ok
+  CHECK(cap.count<OrderAccepted>() == 1);
+}
+
+}  // namespace
+
+TEST(Mm, EngineSuite)
+{
+  test_last_look();
+  test_last_look_reject_releases_reservation();
+  test_mmp();
+  test_mass_cancel();
+  test_quote();
+  test_fees();
+  test_credit();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_multi_symbol_soak.cpp
+++ b/venue/tests/test_venue_multi_symbol_soak.cpp
@@ -1,0 +1,229 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/ledger.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/symbol_router.h"
+#include "flox/book/matching_book.h"
+
+#include "flox/backtest/fee_schedule.h"
+
+#include <gtest/gtest.h>
+#include <array>
+#include <cstdint>
+
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr AssetId QUOTE = 0;
+constexpr uint64_t VENUE = 500;
+constexpr int NACCT = 6;
+constexpr int NSYM = 3;
+// Symbol s uses base asset (s) and the shared quote asset.
+constexpr std::array<SymbolId, NSYM> SYMS = {101, 102, 103};
+constexpr std::array<AssetId, NSYM> BASES = {1, 2, 3};
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount base(double v) { return amountOf(qty(v)); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+
+struct Rng
+{
+  uint64_t s;
+  uint64_t next()
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  }
+};
+
+SymbolConfig cfg(SymbolId id, AssetId baseAsset)
+{
+  SymbolConfig c;
+  c.id = id;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50);
+  c.maxPrice = px(150);
+  c.baseAsset = baseAsset;
+  c.quoteAsset = QUOTE;
+  return c;
+}
+
+void test_soak()
+{
+  std::printf("test_multi_symbol_soak\n");
+  Ledger led;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    led.deposit(a, QUOTE, quote(1000000));
+    for (int s = 0; s < NSYM; ++s)
+    {
+      led.deposit(a, BASES[s], base(10000));
+    }
+  }
+  const Amount initQuote = quote(1000000) * NACCT;
+  const Amount initBase = base(10000) * NACCT;
+
+  Metrics metrics;
+  // One market-data publisher per symbol; kept in a stable container.
+  std::vector<std::unique_ptr<MarketDataPublisher<>>> mds;
+  for (int s = 0; s < NSYM; ++s)
+  {
+    mds.push_back(std::make_unique<MarketDataPublisher<>>([](const MdMessage&) {}, px(0.01), SYMS[s]));
+  }
+
+  SymbolRouter<MatchingBook> router(NSYM);
+  std::array<MatchingEngine<MatchingBook>*, NSYM> engines{};
+  for (int s = 0; s < NSYM; ++s)
+  {
+    MarketDataPublisher<>* md = mds[s].get();
+    auto& eng = router.addSymbol(cfg(SYMS[s], BASES[s]), [&metrics, md](const OutboundEvent& e)
+                                 {
+                                   metrics.observe(e);
+                                   md->onEvent(e); });
+    flox::FeeSchedule fs;
+    fs.addTier(0.0, -1.0, 2.0);  // maker rebate / taker fee -> venue nets fees
+    eng.setFeeSchedule(fs);
+    eng.setLedger(&led, VENUE);
+    engines[s] = &eng;
+  }
+
+  auto assetConserved = [&](AssetId asset, Amount init)
+  {
+    Amount t = led.total(VENUE, asset);
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, asset);
+    }
+    return t == init;
+  };
+
+  Rng rng{0x5EED1234ABULL};
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  std::array<OrderId, NSYM> nextId{};
+  for (int s = 0; s < NSYM; ++s)
+  {
+    nextId[s] = 1;
+  }
+  int breaches = 0;
+
+  const int OPS = 150000;
+  for (int i = 0; i < OPS; ++i)
+  {
+    const uint64_t r = rng.next();
+    const int s = static_cast<int>((r >> 3) % NSYM);
+    const uint32_t kind = r % 100;
+    if (kind < 15 && nextId[s] > 1)
+    {
+      const OrderId victim = 1 + (rng.next() % (nextId[s] - 1));
+      // encode a per-symbol unique id space: id = sym-local; router uses symbol
+      router.submit(InboundCommand{CancelOrder{victim + static_cast<OrderId>(s) * 10000000, SYMS[s], 0}});
+    }
+    else
+    {
+      NewOrder o;
+      o.id = nextId[s]++ + static_cast<OrderId>(s) * 10000000;
+      o.symbol = SYMS[s];
+      o.side = (r & 1) ? Side::BUY : Side::SELL;
+      o.accountId = 1 + (r >> 8) % NACCT;
+      const int ticks = static_cast<int>((r >> 1) % 101) - 50;
+      o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+      o.quantity = qty(1.0 + static_cast<double>((r >> 20) % 5));
+      o.type = (kind < 25) ? OrderType::MARKET : OrderType::LIMIT;
+      router.submit(InboundCommand{o});
+    }
+
+    if (!assetConserved(QUOTE, initQuote))
+    {
+      ++breaches;
+    }
+    for (int k = 0; k < NSYM; ++k)
+    {
+      if (!assetConserved(BASES[k], initBase))
+      {
+        ++breaches;
+      }
+    }
+    if (breaches == 1)
+    {
+      std::printf("  first breach at op %d\n", i);
+    }
+  }
+
+  CHECK(breaches == 0);
+  CHECK(metrics.trades > 0);
+  std::printf("  %d ops across %d symbols: trades=%llu, breaches=%d\n", OPS, NSYM,
+              (unsigned long long)metrics.trades, breaches);
+
+  // Market data agrees with each engine's book, and books are well-formed.
+  for (int s = 0; s < NSYM; ++s)
+  {
+    CHECK(engines[s]->book().bestBid() == mds[s]->book().bestBid());
+    CHECK(engines[s]->book().bestAsk() == mds[s]->book().bestAsk());
+    const auto bb = engines[s]->book().bestBid();
+    const auto ba = engines[s]->book().bestAsk();
+    if (bb.has_value() && ba.has_value())
+    {
+      CHECK(bb.value() < ba.value());
+    }
+  }
+
+  // Cross-shard account snapshot: the router aggregates each symbol where an
+  // account is active, and the total resting-order count across the router's
+  // snapshots equals the sum of every engine's resting orders.
+  uint64_t routerResting = 0;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    for (const auto& [sym, snap] : router.snapshotAccount(a))
+    {
+      (void)sym;
+      routerResting += snap.openOrders.size();
+    }
+  }
+  uint64_t engineResting = 0;
+  for (int s = 0; s < NSYM; ++s)
+  {
+    engineResting += engines[s]->restingOrderCount();
+  }
+  CHECK(routerResting == engineResting);  // snapshots account for every live order
+}
+
+}  // namespace
+
+TEST(MultiSymbolSoak, EngineSuite)
+{
+  test_soak();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_network.cpp
+++ b/venue/tests/test_venue_network.cpp
@@ -1,0 +1,714 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/control_api.h"
+#include "flox-venue/control_plane.h"
+#include "flox-venue/control_server.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/ouch_codec.h"
+#include "flox-venue/rest_json.h"
+#include "flox-venue/session.h"
+#include "flox-venue/tcp_gateway.h"
+#include "flox-venue/udp_multicast.h"
+#include "flox-venue/ws_gateway.h"
+#include "flox/book/matching_book.h"
+#include "flox/util/crypto.h"
+#include "flox/util/websocket.h"
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <chrono>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+NewOrder mk(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+void test_session()
+{
+  std::printf("test_session\n");
+  flox::RateLimitPolicy limits;
+  limits.addBucket("t", 1'000'000'000, 3);  // 3 actions / 1s window
+  GatewaySession s(7, [](const uint8_t* p, size_t n)
+                   { return OuchCodec::decode(p, n); }, limits);
+
+  std::vector<uint8_t> buf;
+  OuchCodec::encode(InboundCommand{mk(1, Side::BUY, 100, 1)}, buf);
+
+  SessionReject rej{};
+  CHECK(!s.handle(buf.data(), buf.size(), 1000, rej).has_value());
+  CHECK(rej == SessionReject::Unauthenticated);
+
+  s.authenticate(true);
+  CHECK(s.handle(buf.data(), buf.size(), 1000, rej).has_value());
+  CHECK(s.handle(buf.data(), buf.size(), 1000, rej).has_value());
+  CHECK(s.handle(buf.data(), buf.size(), 1000, rej).has_value());
+  CHECK(!s.handle(buf.data(), buf.size(), 1000, rej).has_value());  // 4th within window
+  CHECK(rej == SessionReject::RateLimited);
+
+  uint8_t junk[3] = {0xFF, 0x00, 0x11};
+  CHECK(!s.handle(junk, sizeof junk, 2'000'000'000, rej).has_value());  // next window
+  CHECK(rej == SessionReject::DecodeError);
+}
+
+void test_tcp_gateway()
+{
+  std::printf("test_tcp_gateway\n");
+  std::mutex m;
+  TcpGateway::Responder currentResp;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     std::vector<uint8_t> b;
+                                     OuchCodec::encode(e, b);
+                                     if (!b.empty() && currentResp){ currentResp(b.data(), b.size());
+} });
+
+  TcpGateway gw([](const uint8_t* p, size_t n)
+                { return OuchCodec::decode(p, n); });
+  const int port = gw.start(0, [&](const InboundCommand& c, const TcpGateway::Responder& r)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              currentResp = r;
+                              eng.submit(c);
+                              currentResp = {}; });
+  CHECK(port > 0);
+  if (port <= 0)
+  {
+    return;
+  }
+
+  const int c = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  CHECK(::connect(c, reinterpret_cast<sockaddr*>(&a), sizeof a) == 0);
+
+  auto sendCmd = [&](const InboundCommand& cmd)
+  {
+    std::vector<uint8_t> b;
+    OuchCodec::encode(cmd, b);
+    net::writeFrame(c, b.data(), b.size());
+  };
+  sendCmd(InboundCommand{mk(1, Side::SELL, 100, 5, 1)});
+  sendCmd(InboundCommand{mk(2, Side::BUY, 100, 3, 2)});
+
+  timeval tv{1, 0};
+  ::setsockopt(c, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+  std::set<uint8_t> tags;
+  std::vector<uint8_t> frame;
+  while (net::readFrame(c, frame))
+  {
+    if (!frame.empty())
+    {
+      tags.insert(frame[0]);
+    }
+    if (tags.count(static_cast<uint8_t>(OuchOut::Accepted)) &&
+        tags.count(static_cast<uint8_t>(OuchOut::Trade)) &&
+        tags.count(static_cast<uint8_t>(OuchOut::Executed)))
+    {
+      break;
+    }
+  }
+  ::close(c);
+  gw.stop();
+
+  CHECK(tags.count(static_cast<uint8_t>(OuchOut::Accepted)) == 1);
+  CHECK(tags.count(static_cast<uint8_t>(OuchOut::Trade)) == 1);
+  CHECK(tags.count(static_cast<uint8_t>(OuchOut::Executed)) == 1);
+}
+
+int deliverOverUdp(bool multicast)
+{
+  const char* group = "239.7.7.7";
+  UdpMdSubscriber sub;
+  if (!sub.join(group, 0, multicast))
+  {
+    return -1;
+  }
+  sub.setTimeout(300);
+  UdpMdPublisher pub;
+  if (!pub.open(multicast ? group : "127.0.0.1", static_cast<uint16_t>(sub.port()), multicast))
+  {
+    return -1;
+  }
+
+  constexpr int K = 5;
+  for (int i = 1; i <= K; ++i)
+  {
+    pub.publish(MdMessage{MdType::Trade, static_cast<uint64_t>(i), SYM, static_cast<uint64_t>(i),
+                          Side::BUY, px(100 + i), qty(i), 0});
+  }
+
+  int got = 0;
+  MdMessage m;
+  while (got < K && sub.recv(m))
+  {
+    const int i = static_cast<int>(m.id);
+    if (m.type == MdType::Trade && m.price == px(100 + i) && m.qty == qty(i))
+    {
+      ++got;
+    }
+  }
+  return got;
+}
+
+void test_udp_md()
+{
+  std::printf("test_udp_md\n");
+  int got = deliverOverUdp(/*multicast*/ true);
+  const char* path = "multicast";
+  if (got <= 0)
+  {
+    got = deliverOverUdp(/*multicast*/ false);  // fallback where multicast is blocked
+    path = "unicast";
+  }
+  std::printf("  UDP MD delivered %d/5 via %s\n", got, path);
+  CHECK(got > 0);
+}
+
+// A session bound to a real account must force THAT account onto every command,
+// so a client cannot act as another account by writing a different id into the
+// payload. An unbound (account 0 / trusted-transport) session passes through.
+void test_session_account_binding()
+{
+  std::printf("test_session_account_binding\n");
+  auto dec = [](const uint8_t* p, size_t n)
+  { return OuchCodec::decode(p, n); };
+
+  // Bound to account 7; the wire order claims account 1 -> must be stamped to 7.
+  GatewaySession bound(7, dec);
+  bound.authenticate(true);
+  std::vector<uint8_t> buf;
+  OuchCodec::encode(InboundCommand{mk(1, Side::BUY, 100, 1, /*acct*/ 1)}, buf);
+  SessionReject rej{};
+  auto cmd = bound.handle(buf.data(), buf.size(), 1000, rej);
+  CHECK(cmd.has_value());
+  const auto* no = std::get_if<NewOrder>(&*cmd);
+  CHECK(no != nullptr);
+  CHECK(no->accountId == 7);  // client-supplied 1 overridden by the session account
+
+  // Unbound session (account 0): the client-supplied account passes through.
+  GatewaySession open(0, dec);
+  open.authenticate(true);
+  std::vector<uint8_t> buf2;
+  OuchCodec::encode(InboundCommand{mk(2, Side::BUY, 100, 1, /*acct*/ 1)}, buf2);
+  auto cmd2 = open.handle(buf2.data(), buf2.size(), 1000, rej);
+  CHECK(cmd2.has_value());
+  const auto* no2 = std::get_if<NewOrder>(&*cmd2);
+  CHECK(no2 != nullptr && no2->accountId == 1);  // trusted passthrough
+}
+
+void test_logon()
+{
+  std::printf("test_logon\n");
+  const std::string secret = "topsecret";
+  auto dec = [](const uint8_t* p, size_t n)
+  { return OuchCodec::decode(p, n); };
+  const std::string apiKey = "key123";
+  const uint64_t ts = 1000;
+  const std::string payload = apiKey + ":" + std::to_string(ts);
+  const auto mac = crypto::hmacSha256(reinterpret_cast<const uint8_t*>(secret.data()), secret.size(),
+                                      reinterpret_cast<const uint8_t*>(payload.data()),
+                                      payload.size());
+  const std::string sig = crypto::toHex(mac.data(), mac.size());
+
+  GatewaySession s(7, dec, flox::RateLimitPolicy::binance_um_futures(), secret);
+  CHECK(!s.authenticated());
+  CHECK(s.logon(apiKey, ts, sig, 1002));  // within skew
+  CHECK(s.authenticated());
+
+  GatewaySession s2(7, dec, flox::RateLimitPolicy::binance_um_futures(), secret);
+  CHECK(!s2.logon(apiKey, ts, "deadbeef", 1002));  // bad signature
+  CHECK(!s2.authenticated());
+
+  GatewaySession s3(7, dec, flox::RateLimitPolicy::binance_um_futures(), secret);
+  CHECK(!s3.logon(apiKey, ts, sig, 2000));  // skew 1000s > 5s
+}
+
+void test_websocket()
+{
+  std::printf("test_websocket\n");
+  CHECK(ws::acceptKey("dGhlIHNhbXBsZSBub25jZQ==") == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+  const std::string req =
+      "GET /ws HTTP/1.1\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n";
+  const std::string resp = ws::handshakeResponse(req);
+  CHECK(resp.find("101 Switching Protocols") != std::string::npos);
+  CHECK(resp.find("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=") != std::string::npos);
+
+  const char* txt = "{\"a\":1}";
+  auto f = ws::buildFrame(ws::Opcode::Text, reinterpret_cast<const uint8_t*>(txt), 7);
+  ws::Opcode op{};
+  std::vector<uint8_t> pl;
+  CHECK(ws::parseFrame(f.data(), f.size(), op, pl) == f.size());
+  CHECK(op == ws::Opcode::Text && std::string(pl.begin(), pl.end()) == "{\"a\":1}");
+
+  // masked client frame ("abc")
+  std::vector<uint8_t> mf = {0x81, static_cast<uint8_t>(0x80 | 3)};
+  const uint8_t mask[4] = {1, 2, 3, 4};
+  for (int i = 0; i < 4; ++i)
+  {
+    mf.push_back(mask[i]);
+  }
+  const char* abc = "abc";
+  for (int i = 0; i < 3; ++i)
+  {
+    mf.push_back(static_cast<uint8_t>(abc[i] ^ mask[i & 3]));
+  }
+  CHECK(ws::parseFrame(mf.data(), mf.size(), op, pl) == mf.size());
+  CHECK(std::string(pl.begin(), pl.end()) == "abc");
+
+  // Hostile 64-bit extended length that OVERFLOWS off + len: 0x82 FIN+Binary,
+  // 0x7F = length code 127, then len = 2^64 - 9. Naively `n < off + len` wraps to
+  // a tiny value and the guard is bypassed -> resize(~2^64) crash. Must instead
+  // be rejected as a protocol error (kParseError), never a crash or a 0.
+  std::vector<uint8_t> ovf = {0x82, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF7};
+  CHECK(ws::parseFrame(ovf.data(), ovf.size(), op, pl) == ws::kParseError);
+
+  // Oversized-but-not-overflowing length (above kMaxFramePayload) is also
+  // rejected before allocation, not buffered forever.
+  std::vector<uint8_t> big = {0x82, 0x7F, 0, 0, 0, 0, 0x10, 0, 0, 0};  // len = 0x10000000 = 256 MiB
+  CHECK(ws::parseFrame(big.data(), big.size(), op, pl) == ws::kParseError);
+
+  // A well-formed but not-yet-complete frame still returns 0 (need more bytes),
+  // NOT an error: 4-byte payload declared, only 2 delivered.
+  std::vector<uint8_t> partial = {0x82, 0x04, 0xAA, 0xBB};
+  CHECK(ws::parseFrame(partial.data(), partial.size(), op, pl) == 0);
+
+  // Binary/TLS length-prefix path: a u32 prefix beyond net::kMaxFrame must make
+  // readFrame reject rather than resize() up to 4 GiB. Drive it through a pipe.
+  {
+    int fds[2];
+    CHECK(::pipe(fds) == 0);
+    const uint8_t hostileHdr[4] = {0xFF, 0xFF, 0xFF, 0xFF};  // len = 4294967295
+    CHECK(::write(fds[1], hostileHdr, 4) == 4);
+    ::close(fds[1]);
+    std::vector<uint8_t> out;
+    CHECK(!net::readFrame(fds[0], out));  // rejected before allocation
+    ::close(fds[0]);
+  }
+}
+
+void test_control_server()
+{
+  std::printf("test_control_server\n");
+  InstrumentRegistry reg;
+  ControlApi api(reg);
+  ControlServer srv(api);
+  std::istringstream in(std::string(R"({"method":"listInstrument","symbol":1,"tick":0.01})") + "\n" +
+                        R"({"method":"list"})" + "\n");
+  std::ostringstream out;
+  srv.serve(in, out);
+  const std::string s = out.str();
+  CHECK(s.find("\"ok\":true") != std::string::npos);
+  CHECK(s.find("\"instruments\":[1]") != std::string::npos);
+}
+
+void test_tcp_control()
+{
+  std::printf("test_tcp_control\n");
+  InstrumentRegistry reg;
+  ControlApi api(reg);
+  TcpControlServer srv(api);
+  const int port = srv.start(0);
+  CHECK(port > 0);
+
+  const int c = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  ::connect(c, reinterpret_cast<sockaddr*>(&a), sizeof a);
+  timeval tv{1, 0};
+  ::setsockopt(c, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+
+  auto request = [&](const std::string& req) -> std::string
+  {
+    ::write(c, req.data(), req.size());
+    std::string resp;
+    char tb[512];
+    while (resp.find('\n') == std::string::npos)
+    {
+      const ssize_t r = ::read(c, tb, sizeof tb);
+      if (r <= 0)
+      {
+        break;
+      }
+      resp.append(tb, static_cast<size_t>(r));
+    }
+    return resp;
+  };
+
+  CHECK(request(R"({"method":"listInstrument","symbol":1,"tick":0.01})"
+                "\n")
+            .find("\"ok\":true") != std::string::npos);
+  CHECK(request(R"({"method":"list"})"
+                "\n")
+            .find("\"instruments\":[1]") != std::string::npos);
+  ::close(c);
+  srv.stop();
+}
+
+void test_md_snapshot()
+{
+  std::printf("test_md_snapshot\n");
+  MarketDataPublisher<> md([](const MdMessage&) {}, Price::fromDouble(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e); });
+  eng.submit(mk(1, Side::SELL, 100, 5));
+  eng.submit(mk(2, Side::SELL, 101, 3));
+  eng.submit(mk(3, Side::BUY, 99, 4));
+
+  const auto snap = md.snapshot();
+  CHECK(snap.size() == 3);
+  Quantity ask100{}, bid99{};
+  for (const auto& m : snap)
+  {
+    if (m.side == Side::SELL && m.price == px(100))
+    {
+      ask100 += m.qty;
+    }
+    if (m.side == Side::BUY && m.price == px(99))
+    {
+      bid99 += m.qty;
+    }
+  }
+  CHECK(ask100 == qty(5));
+  CHECK(bid99 == qty(4));
+  CHECK(md.book().askAtPrice(px(100)) == qty(5));  // snapshot agrees with live depth
+}
+
+std::vector<uint8_t> wsClientFrame(const std::string& s)
+{
+  std::vector<uint8_t> f;
+  f.push_back(0x81);  // FIN + Text
+  const size_t n = s.size();
+  const uint8_t mask[4] = {0x11, 0x22, 0x33, 0x44};
+  if (n < 126)
+  {
+    f.push_back(static_cast<uint8_t>(0x80 | n));
+  }
+  else
+  {
+    f.push_back(0x80 | 126);
+    f.push_back(static_cast<uint8_t>(n >> 8));
+    f.push_back(static_cast<uint8_t>(n));
+  }
+  for (int i = 0; i < 4; ++i)
+  {
+    f.push_back(mask[i]);
+  }
+  for (size_t i = 0; i < n; ++i)
+  {
+    f.push_back(static_cast<uint8_t>(s[i] ^ mask[i & 3]));
+  }
+  return f;
+}
+
+void test_ws_gateway()
+{
+  std::printf("test_ws_gateway\n");
+  std::mutex m;
+  WsGateway::Responder currentResp;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     const std::string j = RestJson::encode(e);
+                                     if (!j.empty() && currentResp){
+                                       currentResp(reinterpret_cast<const uint8_t*>(j.data()), j.size());
+} });
+  WsGateway gw([](const uint8_t* p, size_t n)
+               { return RestJson::decode(std::string(reinterpret_cast<const char*>(p), n)); });
+  const int port = gw.start(0, [&](const InboundCommand& c, const WsGateway::Responder& r)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              currentResp = r;
+                              eng.submit(c);
+                              currentResp = {}; });
+  CHECK(port > 0);
+
+  const int c = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  ::connect(c, reinterpret_cast<sockaddr*>(&a), sizeof a);
+  timeval tv{1, 0};
+  ::setsockopt(c, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+
+  const std::string hs =
+      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+  ::write(c, hs.data(), hs.size());
+
+  std::string resp;
+  uint8_t tb[2048];
+  while (resp.find("\r\n\r\n") == std::string::npos)
+  {
+    const ssize_t r = ::read(c, tb, sizeof tb);
+    if (r <= 0)
+    {
+      break;
+    }
+    resp.append(reinterpret_cast<char*>(tb), static_cast<size_t>(r));
+  }
+  CHECK(resp.find("101 Switching Protocols") != std::string::npos);
+
+  auto sell = wsClientFrame(
+      R"({"action":"new","id":1,"symbol":1,"side":"sell","ordType":"limit","qty":5,"price":100})");
+  ::write(c, sell.data(), sell.size());
+  auto buy = wsClientFrame(
+      R"({"action":"new","id":2,"symbol":1,"side":"buy","ordType":"limit","qty":3,"price":100,"account":2})");
+  ::write(c, buy.data(), buy.size());
+
+  std::vector<uint8_t> buf;
+  std::string all;
+  for (int iter = 0; iter < 50 && all.find("\"type\":\"trade\"") == std::string::npos; ++iter)
+  {
+    const ssize_t r = ::read(c, tb, sizeof tb);
+    if (r <= 0)
+    {
+      break;
+    }
+    buf.insert(buf.end(), tb, tb + r);
+    ws::Opcode op{};
+    std::vector<uint8_t> pl;
+    size_t cons;
+    while ((cons = ws::parseFrame(buf.data(), buf.size(), op, pl)) > 0)
+    {
+      buf.erase(buf.begin(), buf.begin() + static_cast<std::ptrdiff_t>(cons));
+      if (op == ws::Opcode::Text)
+      {
+        all.append(pl.begin(), pl.end());
+      }
+    }
+  }
+  ::close(c);
+  gw.stop();
+  CHECK(all.find("\"type\":\"trade\"") != std::string::npos);  // WS round-trip produced a trade
+}
+
+void test_cancel_on_disconnect()
+{
+  std::printf("test_cancel_on_disconnect\n");
+  std::mutex m;
+  TcpGateway::Responder currentResp;
+  std::vector<OutboundEvent> events;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     events.push_back(e);
+                                     std::vector<uint8_t> b;
+                                     OuchCodec::encode(e, b);
+                                     if (!b.empty() && currentResp){ currentResp(b.data(), b.size());
+} });
+
+  TcpGateway gw([](const uint8_t* p, size_t n)
+                { return OuchCodec::decode(p, n); });
+  gw.setCancelOnDisconnect(true);
+  const int port = gw.start(0, [&](const InboundCommand& c, const TcpGateway::Responder& r)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              currentResp = r;
+                              eng.submit(c);
+                              currentResp = {}; });
+  CHECK(port > 0);
+
+  const int c = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  ::connect(c, reinterpret_cast<sockaddr*>(&a), sizeof a);
+
+  std::vector<uint8_t> b;
+  OuchCodec::encode(InboundCommand{mk(1, Side::SELL, 100, 5, 3)}, b);
+  net::writeFrame(c, b.data(), b.size());
+
+  timeval tv{1, 0};
+  ::setsockopt(c, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+  std::vector<uint8_t> frame;
+  net::readFrame(c, frame);  // wait for the Accepted report -> order is resting
+  ::close(c);
+  gw.stop();  // joins the conn thread -> disconnect -> cancel-on-disconnect fires
+
+  CHECK(eng.book().empty());  // the resting order was canceled on disconnect
+  bool canceled = false;
+  for (const auto& e : events)
+  {
+    if (const auto* x = std::get_if<OrderCanceled>(&e); x && x->id == 1)
+    {
+      canceled = true;
+    }
+  }
+  CHECK(canceled);
+}
+
+void test_ws_cancel_on_disconnect()
+{
+  std::printf("test_ws_cancel_on_disconnect\n");
+  std::mutex m;
+  WsGateway::Responder currentResp;
+  std::vector<OutboundEvent> events;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     events.push_back(e);
+                                     const std::string j = RestJson::encode(e);
+                                     if (!j.empty() && currentResp){
+                                       currentResp(reinterpret_cast<const uint8_t*>(j.data()), j.size());
+} });
+  WsGateway gw([](const uint8_t* p, size_t n)
+               { return RestJson::decode(std::string(reinterpret_cast<const char*>(p), n)); });
+  gw.setCancelOnDisconnect(true);
+  const int port = gw.start(0, [&](const InboundCommand& c, const WsGateway::Responder& r)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              currentResp = r;
+                              eng.submit(c);
+                              currentResp = {}; });
+  CHECK(port > 0);
+
+  const int c = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  ::connect(c, reinterpret_cast<sockaddr*>(&a), sizeof a);
+  timeval tv{1, 0};
+  ::setsockopt(c, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+
+  const std::string hs =
+      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+  ::write(c, hs.data(), hs.size());
+  std::string resp;
+  uint8_t tb[2048];
+  while (resp.find("\r\n\r\n") == std::string::npos)
+  {
+    const ssize_t r = ::read(c, tb, sizeof tb);
+    if (r <= 0)
+    {
+      break;
+    }
+    resp.append(reinterpret_cast<char*>(tb), static_cast<size_t>(r));
+  }
+
+  auto sell = wsClientFrame(
+      R"({"action":"new","id":1,"symbol":1,"side":"sell","ordType":"limit","qty":5,"price":100,"account":3})");
+  ::write(c, sell.data(), sell.size());
+
+  std::vector<uint8_t> buf;
+  bool accepted = false;
+  for (int iter = 0; iter < 50 && !accepted; ++iter)
+  {
+    const ssize_t r = ::read(c, tb, sizeof tb);
+    if (r <= 0)
+    {
+      break;
+    }
+    buf.insert(buf.end(), tb, tb + r);
+    ws::Opcode op{};
+    std::vector<uint8_t> pl;
+    size_t cons;
+    while ((cons = ws::parseFrame(buf.data(), buf.size(), op, pl)) > 0)
+    {
+      buf.erase(buf.begin(), buf.begin() + static_cast<std::ptrdiff_t>(cons));
+      if (op == ws::Opcode::Text &&
+          std::string(pl.begin(), pl.end()).find("accepted") != std::string::npos)
+      {
+        accepted = true;
+      }
+    }
+  }
+  CHECK(accepted);  // order is resting
+  ::close(c);
+  gw.stop();  // disconnect -> cancel-on-disconnect fires over WebSocket
+
+  CHECK(eng.book().empty());
+  bool canceled = false;
+  for (const auto& e : events)
+  {
+    if (const auto* x = std::get_if<OrderCanceled>(&e); x && x->id == 1)
+    {
+      canceled = true;
+    }
+  }
+  CHECK(canceled);
+}
+
+}  // namespace
+
+TEST(Network, EngineSuite)
+{
+  test_session();
+  test_session_account_binding();
+  test_logon();
+  test_websocket();
+  test_control_server();
+  test_tcp_control();
+  test_md_snapshot();
+  test_tcp_gateway();
+  test_ws_gateway();
+  test_cancel_on_disconnect();
+  test_ws_cancel_on_disconnect();
+  test_udp_md();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_parser_fuzz.cpp
+++ b/venue/tests/test_venue_parser_fuzz.cpp
@@ -1,0 +1,333 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/fix_codec.h"
+#include "flox-venue/itch_codec.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/ouch_codec.h"
+#include "flox-venue/rest_json.h"
+#include "flox/util/websocket.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+struct Rng
+{
+  uint64_t s;
+  uint64_t next()
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  }
+};
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+NewOrder sampleOrder()
+{
+  NewOrder o;
+  o.id = 42;
+  o.symbol = 1;
+  o.side = Side::BUY;
+  o.type = OrderType::LIMIT;
+  o.price = px(100);
+  o.quantity = qty(5);
+  o.accountId = 7;
+  return o;
+}
+
+void test_ouch_fuzz()
+{
+  std::printf("test_ouch_parser_fuzz\n");
+  std::vector<uint8_t> wire;
+  OuchCodec::encode(InboundCommand{sampleOrder()}, wire);
+  CHECK(!wire.empty());
+
+  // Positive control: a valid frame round-trips.
+  auto ok = OuchCodec::decode(wire.data(), wire.size());
+  CHECK(ok.has_value());
+
+  Rng rng{0xF0F0F0F0ULL};
+
+  // Truncation: decode every prefix length (including 0). Must not crash.
+  for (size_t len = 0; len <= wire.size(); ++len)
+  {
+    auto d = OuchCodec::decode(wire.data(), len);
+    (void)d;
+  }
+
+  // Bit-flip corruption of the valid frame.
+  for (int i = 0; i < 200000; ++i)
+  {
+    std::vector<uint8_t> c = wire;
+    const size_t flips = 1 + (rng.next() % 4);
+    for (size_t f = 0; f < flips; ++f)
+    {
+      c[rng.next() % c.size()] ^= static_cast<uint8_t>(rng.next() & 0xFF);
+    }
+    auto d = OuchCodec::decode(c.data(), c.size());
+    (void)d;
+  }
+
+  // Pure random buffers of random length.
+  int decoded = 0;
+  for (int i = 0; i < 300000; ++i)
+  {
+    uint8_t buf[64];
+    const size_t n = rng.next() % 64;
+    for (size_t k = 0; k < n; ++k)
+    {
+      buf[k] = static_cast<uint8_t>(rng.next() & 0xFF);
+    }
+    auto d = OuchCodec::decode(buf, n);
+    if (d)
+    {
+      ++decoded;
+    }
+  }
+  CHECK(true);  // reached here without crashing
+  std::printf("  ouch survived truncation + 200k corruptions + 300k random (%d parsed)\n", decoded);
+}
+
+void test_fix_fuzz()
+{
+  std::printf("test_fix_parser_fuzz\n");
+  Rng rng{0xABCDEF01ULL};
+  const char* seeds[] = {
+      "8=FIX.4.4\x01"
+      "35=D\x01"
+      "11=1\x01"
+      "55=1\x01"
+      "54=1\x01"
+      "38=5\x01"
+      "44=100\x01"
+      "10=000\x01",
+      "8=FIX.4.4\x01"
+      "35=F\x01"
+      "11=2\x01"
+      "41=1\x01"
+      "10=000\x01",
+      "garbage-not-fix",
+      "",
+  };
+  for (const char* seed : seeds)
+  {
+    const std::string base(seed);
+    // Truncations.
+    for (size_t len = 0; len <= base.size(); ++len)
+    {
+      auto d = FixCodec::decode(base.substr(0, len));
+      (void)d;
+    }
+    // Corruptions + random junk.
+    for (int i = 0; i < 100000; ++i)
+    {
+      std::string c = base;
+      if (!c.empty())
+      {
+        const size_t flips = 1 + (rng.next() % 5);
+        for (size_t f = 0; f < flips; ++f)
+        {
+          c[rng.next() % c.size()] ^= static_cast<char>(rng.next() & 0x7F);
+        }
+      }
+      const size_t extra = rng.next() % 8;
+      for (size_t e = 0; e < extra; ++e)
+      {
+        c.push_back(static_cast<char>(rng.next() & 0xFF));
+      }
+      auto d = FixCodec::decode(c);
+      (void)d;
+    }
+  }
+  // Random ASCII with SOH separators.
+  for (int i = 0; i < 100000; ++i)
+  {
+    std::string s;
+    const size_t n = rng.next() % 40;
+    for (size_t k = 0; k < n; ++k)
+    {
+      const uint32_t c = rng.next() % 40;
+      s.push_back(c == 0 ? '\x01' : static_cast<char>('0' + (c % 74)));
+    }
+    auto d = FixCodec::decode(s);
+    (void)d;
+  }
+  CHECK(true);
+  std::printf("  fix survived truncation + corruption + random\n");
+}
+
+void test_rest_fuzz()
+{
+  std::printf("test_rest_parser_fuzz\n");
+  Rng rng{0x12345678ULL};
+  const char* seeds[] = {
+      R"({"action":"new","id":1,"symbol":1,"side":"buy","ordType":"limit","qty":5,"price":100})",
+      R"({"action":"cancel","id":1,"symbol":1})",
+      R"({"action":"new","id":1)",  // truncated
+      R"(not json at all)",
+      R"({})",
+      "",
+  };
+  for (const char* seed : seeds)
+  {
+    const std::string base(seed);
+    for (size_t len = 0; len <= base.size(); ++len)
+    {
+      auto d = RestJson::decode(base.substr(0, len));
+      (void)d;
+    }
+    for (int i = 0; i < 100000; ++i)
+    {
+      std::string c = base;
+      if (!c.empty())
+      {
+        const size_t flips = 1 + (rng.next() % 5);
+        for (size_t f = 0; f < flips; ++f)
+        {
+          c[rng.next() % c.size()] ^= static_cast<char>(rng.next() & 0x7F);
+        }
+      }
+      auto d = RestJson::decode(c);
+      (void)d;
+    }
+  }
+  // Random braces/quotes/digits soup.
+  const char* alphabet = "{}[]\":,0123456789abcstunew ";
+  for (int i = 0; i < 200000; ++i)
+  {
+    std::string s;
+    const size_t n = rng.next() % 60;
+    for (size_t k = 0; k < n; ++k)
+    {
+      s.push_back(alphabet[rng.next() % 27]);
+    }
+    auto d = RestJson::decode(s);
+    (void)d;
+  }
+  CHECK(true);
+  std::printf("  rest survived truncation + corruption + random soup\n");
+}
+
+void test_ws_fuzz()
+{
+  std::printf("test_ws_parser_fuzz\n");
+  // A valid text frame as the corruption/truncation seed.
+  const uint8_t payload[] = {'h', 'e', 'l', 'l', 'o'};
+  const std::vector<uint8_t> frame = ws::buildFrame(ws::Opcode::Text, payload, sizeof payload);
+
+  ws::Opcode op{};
+  std::vector<uint8_t> out;
+  for (size_t len = 0; len <= frame.size(); ++len)
+  {
+    ws::parseFrame(frame.data(), len, op, out);  // truncation: no OOB on short length fields
+  }
+
+  Rng rng{0x5151A1A1ULL};
+  for (int i = 0; i < 200000; ++i)
+  {
+    std::vector<uint8_t> c = frame;
+    const size_t flips = 1 + (rng.next() % 6);
+    for (size_t f = 0; f < flips; ++f)
+    {
+      c[rng.next() % c.size()] ^= static_cast<uint8_t>(rng.next() & 0xFF);
+    }
+    ws::parseFrame(c.data(), c.size(), op, out);
+  }
+  for (int i = 0; i < 300000; ++i)
+  {
+    uint8_t buf[80];
+    const size_t n = rng.next() % 80;
+    for (size_t k = 0; k < n; ++k)
+    {
+      buf[k] = static_cast<uint8_t>(rng.next() & 0xFF);
+    }
+    ws::parseFrame(buf, n, op, out);  // arbitrary lengths incl. 64-bit length headers
+  }
+
+  // Handshake HTTP header parsing.
+  const std::string hs =
+      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+  for (size_t len = 0; len <= hs.size(); ++len)
+  {
+    auto r = ws::handshakeResponse(hs.substr(0, len));
+    (void)r;
+  }
+  for (int i = 0; i < 50000; ++i)
+  {
+    std::string c = hs;
+    const size_t flips = 1 + (rng.next() % 8);
+    for (size_t f = 0; f < flips; ++f)
+    {
+      c[rng.next() % c.size()] ^= static_cast<char>(rng.next() & 0x7F);
+    }
+    auto r = ws::handshakeResponse(c);
+    (void)r;
+  }
+  CHECK(true);
+  std::printf("  ws survived truncation + corruption + random frames + handshake fuzz\n");
+}
+
+void test_itch_fuzz()
+{
+  std::printf("test_itch_parser_fuzz\n");
+  Rng rng{0x1DC4C0DEULL};
+  MdMessage m{};
+  for (int i = 0; i < 300000; ++i)
+  {
+    uint8_t buf[48];
+    const size_t n = rng.next() % 48;
+    for (size_t k = 0; k < n; ++k)
+    {
+      buf[k] = static_cast<uint8_t>(rng.next() & 0xFF);
+    }
+    ItchCodec::decode(buf, n, m);  // big-endian field reads on short/garbage buffers
+  }
+  CHECK(true);
+  std::printf("  itch survived random buffers\n");
+}
+
+}  // namespace
+
+TEST(ParserFuzz, EngineSuite)
+{
+  test_ouch_fuzz();
+  test_fix_fuzz();
+  test_rest_fuzz();
+  test_ws_fuzz();
+  test_itch_fuzz();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_perp.cpp
+++ b/venue/tests/test_venue_perp.cpp
@@ -1,0 +1,504 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId QUOTE = 1;  // collateral (USD)
+constexpr uint64_t VENUE = 999;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  c.quoteAsset = QUOTE;
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;  // 10% -> 10x
+  return c;
+}
+NewOrder ord(OrderId id, Side s, double p, double q, uint64_t acct, bool reduceOnly = false)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  o.reduceOnly = reduceOnly;
+  return o;
+}
+NewOrder stopMkt(OrderId id, Side s, double q, double trig, uint64_t acct, bool reduceOnly = false)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::STOP_MARKET;
+  o.quantity = qty(q);
+  o.triggerPrice = px(trig);
+  o.accountId = acct;
+  o.reduceOnly = reduceOnly;
+  return o;
+}
+
+void test_open_and_close()
+{
+  std::printf("test_perp_open_close\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(1000));
+  led.deposit(2, QUOTE, quote(1000));
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);   // IM 100
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);  // IM 100, trade 10@100
+
+  CHECK(eng.positionQty(1) == qty(10).raw());   // long 10
+  CHECK(eng.positionQty(2) == -qty(10).raw());  // short 10
+  CHECK(eng.positionEntry(1) == px(100));
+  CHECK(led.available(1, QUOTE) == quote(900) && led.reserved(1, QUOTE) == quote(100));
+
+  // Close both at 110: long +100 PnL, short -100 PnL, funded via the pool.
+  eng.submit(InboundCommand{ord(3, Side::SELL, 110, 10, 1, /*reduceOnly*/ true)}, 2);
+  eng.submit(InboundCommand{ord(4, Side::BUY, 110, 10, 2, /*reduceOnly*/ true)}, 3);
+
+  CHECK(eng.positionQty(1) == 0 && eng.positionQty(2) == 0);
+  CHECK(led.available(1, QUOTE) == quote(1100));  // +100 profit, margin returned
+  CHECK(led.available(2, QUOTE) == quote(900));   // -100 loss
+  CHECK(led.reserved(1, QUOTE) == 0 && led.reserved(2, QUOTE) == 0);
+  // Conservation across traders + clearing pool.
+  const Amount tot = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(tot == quote(2000));
+}
+
+void test_insufficient_margin()
+{
+  std::printf("test_perp_insufficient_margin\n");
+  Ledger led;
+  led.deposit(3, QUOTE, quote(50));  // needs IM 100 for 10@100
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 3)}, 0);
+  bool rejected = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e); r && r->reason == RejectReason::InsufficientFunds)
+    {
+      rejected = true;
+    }
+  }
+  CHECK(rejected);
+}
+
+void test_funding()
+{
+  std::printf("test_perp_funding\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(1000));
+  led.deposit(2, QUOTE, quote(1000));
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+
+  eng.applyFunding(/*rate*/ 0.01, /*mark*/ px(100));  // notional 1000 -> 10 pays
+  CHECK(led.available(1, QUOTE) == quote(890));       // long paid 10 (900 - 10)
+  CHECK(led.available(2, QUOTE) == quote(910));       // short received 10
+  CHECK(led.total(VENUE, QUOTE) == 0);                // pool net zero
+}
+
+bool liquidated(const std::vector<OutboundEvent>& ev, uint64_t acct, bool& bankrupt)
+{
+  for (auto& e : ev)
+  {
+    if (auto* l = std::get_if<Liquidation>(&e); l && l->account == acct)
+    {
+      bankrupt = l->bankrupt;
+      return true;
+    }
+  }
+  return false;
+}
+
+void test_liquidation()
+{
+  std::printf("test_perp_liquidation\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100));  // exactly the IM for 10@100 -> highly leveraged
+  led.deposit(2, QUOTE, quote(1000));
+  auto c = cfg();
+  c.maintenanceMarginBps = 500;  // 5%
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+  CHECK(eng.positionQty(1) == qty(10).raw());
+  CHECK(led.available(1, QUOTE) == 0 && led.reserved(1, QUOTE) == quote(100));
+
+  // Mark drops to 91: equity = 100 + (91-100)*10 = 10 < MM(910*5%=45.5) -> liquidate acct1.
+  eng.setMarkPrice(px(91));
+  bool bankrupt = true;
+  CHECK(liquidated(ev, 1, bankrupt));
+  CHECK(!bankrupt);
+  CHECK(eng.positionQty(1) == 0);
+  CHECK(led.available(1, QUOTE) == quote(10));  // equity returned
+  CHECK(eng.positionQty(2) == -qty(10).raw());  // short survives (profit)
+
+  // Conservation.
+  const Amount tot = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(tot == quote(1100));
+}
+
+void test_bankruptcy()
+{
+  std::printf("test_perp_bankruptcy\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100));
+  led.deposit(2, QUOTE, quote(1000));
+  auto c = cfg();
+  c.maintenanceMarginBps = 500;
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+
+  // Mark crashes to 85: equity = 100 - 150 = -50 -> bankrupt, insurance covers.
+  eng.setMarkPrice(px(85));
+  bool bankrupt = false;
+  CHECK(liquidated(ev, 1, bankrupt));
+  CHECK(bankrupt);
+  CHECK(led.available(1, QUOTE) == 0);  // wiped out, insurance topped up to zero
+  CHECK(eng.positionQty(1) == 0);
+  // Pool holds the long's booked loss (backs the short's gain); nets to the -50
+  // insurance deficit once the short also settles. Value is conserved throughout.
+  const Amount tot = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(tot == quote(1100));
+}
+
+// A liquidated account's OTHER resting orders lock initial margin in `reserved`
+// -- the account's own collateral. Liquidation must cancel them first so that
+// collateral covers the position's shortfall, instead of the insurance fund
+// paying out to an account that is solvent on a total-equity basis.
+void test_liquidation_frees_resting_collateral()
+{
+  std::printf("test_perp_liquidation_frees_resting_collateral\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(200));   // funds IM 100 (position) + IM 100 (resting)
+  led.deposit(2, QUOTE, quote(1000));  // counterparty
+  auto c = cfg();
+  c.maintenanceMarginBps = 500;
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  // Acct1 opens long 10 @ 100 (IM 100), then rests a second buy 10 @ 100 that
+  // does not fill (empty book) -- reserving another IM 100. avail 0, reserved 200.
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+  eng.submit(InboundCommand{ord(3, Side::BUY, 100, 10, 1)}, 2);  // rests, reserves IM 100
+  CHECK(led.available(1, QUOTE) == 0);
+  CHECK(led.reserved(1, QUOTE) == quote(200));
+
+  // Mark crashes to 85: position equity = 100 - 150 = -50. But acct1 holds 100 of
+  // its own collateral behind the resting order. After that order is canceled and
+  // its IM freed, the account covers its own 50 shortfall -> NOT bankrupt, no
+  // insurance payout. Deposited 200, lost 150 on the position -> ends with 50.
+  eng.setMarkPrice(px(85));
+  bool bankrupt = true;
+  CHECK(liquidated(ev, 1, bankrupt));
+  CHECK(!bankrupt);  // solvent on total equity -> no insurance
+  CHECK(eng.positionQty(1) == 0);
+  CHECK(led.total(1, QUOTE) == quote(50));  // buggy path leaves 100 (a 50 windfall)
+  bool restingCanceled = false;
+  for (auto& e : ev)
+  {
+    if (auto* c2 = std::get_if<OrderCanceled>(&e);
+        c2 && c2->id == 3 && c2->reason == CancelReason::Liquidation)
+    {
+      restingCanceled = true;
+    }
+  }
+  CHECK(restingCanceled);  // its collateral was freed, not stranded
+  // Conservation across accounts + venue.
+  const Amount tot = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(tot == quote(1200));
+}
+
+// Funding is charged to the wallet (`available`). A max-leverage payer with no
+// free collateral goes wallet-negative on funding; that negative must drag the
+// maintenance check so an unaffordable funding payment triggers liquidation
+// instead of accruing unbounded silent bad debt.
+void test_funding_triggers_liquidation()
+{
+  std::printf("test_perp_funding_triggers_liquidation\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100));     // exactly IM for long 10 @ 100 -> avail 0
+  led.deposit(2, QUOTE, quote(100000));  // deep, healthy counterparty
+  auto c = cfg();
+  c.maintenanceMarginBps = 500;  // mmReq at mark 100 = 1000 * 5% = 50
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+  CHECK(led.available(1, QUOTE) == 0);  // max leverage: no free collateral
+
+  // Mark unchanged (uPnl 0), but a 6% funding charge pays 60 from a wallet that
+  // has 0 free -> avail -60. Equity = margin 100 + uPnl 0 + walletDrag(-60) = 40
+  // < mmReq 50 -> liquidation. Without the wallet-drag term the check sees only
+  // margin+uPnl = 100 and the account keeps its position with a -60 wallet.
+  eng.applyFunding(/*rate*/ 0.06, /*mark*/ px(100));
+  bool bankrupt = true;
+  CHECK(liquidated(ev, 1, bankrupt));
+  CHECK(!bankrupt);  // margin covers the funding shortfall
+  CHECK(eng.positionQty(1) == 0);
+  CHECK(led.total(1, QUOTE) == quote(40));  // 100 deposited - 60 funding paid
+  // Conservation across accounts + venue (funding is a long->short transfer).
+  const Amount tot = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(tot == quote(100100));
+}
+
+// A reduce-only conditional (stop) order that fires from a FLAT account must NOT
+// open a position: it re-enters matching via processTriggers, not onNew, so the
+// reduce-only cap must be applied there too -- otherwise it opens an
+// uncollateralized (margin=0) position, violating "reduce-only never opens".
+void test_reduce_only_stop_cannot_open()
+{
+  std::printf("test_perp_reduce_only_stop_cannot_open\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(1000));    // flat account -- owns the reduce-only stop
+  led.deposit(2, QUOTE, quote(100000));  // resting bid liquidity
+  led.deposit(3, QUOTE, quote(100000));  // triggers the print
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 95, 10, 2)}, 0);                            // acct2 bid 10 @ 95
+  eng.submit(InboundCommand{stopMkt(10, Side::SELL, 5, 95, 1, /*reduceOnly*/ true)}, 1);  // parked
+  CHECK(eng.positionQty(1) == 0);
+  // A trade at 95 sets last = 95 -> the SELL stop (trigger 95) fires from FLAT.
+  eng.submit(InboundCommand{ord(2, Side::SELL, 95, 3, 3)}, 2);
+  CHECK(eng.positionQty(1) == 0);  // must stay flat -- bug opened an im=0 short of -5
+  bool rejected = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e);
+        r && r->id == 10 && r->reason == RejectReason::InvalidQuantity)
+    {
+      rejected = true;
+    }
+  }
+  CHECK(rejected);  // reduce-only-from-flat capped to 0 -> rejected, not opened
+}
+
+// A modify (cancel/replace) of a perp order re-enters matching outside onNew, so
+// it must still honor maxPositionQty -- else a size-increase modify grows the
+// position past the cap that a fresh order of that size would be rejected for.
+void test_perp_modify_respects_position_cap()
+{
+  std::printf("test_perp_modify_respects_position_cap\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100000));
+  auto c = cfg();
+  c.maxPositionQty = qty(10);
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);  // rests at the cap (no ask -> no fill)
+  CHECK(eng.book().bestBid().has_value() && eng.book().bestBid().value() == px(100));
+  ev.clear();
+  // Grow it to 20 (> cap). A fresh qty-20 order is rejected in onNew; the modify
+  // must be too, not silently accepted.
+  eng.submit(InboundCommand{ModifyOrder{1, SYM, px(100), qty(20), 1}}, 1);
+  bool rejected = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e);
+        r && r->id == 1 && r->reason == RejectReason::PositionLimitExceeded)
+    {
+      rejected = true;
+    }
+  }
+  CHECK(rejected);
+  CHECK(!eng.book().bestBid().has_value());  // order gone, not resting at qty 20
+}
+
+// reduce-only must survive a modify: a resting reduce-only order that is
+// repriced/resized re-enters matching outside onNew, and its reduce-only nature
+// (carried on the resting record) must be preserved and re-capped -- else the
+// modified order can flip the position, the exact thing reduce-only forbids.
+void test_perp_modify_preserves_reduce_only()
+{
+  std::printf("test_perp_modify_preserves_reduce_only\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100000));
+  led.deposit(2, QUOTE, quote(100000));
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 5, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 5, 2)}, 1);  // acct1 long +5
+  CHECK(eng.positionQty(1) == qty(5).raw());
+  // Reduce-only SELL rests above market (capped to the +5 position at submit).
+  eng.submit(InboundCommand{ord(3, Side::SELL, 110, 5, 1, /*reduceOnly*/ true)}, 2);
+  // Modify to a LARGER qty (10): reduce-only must be preserved and re-capped to 5.
+  eng.submit(InboundCommand{ModifyOrder{3, SYM, px(110), qty(10), 1}}, 3);
+  // Fill it fully: acct2 buys 10 @ 110. Only 5 should rest -> acct1 reduces to FLAT.
+  eng.submit(InboundCommand{ord(4, Side::BUY, 110, 10, 2)}, 4);
+  CHECK(eng.positionQty(1) == 0);  // reduced to flat -- bug flips it to -5 (opened a short)
+}
+
+void test_engine_adl()
+{
+  std::printf("test_perp_engine_adl\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100));     // exactly IM for 10@100 -> max leverage
+  led.deposit(2, QUOTE, quote(100000));  // deep winner
+  auto c = cfg();
+  c.maintenanceMarginBps = 500;
+  c.autoDeleverage = true;
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  const Amount init = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+  const Amount venueBefore = led.total(VENUE, QUOTE);  // insurance level
+
+  // Mark crashes to 85: acct1 equity = 100 + (85-100)*10 = -50 (bankrupt, deficit 50).
+  eng.setMarkPrice(px(85));
+  CHECK(eng.positionQty(1) == 0);
+  CHECK(eng.positionQty(2) == 0);  // winner auto-deleveraged
+
+  // Insurance spared: the 50 deficit was clawed from acct2's forgone profit.
+  CHECK(led.total(VENUE, QUOTE) == venueBefore);
+
+  bool sawAdl = false, sawBankrupt = false;
+  for (const auto& e : ev)
+  {
+    if (const auto* l = std::get_if<Liquidation>(&e))
+    {
+      if (l->adl)
+      {
+        sawAdl = true;
+      }
+      if (l->bankrupt)
+      {
+        sawBankrupt = true;
+      }
+    }
+  }
+  CHECK(sawAdl);
+  CHECK(sawBankrupt);
+  CHECK(led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE) == init);
+}
+
+void test_position_limit()
+{
+  std::printf("test_perp_position_limit\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100000));
+  led.deposit(2, QUOTE, quote(100000));
+  auto c = cfg();
+  c.maxPositionQty = qty(10);  // cap |position| at 10 contracts
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  // Open exactly at the cap: allowed.
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+  CHECK(eng.positionQty(1) == qty(10).raw());
+
+  // One more contract in the same direction would breach the cap -> rejected.
+  ev.clear();
+  eng.submit(InboundCommand{ord(3, Side::BUY, 100, 1, 1)}, 2);
+  bool rejected = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e);
+        r && r->reason == RejectReason::PositionLimitExceeded)
+    {
+      rejected = true;
+    }
+  }
+  CHECK(rejected);
+  CHECK(eng.positionQty(1) == qty(10).raw());  // unchanged
+
+  // A reduce-only order in the opposite direction is still allowed.
+  ev.clear();
+  eng.submit(InboundCommand{ord(4, Side::SELL, 100, 5, 1, /*reduceOnly*/ true)}, 3);
+  eng.submit(InboundCommand{ord(5, Side::BUY, 100, 5, 2)}, 4);
+  CHECK(eng.positionQty(1) == qty(5).raw());  // reduced to 5
+}
+
+}  // namespace
+
+TEST(Perp, EngineSuite)
+{
+  test_open_and_close();
+  test_insufficient_margin();
+  test_funding();
+  test_liquidation();
+  test_bankruptcy();
+  test_liquidation_frees_resting_collateral();
+  test_funding_triggers_liquidation();
+  test_reduce_only_stop_cannot_open();
+  test_perp_modify_respects_position_cap();
+  test_perp_modify_preserves_reduce_only();
+  test_engine_adl();
+  test_position_limit();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_perp_recovery.cpp
+++ b/venue/tests/test_venue_perp_recovery.cpp
@@ -1,0 +1,153 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/journal.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 999;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1);
+  c.maxPrice = px(1000);
+  c.quoteAsset = QUOTE;
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;
+  c.maintenanceMarginBps = 500;
+  return c;
+}
+NewOrder ord(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// The session: open a long/short pair, apply funding, then crash the mark to
+// force a maintenance-margin liquidation. Marks/funding are COMMANDS now.
+std::vector<std::pair<int64_t, InboundCommand>> session()
+{
+  std::vector<std::pair<int64_t, InboundCommand>> s;
+  s.emplace_back(0, InboundCommand{SetMark{SYM, px(100)}});
+  s.emplace_back(1, InboundCommand{ord(1, Side::BUY, 100, 10, 1)});     // acct1 long 10 @ 100 (IM 100)
+  s.emplace_back(2, InboundCommand{ord(2, Side::SELL, 100, 10, 2)});    // acct2 short
+  s.emplace_back(3, InboundCommand{ApplyFunding{SYM, 0.01, px(100)}});  // longs pay
+  s.emplace_back(4, InboundCommand{SetMark{SYM, px(91)}});              // still solvent
+  s.emplace_back(5, InboundCommand{SetMark{SYM, px(85)}});              // acct1 liquidated here
+  return s;
+}
+
+struct Run
+{
+  Ledger led;
+  int64_t pos1{0}, pos2{0};
+  Amount venueQuote{0};
+  std::vector<uint64_t> liquidated;
+};
+
+Run drive(const std::vector<std::pair<int64_t, InboundCommand>>& cmds)
+{
+  Run r;
+  r.led.deposit(1, QUOTE, quote(100));  // exactly IM -> highly leveraged
+  r.led.deposit(2, QUOTE, quote(1000));
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     if (const auto* l = std::get_if<Liquidation>(&e)){
+                                       r.liquidated.push_back(l->account);
+} });
+  eng.setLedger(&r.led, VENUE);
+  for (const auto& [ts, c] : cmds)
+  {
+    eng.submit(c, ts);
+  }
+  r.pos1 = eng.positionQty(1);
+  r.pos2 = eng.positionQty(2);
+  return r;
+}
+
+void test_perp_recovery()
+{
+  std::printf("test_perp_recovery\n");
+  const std::string path = "/tmp/flox_test_venue_perp_recovery_perp_recovery.bin";
+  const auto cmds = session();
+
+  // Live: journal every command (incl. SetMark / ApplyFunding).
+  {
+    Journal j(path);
+    for (const auto& [ts, c] : cmds)
+    {
+      j.append(c, ts);
+    }
+    j.flush();
+  }
+  const Run live = drive(cmds);
+  CHECK(live.pos1 == 0);  // acct1 was liquidated by the mark crash
+  CHECK(!live.liquidated.empty());
+
+  // Recover: replay ONLY what the journal holds. If marks/funding weren't
+  // journaled, acct1 would still be open here and balances would diverge.
+  const auto replayed = Journal::loadTimed(path);
+  CHECK(replayed.size() == cmds.size());
+  const Run rec = drive(replayed);
+
+  CHECK(rec.pos1 == live.pos1 && rec.pos2 == live.pos2);       // positions reconstruct
+  CHECK(rec.liquidated == live.liquidated);                    // same liquidation replayed
+  CHECK(rec.led.total(1, QUOTE) == live.led.total(1, QUOTE));  // balances reconstruct
+  CHECK(rec.led.total(2, QUOTE) == live.led.total(2, QUOTE));
+  CHECK(rec.led.total(VENUE, QUOTE) == live.led.total(VENUE, QUOTE));
+}
+
+}  // namespace
+
+TEST(PerpRecovery, EngineSuite)
+{
+  test_perp_recovery();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_perp_venue.cpp
+++ b/venue/tests/test_venue_perp_venue.cpp
@@ -1,0 +1,228 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/cross_margin.h"
+#include "flox-venue/funding_scheduler.h"
+#include "flox-venue/index_feed.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/prometheus.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 777;
+constexpr int NACCT = 5;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+constexpr int64_t MS = 1'000'000LL;
+
+struct Rng
+{
+  uint64_t s;
+  uint64_t next()
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  }
+};
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50);
+  c.maxPrice = px(150);
+  c.quoteAsset = QUOTE;
+  return c;  // pure matcher: no linearPerp, no ledger -> engine just crosses
+}
+
+void test_perp_venue()
+{
+  std::printf("test_perp_venue\n");
+  Ledger led;
+  led.deposit(VENUE, QUOTE, quote(100000));  // seed insurance fund
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    led.deposit(a, QUOTE, quote(100000));
+  }
+  const Amount init = [&]
+  {
+    Amount t = led.total(VENUE, QUOTE);
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, QUOTE);
+    }
+    return t;
+  }();
+
+  // The money + risk authority (cross-margin), fed from the trade stream.
+  CrossMarginManager cm(led, QUOTE, VENUE, [](const Liquidation&) {}, /*autoDeleverage*/ true);
+  cm.configureSymbol(SYM, /*im*/ 1000, /*mm*/ 500);
+  cm.setMark(SYM, px(100));
+
+  Metrics metrics;
+  int64_t lastTradeRaw = px(100).raw();
+
+  // Engine as a pure matcher: on each Trade, settle BOTH sides into cross-margin.
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     metrics.observe(e);
+                                     if (const auto* t = std::get_if<Trade>(&e))
+                                     {
+                                       const Side takerSide = t->takerSide;
+                                       const Side makerSide =
+                                           takerSide == Side::BUY ? Side::SELL : Side::BUY;
+                                       cm.applyFill(t->takerAccount, SYM, takerSide, t->quantity.raw(),
+                                                    t->price.raw());
+                                       cm.applyFill(t->makerAccount, SYM, makerSide, t->quantity.raw(),
+                                                    t->price.raw());
+                                       lastTradeRaw = t->price.raw();
+                                     } });
+
+  IndexAggregator idx(/*staleness*/ 60 * MS, /*maxDevBps*/ 200, /*minSources*/ 3);
+  MarkPrice mark(/*clampBps*/ 300);
+  FundingScheduler<MatchingEngine<MatchingBook>> sched(eng, /*interval*/ 1000 * MS);
+
+  auto quoteConserved = [&]
+  {
+    Amount t = led.total(VENUE, QUOTE);
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, QUOTE);
+    }
+    return t == init;
+  };
+
+  Rng rng{0xBADC0FFEEULL};
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  OrderId nextId = 1;
+  int breaches = 0;
+  int64_t refRaw = midRaw;  // external index reference (random walk)
+
+  const int OPS = 60000;
+  for (int i = 0; i < OPS; ++i)
+  {
+    const int64_t now = static_cast<int64_t>(i) * MS;
+    const uint64_t r = rng.next();
+
+    // External index random-walks; refresh three spot sources (kept fresh).
+    refRaw += (static_cast<int64_t>((r >> 40) % 3) - 1) * tickRaw;
+    if (refRaw < px(80).raw())
+    {
+      refRaw = px(80).raw();
+    }
+    if (refRaw > px(120).raw())
+    {
+      refRaw = px(120).raw();
+    }
+    idx.update(1, Price::fromRaw(refRaw), now);
+    idx.update(2, Price::fromRaw(refRaw + tickRaw), now);
+    idx.update(3, Price::fromRaw(refRaw - tickRaw), now);
+
+    const uint32_t kind = r % 100;
+    if (kind < 70)
+    {
+      NewOrder o;
+      o.id = nextId++;
+      o.symbol = SYM;
+      o.side = (r & 1) ? Side::BUY : Side::SELL;
+      o.accountId = 1 + (r >> 8) % NACCT;
+      const int ticks = static_cast<int>((r >> 1) % 41) - 20;
+      o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+      o.quantity = qty(1.0 + static_cast<double>((r >> 20) % 4));
+      o.type = OrderType::LIMIT;
+      // Pre-trade portfolio buying-power gate (ingress credit check).
+      if (cm.canOpen(o.accountId, SYM, o.side, o.quantity.raw(), o.price.raw()))
+      {
+        eng.submit(InboundCommand{o}, now);
+      }
+    }
+
+    // Mark: median(index, impact-mid from the live book, last trade), clamped.
+    if (idx.hasIndex(now))
+    {
+      mark.setIndex(idx.index(now));
+      const int64_t impact = bookImpactMidRaw(eng.book(), qty(3).raw());
+      if (impact > 0)
+      {
+        mark.setMid(Price::fromRaw(impact));
+      }
+      mark.setLast(Price::fromRaw(lastTradeRaw));
+      const Price mk = mark.value();
+      cm.setMark(SYM, mk);                    // may liquidate underwater accounts
+      sched.onTick(now, mk, idx.index(now));  // may settle funding
+    }
+
+    if (!quoteConserved())
+    {
+      ++breaches;
+      if (breaches == 1)
+      {
+        std::printf("  first breach at op %d\n", i);
+      }
+    }
+  }
+
+  CHECK(breaches == 0);
+  CHECK(metrics.trades > 0);
+
+  // Final observability snapshot from live venue state.
+  Gauges g;
+  g.insuranceFundRaw = led.total(VENUE, QUOTE);
+  g.openInterestRaw = cm.openInterestRaw();
+  g.openPositions = cm.openPositionCount();
+  g.restingOrders = eng.restingOrderCount();
+  g.fundingRate = sched.lastRate();
+  const std::string page = prom::render(metrics, g);
+  CHECK(page.find("fme_open_interest_raw") != std::string::npos);
+  CHECK(page.find("fme_insurance_fund_raw") != std::string::npos);
+
+  std::printf("  %d ops: trades=%llu, funding settlements=%llu, OI=%.2f, insurance=%.2f, breaches=%d\n",
+              OPS, (unsigned long long)metrics.trades, (unsigned long long)sched.settlements(),
+              (double)cm.openInterestRaw() / 1e8, (double)led.total(VENUE, QUOTE) / 1e8, breaches);
+}
+
+}  // namespace
+
+TEST(PerpVenue, EngineSuite)
+{
+  test_perp_venue();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_prorata.cpp
+++ b/venue/tests/test_venue_prorata.cpp
@@ -1,0 +1,177 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/matching_engine.h"
+#include "flox/book/ladder_book.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+const char* g_label = "";
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL [%s] line %d: %s\n", g_label, line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+LadderBook::Config lc() { return LadderBook::Config{0, px(0.01).raw(), 16000, 1 << 16}; }
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+struct Cap
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+  int trades() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<Trade>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  Quantity forMaker(OrderId m) const
+  {
+    Quantity t{};
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<Trade>(&e); x && x->makerId == m)
+      {
+        t += x->quantity;
+      }
+    }
+    return t;
+  }
+  Quantity total() const
+  {
+    Quantity t{};
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<Trade>(&e))
+      {
+        t += x->quantity;
+      }
+    }
+    return t;
+  }
+};
+
+template <class Book>
+void run(const std::function<Book()>& mk, const char* label)
+{
+  g_label = label;
+  std::printf("== pro-rata book: %s ==\n", label);
+  {  // partial: BUY 5 split across a 2/3/5 level (total 10) -> 1.0 / 1.5 / 2.5
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    eng.submit(limit(1, Side::SELL, 100, 2, 1));
+    eng.submit(limit(2, Side::SELL, 100, 3, 1));
+    eng.submit(limit(3, Side::SELL, 100, 5, 1));
+    eng.submit(limit(9, Side::BUY, 100, 5, 2));
+    CHECK(cap.trades() == 3);
+    CHECK(cap.total() == qty(5));
+    CHECK(cap.forMaker(1) == qty(1.0));
+    CHECK(cap.forMaker(2) == qty(1.5));
+    CHECK(cap.forMaker(3) == qty(2.5));
+  }
+  {  // full sweep: BUY 10 clears the level, everyone fully filled
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    eng.submit(limit(1, Side::SELL, 100, 2, 1));
+    eng.submit(limit(2, Side::SELL, 100, 3, 1));
+    eng.submit(limit(3, Side::SELL, 100, 5, 1));
+    eng.submit(limit(9, Side::BUY, 100, 10, 2));
+    CHECK(cap.trades() == 3);
+    CHECK(cap.total() == qty(10));
+    CHECK(eng.book().empty());
+  }
+  {  // pro-rata over displayed size with an iceberg maker present
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    NewOrder ice = limit(1, Side::SELL, 100, 10, 1);  // total 10
+    ice.visibleQuantity = qty(4);                     // displayed 4, hidden 6
+    eng.submit(ice);
+    eng.submit(limit(2, Side::SELL, 100, 4, 1));  // plain displayed 4
+    eng.submit(limit(9, Side::BUY, 100, 4, 2));   // 4 pro-rata over displayed 4/4 -> 2/2
+    CHECK(cap.trades() == 2);
+    CHECK(cap.forMaker(1) == qty(2));
+    CHECK(cap.forMaker(2) == qty(2));
+  }
+  {  // full sweep drains the iceberg reserve + plain order
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    NewOrder ice = limit(1, Side::SELL, 100, 10, 1);
+    ice.visibleQuantity = qty(4);
+    eng.submit(ice);
+    eng.submit(limit(2, Side::SELL, 100, 6, 1));
+    eng.submit(limit(9, Side::BUY, 100, 16, 2));  // sweep all 10 + 6
+    CHECK(cap.total() == qty(16));
+    CHECK(eng.book().empty());
+  }
+}
+
+}  // namespace
+
+TEST(Prorata, EngineSuite)
+{
+  run<MatchingBook>([]
+                    { return MatchingBook{}; }, "map-reference");
+  run<LadderBook>([]
+                  { return LadderBook{lc()}; }, "ladder-o1");
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_reliability.cpp
+++ b/venue/tests/test_venue_reliability.cpp
@@ -1,0 +1,153 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/symbol_router.h"
+#include "flox-venue/workload.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+
+void checkImpl(bool ok, const char* expr, const char* file, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL %s:%d  %s\n", file, line, expr);
+  }
+}
+#define CHECK(x) checkImpl((x), #x, __FILE__, __LINE__)
+
+SymbolConfig cfgFor(SymbolId id)
+{
+  SymbolConfig c;
+  c.id = id;
+  c.tickSize = Price::fromDouble(0.01);
+  c.minPrice = Price::fromDouble(50.0);
+  c.maxPrice = Price::fromDouble(150.0);
+  return c;
+}
+
+uint64_t runHash(const std::vector<InboundCommand>& cmds, Journal* journal)
+{
+  uint64_t h = 1469598103934665603ULL;
+  auto sink = [&](const OutboundEvent& e)
+  { h = hashEvent(h, e); };
+  MatchingEngine<MatchingBook> eng(cfgFor(1), sink);
+  for (const auto& c : cmds)
+  {
+    if (journal)
+    {
+      journal->append(c);
+    }
+    eng.submit(c);
+  }
+  return h;
+}
+
+void test_journal_replay()
+{
+  std::printf("test_journal_replay\n");
+  workload::Params p;
+  p.symbol = 1;
+  p.count = 5000;
+  auto cmds = workload::symmetricLimits(p);
+  // exercise the cancel record path too (some hit live orders, some don't)
+  cmds.emplace_back(CancelOrder{5, 1, 1});
+  cmds.emplace_back(CancelOrder{123, 1, 1});
+  cmds.emplace_back(CancelOrder{999999, 1, 1});
+
+  const std::string path = "/tmp/flox_test_venue_reliability_journal_test.bin";
+
+  uint64_t hashLive;
+  uint64_t journaled;
+  {
+    Journal journal(path);
+    hashLive = runHash(cmds, &journal);
+    journal.flush();
+    journaled = journal.count();
+  }
+
+  CHECK(journaled == cmds.size());
+
+  const auto replayed = Journal::load(path);
+  CHECK(replayed.size() == cmds.size());
+
+  const uint64_t hashReplay = runHash(replayed, nullptr);
+  CHECK(hashLive == hashReplay);  // deterministic recovery
+}
+
+void test_sharding()
+{
+  std::printf("test_sharding\n");
+  SymbolRouter<MatchingBook> router(4);
+
+  int trades1 = 0;
+  int trades2 = 0;
+  router.addSymbol(cfgFor(1), [&](const OutboundEvent& e)
+                   { if (std::get_if<Trade>(&e)){ ++trades1;
+} });
+  router.addSymbol(cfgFor(2), [&](const OutboundEvent& e)
+                   { if (std::get_if<Trade>(&e)){ ++trades2;
+} });
+
+  CHECK(router.shardCount() == 4);
+  CHECK(router.shardOf(1) == router.shardOf(1));  // deterministic
+  CHECK(router.has(1) && router.has(2));
+
+  auto mk = [](OrderId id, SymbolId sym, Side s, double px, double q)
+  {
+    NewOrder o;
+    o.id = id;
+    o.symbol = sym;
+    o.side = s;
+    o.type = OrderType::LIMIT;
+    o.price = Price::fromDouble(px);
+    o.quantity = Quantity::fromDouble(q);
+    o.accountId = 1;
+    return InboundCommand{o};
+  };
+
+  // Cross on symbol 1 only.
+  router.submit(mk(1, 1, Side::SELL, 100.0, 5));
+  router.submit(mk(2, 1, Side::BUY, 100.0, 5));
+  CHECK(trades1 == 1);
+  CHECK(trades2 == 0);  // symbol 2 untouched
+
+  // Cross on symbol 2 only.
+  router.submit(mk(3, 2, Side::SELL, 100.0, 5));
+  router.submit(mk(4, 2, Side::BUY, 100.0, 5));
+  CHECK(trades2 == 1);
+  CHECK(trades1 == 1);  // symbol 1 unchanged
+}
+
+}  // namespace
+
+TEST(Reliability, EngineSuite)
+{
+  test_journal_replay();
+  test_sharding();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_segregation.cpp
+++ b/venue/tests/test_venue_segregation.cpp
@@ -1,0 +1,107 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/ledger.h"
+#include "flox-venue/segregation.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr AssetId USD = 1;
+constexpr uint64_t VENUE = 900;      // operational + fee capture
+constexpr uint64_t INSURANCE = 901;  // insurance fund
+Amount usd(double v) { return amountOf(Volume::fromDouble(v)); }
+
+void test_segregation()
+{
+  std::printf("test_segregation\n");
+  Ledger led;
+  led.deposit(1, USD, usd(1000));
+  led.deposit(2, USD, usd(2500));
+  led.deposit(3, USD, usd(500));
+  led.deposit(VENUE, USD, usd(300));  // house money (not client)
+  led.deposit(INSURANCE, USD, usd(10000));
+
+  SegregationReport seg(led, {VENUE, INSURANCE});
+
+  // Client money owed = sum of client accounts (house excluded).
+  CHECK(seg.clientTotal(USD) == usd(4000));  // 1000 + 2500 + 500
+  CHECK(seg.houseTotal(USD) == usd(10300));  // 300 + 10000
+
+  // Custody fully backs client money.
+  CHECK(seg.fullyBacked(USD, usd(4000)));
+  CHECK(seg.fullyBacked(USD, usd(5000)));
+  CHECK(seg.shortfall(USD, usd(4000)) == 0);
+
+  // Custody deficit -> reportable breach.
+  CHECK(!seg.fullyBacked(USD, usd(3999)));
+  CHECK(seg.shortfall(USD, usd(3999)) == usd(1));
+  CHECK(seg.shortfall(USD, usd(3000)) == usd(1000));
+
+  // A reservation (buying power locked) still counts as client money owed --
+  // reserved + available both belong to the client.
+  led.reserve(1, USD, usd(400));
+  CHECK(seg.clientTotal(USD) == usd(4000));  // unchanged: total = avail + reserved
+
+  // A trade moving value between clients keeps the client total invariant; a fee
+  // to the house reduces client money (and custody requirement) accordingly.
+  led.debit(2, USD, usd(100));
+  led.credit(1, USD, usd(90));
+  led.credit(VENUE, USD, usd(10));           // 10 fee captured by the house
+  CHECK(seg.clientTotal(USD) == usd(3990));  // 4000 - 10 fee
+  CHECK(seg.houseTotal(USD) == usd(10310));
+}
+
+// A client with a DEBIT (negative) balance must not net down the segregation
+// requirement: the firm still owes the credit clients their full balances, and a
+// negative wallet is the firm's receivable, not a reduction of client money.
+void test_segregation_no_debit_netting()
+{
+  std::printf("test_segregation_no_debit_netting\n");
+  Ledger led;
+  led.deposit(1, USD, usd(10000));  // client A is owed 10000
+  led.credit(2, USD, -usd(3000));   // client B's wallet driven negative (e.g. funding)
+  SegregationReport seg(led, {VENUE, INSURANCE});
+
+  // Owed = A's 10000 only; B's -3000 is a receivable, NOT a -3000 to net out.
+  CHECK(seg.clientTotal(USD) == usd(10000));  // netting would report 7000
+  // Custody of 7000 must be flagged short by 3000, not "fully backed".
+  CHECK(!seg.fullyBacked(USD, usd(7000)));
+  CHECK(seg.shortfall(USD, usd(7000)) == usd(3000));
+  CHECK(seg.fullyBacked(USD, usd(10000)));
+}
+
+}  // namespace
+
+TEST(Segregation, EngineSuite)
+{
+  test_segregation();
+  test_segregation_no_debit_netting();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_sequenced.cpp
+++ b/venue/tests/test_venue_sequenced.cpp
@@ -1,0 +1,122 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/sequenced_shard.h"
+#include "flox-venue/workload.h"
+#include "flox/book/ladder_book.h"
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cstdint>
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+
+venue::SymbolConfig cfg()
+{
+  venue::SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = Price::fromDouble(0.01);
+  c.minPrice = Price::fromDouble(50.0);
+  c.maxPrice = Price::fromDouble(150.0);
+  return c;
+}
+
+LadderBook::Config ladderCfg()
+{
+  return LadderBook::Config{0, Price::fromDouble(0.01).raw(), 16000, 1 << 20};
+}
+
+uint64_t referenceHash(const std::vector<InboundCommand>& cmds)
+{
+  uint64_t h = 1469598103934665603ULL;
+  MatchingEngine<LadderBook> eng(cfg(), [&](const OutboundEvent& e)
+                                 { h = hashEvent(h, e); }, LadderBook{ladderCfg()});
+  for (const auto& c : cmds)
+  {
+    eng.submit(c);
+  }
+  return h;
+}
+
+struct HashSink : IEngineEventListener
+{
+  uint64_t h = 1469598103934665603ULL;
+  uint64_t count = 0;
+  void onEngineEvent(const EngineEventMsg& e) override
+  {
+    h = hashEvent(h, e.event);
+    ++count;
+  }
+};
+
+}  // namespace
+
+TEST(Sequenced, EngineSuite)
+{
+  workload::Params p;
+  p.symbol = SYM;
+  p.count = 500'000;
+  const auto cmds = workload::symmetricLimits(p);
+
+  const uint64_t hRef = referenceHash(cmds);
+
+  HashSink sink;
+  // Heap-allocated: the shard embeds the Disruptor ring storage (large).
+  auto shard = std::make_unique<SequencedShard<LadderBook>>(cfg(), "/tmp/flox_test_venue_sequenced_seq_journal.bin",
+                                                            LadderBook{ladderCfg()});
+  CHECK(shard->subscribeOutbound(&sink, true));
+  shard->start();
+
+  const auto t0 = std::chrono::steady_clock::now();
+  for (const auto& c : cmds)
+  {
+    shard->submit(c);
+  }
+  shard->flush();
+  const auto t1 = std::chrono::steady_clock::now();
+
+  const uint64_t hSeq = sink.h;
+  const uint64_t journaled = shard->journaled();
+  shard->stop();
+
+  const double sec = std::chrono::duration<double>(t1 - t0).count();
+  std::printf("sequenced shard: %zu commands in %.3fs = %.0f cmd/s end-to-end\n", cmds.size(), sec,
+              static_cast<double>(cmds.size()) / sec);
+  std::printf("outbound events: %llu, journaled: %llu\n",
+              static_cast<unsigned long long>(sink.count),
+              static_cast<unsigned long long>(journaled));
+
+  CHECK(journaled == cmds.size());
+  CHECK(hSeq == hRef);  // Disruptor path == direct path, bit-for-bit
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_session.cpp
+++ b/venue/tests/test_venue_session.cpp
@@ -1,0 +1,147 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/resend_buffer.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  c.lastLookWindowNs = 1000;  // exercise time-driven behaviour under replay
+  return c;
+}
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+void test_resend()
+{
+  std::printf("test_resend\n");
+  ResendBuffer buf;
+  const uint64_t sess = 42;
+  for (int i = 1; i <= 5; ++i)
+  {
+    const uint64_t seq =
+        buf.append(sess, OutboundEvent{OrderCanceled{static_cast<OrderId>(i), SYM, CancelReason::UserRequested}},
+                   /*ts*/ i * 100);
+    CHECK(seq == static_cast<uint64_t>(i));
+  }
+  CHECK(buf.lastSeq(sess) == 5);
+
+  // Reconnect: client had seen through seq 2, requests resend from 3.
+  const auto gap = buf.resend(sess, 3);
+  CHECK(gap.size() == 3);
+  CHECK(gap.front().seq == 3 && gap.back().seq == 5);
+  CHECK(gap.front().tsNs == 300);
+
+  buf.ackThrough(sess, 4);
+  CHECK(buf.resend(sess, 1).size() == 1);  // only seq 5 remains buffered
+
+  // Client-side gap detection.
+  GapDetector gd;
+  CHECK(!gd.observe(1).first);
+  CHECK(!gd.observe(2).first);
+  auto g = gd.observe(5);  // skipped 3,4
+  CHECK(g.first && g.second == 3);
+}
+
+uint64_t runTimed(const std::vector<std::pair<int64_t, InboundCommand>>& cmds)
+{
+  uint64_t h = 1469598103934665603ULL;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { h = hashEvent(h, e); });
+  for (const auto& [ts, c] : cmds)
+  {
+    eng.submit(c, ts);
+  }
+  return h;
+}
+
+void test_timestamped_replay()
+{
+  std::printf("test_timestamped_replay\n");
+  const std::string path = "/tmp/flox_test_venue_session_session_journal.bin";
+  // A last-look maker + a taker hit; the hold times out at ts 5000 (window 1000).
+  std::vector<std::pair<int64_t, InboundCommand>> live;
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  live.emplace_back(10, InboundCommand{mk});
+  live.emplace_back(20, InboundCommand{limit(2, Side::BUY, 100, 3, 2)});  // held @ deadline 1020
+  live.emplace_back(5000, InboundCommand{CancelOrder{999, SYM, 1}});      // past deadline -> timeout
+
+  {
+    Journal j(path);
+    for (const auto& [ts, c] : live)
+    {
+      j.append(c, ts);
+    }
+    j.flush();
+  }
+  const uint64_t hLive = runTimed(live);
+
+  const auto replayed = Journal::loadTimed(path);
+  CHECK(replayed.size() == live.size());
+  CHECK(replayed[1].first == 20);  // timestamp preserved
+  const uint64_t hReplay = runTimed(replayed);
+  CHECK(hLive == hReplay);  // time-driven (last-look timeout) reproduced exactly
+}
+
+}  // namespace
+
+TEST(Session, EngineSuite)
+{
+  test_resend();
+  test_timestamped_replay();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_symbol_scale.cpp
+++ b/venue/tests/test_venue_symbol_scale.cpp
@@ -1,0 +1,226 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include "flox-venue/cross_margin.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/metrics.h"
+#include "flox/book/matching_book.h"
+
+#include <gtest/gtest.h>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE_ACCT = 900;
+
+int64_t i64(Amount a) { return static_cast<int64_t>(a); }
+
+// A meme-coin-shaped symbol: whole-token quantities (qtyScale 1, so supplies of
+// 1e12+ tokens fit int64), prices at the default 1e8 scale.
+SymbolConfig memeCfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  c.priceScale = Price::Scale;
+  c.qtyScale = 1;
+  return c;
+}
+
+NewOrder rawOrder(OrderId id, Side s, int64_t praw, int64_t qraw, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = Price::fromRaw(praw);
+  o.quantity = Quantity::fromRaw(qraw);
+  o.accountId = acct;
+  return o;
+}
+}  // namespace
+
+TEST(SymbolScale, NotionalRawMatchesLegacyAtDefaultScale)
+{
+  // Bit-identical to the fixed-scale expression it replaced.
+  for (int64_t praw : {int64_t{1}, int64_t{9999}, int64_t{12'345'678'901}})
+  {
+    for (int64_t qraw : {int64_t{1}, int64_t{307}, int64_t{5'000'000'000}})
+    {
+      const Amount legacy = static_cast<Amount>(praw) * qraw / Price::Scale;
+      EXPECT_EQ(i64(notionalRaw(praw, qraw, Price::Scale, Quantity::Scale)), i64(legacy));
+      EXPECT_EQ(i64(notionalRaw(-praw, qraw, Price::Scale, Quantity::Scale)), i64(-legacy));
+    }
+  }
+}
+
+TEST(SymbolScale, NotionalRawCoarseAndFineQtyScales)
+{
+  // qtyScale 1: 1e12 tokens at 0.00002 quote = 2e7 quote = raw 2e15.
+  EXPECT_EQ(i64(notionalRaw(2000, 1'000'000'000'000, Price::Scale, 1)), 2'000'000'000'000'000);
+  // Multiply-before-divide: 55 tokens at 0.00002 = 0.0011 quote = raw 110000.
+  // Divide-first would truncate to 0.
+  EXPECT_EQ(i64(notionalRaw(2000, 55, Price::Scale, 1)), 110'000);
+  // qtyScale finer than money (1e10): 3 tokens (qraw 3e10) at 100.0 = 300 quote.
+  EXPECT_EQ(i64(notionalRaw(10'000'000'000, 30'000'000'000, Price::Scale, 10'000'000'000)),
+            30'000'000'000);
+  // Truncation is toward zero for negative deltas, like the legacy expression.
+  EXPECT_EQ(i64(notionalRaw(-3, 7, Price::Scale, Quantity::Scale)), 0);
+
+  // Magnitudes past the multiply-first guard fall back to divide-first instead
+  // of overflowing (no UB on adversarial input).
+  const int64_t big = 9'000'000'000'000'000'000;
+  const Amount prod = static_cast<Amount>(big) * big;
+  EXPECT_TRUE(notionalRaw(big, big, Price::Scale, 1) == prod / Price::Scale * kMoneyScale);
+}
+
+TEST(SymbolScale, ScalesValid)
+{
+  EXPECT_TRUE(scalesValid(Price::Scale, Quantity::Scale));
+  EXPECT_TRUE(scalesValid(Price::Scale, 1));
+  EXPECT_TRUE(scalesValid(1, 10'000'000'000));
+  EXPECT_FALSE(scalesValid(0, 1));
+  EXPECT_FALSE(scalesValid(Price::Scale, 0));
+  EXPECT_FALSE(scalesValid(Price::Scale, 3));            // does not divide 1e8
+  EXPECT_TRUE(scalesValid(Price::Scale, 300'000'000));   // multiple of 1e8: ok
+  EXPECT_FALSE(scalesValid(Price::Scale, 150'000'000));  // neither divides
+}
+
+TEST(SymbolScale, SpotSettlementAtCoarseQtyScale)
+{
+  Ledger led;
+  const int64_t qraw = 1'000'000'000'000;  // 1e12 tokens
+  const int64_t praw = 2000;               // 0.00002 quote
+  const Amount notional = 2'000'000'000'000'000;
+
+  led.deposit(1, BASE, qraw);       // seller: base balances are qty raw
+  led.deposit(2, QUOTE, notional);  // buyer: exactly the notional
+
+  MatchingEngine<MatchingBook> eng(memeCfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+
+  eng.submit(InboundCommand{rawOrder(1, Side::SELL, praw, qraw, 1)}, 0);
+  eng.submit(InboundCommand{rawOrder(2, Side::BUY, praw, qraw, 2)}, 1);
+
+  EXPECT_EQ(i64(led.available(2, BASE)), qraw);
+  EXPECT_EQ(i64(led.available(1, QUOTE)), i64(notional));
+  EXPECT_EQ(i64(led.available(2, QUOTE)), 0);
+  EXPECT_EQ(i64(led.total(1, BASE) + led.total(2, BASE)), qraw);
+  EXPECT_EQ(i64(led.total(1, QUOTE) + led.total(2, QUOTE)), i64(notional));
+}
+
+TEST(SymbolScale, TinyTradeNotTruncatedToZero)
+{
+  Ledger led;
+  led.deposit(1, BASE, 55);
+  led.deposit(2, QUOTE, 110'000);
+
+  MatchingEngine<MatchingBook> eng(memeCfg(), [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+
+  eng.submit(InboundCommand{rawOrder(1, Side::SELL, 2000, 55, 1)}, 0);
+  eng.submit(InboundCommand{rawOrder(2, Side::BUY, 2000, 55, 2)}, 1);
+
+  EXPECT_EQ(i64(led.available(1, QUOTE)), 110'000);  // seller paid in full
+  EXPECT_EQ(i64(led.available(2, BASE)), 55);
+}
+
+TEST(SymbolScale, EquivalentEconomicsAcrossScales)
+{
+  // The same trade (3 tokens at 100.0 quote) settles the same quote money
+  // whether the symbol runs at the default scale or at qtyScale 1e6.
+  auto run = [](int64_t qtyScale, int64_t qraw) -> Amount
+  {
+    Ledger led;
+    led.deposit(1, BASE, qraw);
+    led.deposit(2, QUOTE, 40'000'000'000);
+
+    SymbolConfig c;
+    c.id = SYM;
+    c.baseAsset = BASE;
+    c.quoteAsset = QUOTE;
+    c.qtyScale = qtyScale;
+    MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
+    eng.setLedger(&led, VENUE_ACCT);
+
+    eng.submit(InboundCommand{rawOrder(1, Side::SELL, 10'000'000'000, qraw, 1)}, 0);
+    eng.submit(InboundCommand{rawOrder(2, Side::BUY, 10'000'000'000, qraw, 2)}, 1);
+    return led.available(1, QUOTE);
+  };
+
+  const Amount atDefault = run(Quantity::Scale, 300'000'000);  // 3.0 at 1e8
+  const Amount atMillion = run(1'000'000, 3'000'000);          // 3.0 at 1e6
+  EXPECT_EQ(i64(atDefault), 30'000'000'000);                   // 300 quote raw
+  EXPECT_EQ(i64(atMillion), i64(atDefault));
+}
+
+TEST(SymbolScale, PerpMarginAndPnlAtCoarseQtyScale)
+{
+  Ledger led;
+  led.deposit(1, QUOTE, 2'000'000'000'000'000);  // 2e7 quote
+  led.deposit(2, QUOTE, 2'000'000'000'000'000);
+
+  SymbolConfig c = memeCfg();
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;
+  c.maintenanceMarginBps = 500;
+  MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+
+  // 1e6 tokens at 100.0: notional 1e8 quote raw*1e8 = 1e16; IM 10% = 1e15.
+  const int64_t praw = 10'000'000'000;
+  const int64_t qraw = 1'000'000;
+  eng.submit(InboundCommand{rawOrder(1, Side::BUY, praw, qraw, 1)}, 0);
+  EXPECT_EQ(i64(led.reserved(1, QUOTE)), 1'000'000'000'000'000);
+
+  eng.submit(InboundCommand{rawOrder(2, Side::SELL, praw, qraw, 2)}, 1);
+
+  // Mark +1.0 quote on 1e6 tokens = 1e6 quote = raw 1e14.
+  EXPECT_EQ(i64(eng.unrealizedPnlRaw(1, Price::fromRaw(10'100'000'000))), 100'000'000'000'000);
+  EXPECT_EQ(i64(eng.unrealizedPnlRaw(2, Price::fromRaw(10'100'000'000))), -100'000'000'000'000);
+}
+
+TEST(SymbolScale, CrossMarginAtCoarseQtyScale)
+{
+  Ledger led;
+  led.deposit(1, QUOTE, 1'000'000'000'000'000);
+  CrossMarginManager cm(led, QUOTE, VENUE_ACCT);
+  cm.configureSymbol(SYM, 1000, 500, Price::Scale, 1);
+
+  cm.applyFill(1, SYM, Side::BUY, 1'000'000, 10'000'000'000);
+  cm.setMark(SYM, Price::fromRaw(10'100'000'000));
+
+  // Equity = wallet 1e15 + uPnL (mark +1.0 on 1e6 tokens = raw 1e14).
+  EXPECT_EQ(i64(cm.equity(1)), 1'100'000'000'000'000);
+  // IM at mark: 1e6 tokens * 101.0 * 10% = 1.01e7 quote = raw 1.01e15.
+  EXPECT_EQ(i64(cm.initialMargin(1)), 1'010'000'000'000'000);
+  EXPECT_EQ(i64(cm.openInterestRaw()), 10'100'000'000'000'000);
+}
+
+TEST(SymbolScale, MetricsVolumeNormalizedToMoney)
+{
+  Metrics m;
+  m.setSymbolScales(SYM, Price::Scale, 1);
+
+  Trade t;
+  t.symbol = SYM;
+  t.price = Price::fromRaw(2000);
+  t.quantity = Quantity::fromRaw(1'000'000'000'000);
+  m.observe(OutboundEvent{t});
+
+  EXPECT_EQ(i64(static_cast<Amount>(m.volumeRaw)), 2'000'000'000'000'000);
+}

--- a/venue/tests/test_venue_tape.cpp
+++ b/venue/tests/test_venue_tape.cpp
@@ -1,0 +1,113 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/tape_recorder.h"
+#include "flox-venue/workload.h"
+#include "flox/book/matching_book.h"
+
+#include "flox/replay/readers/binary_log_reader.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+}  // namespace
+
+TEST(Tape, EngineSuite)
+{
+  const std::string dir = "/tmp/flox_test_venue_tape_dir";
+  std::filesystem::remove_all(dir);
+  std::filesystem::create_directories(dir);
+
+  uint64_t liveTrades = 0;
+  __int128 liveNotional = 0;
+
+  {
+    TapeRecorder tape(dir, "tape.floxlog");
+    MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                     {
+                                       tape.onEvent(e);
+                                       if (const auto* t = std::get_if<Trade>(&e))
+                                       {
+                                         ++liveTrades;
+                                         liveNotional +=
+                                             static_cast<__int128>(t->price.raw()) * t->quantity.raw();
+                                       } });
+
+    workload::Params p;
+    p.symbol = SYM;
+    p.count = 50'000;
+    for (const auto& c : workload::symmetricLimits(p))
+    {
+      eng.submit(c);
+    }
+    CHECK(tape.tradesWritten() == liveTrades);
+    tape.close();
+  }
+
+  // Read the floxlog tape back through flox's own reader.
+  flox::replay::ReaderConfig rc;
+  rc.data_dir = dir;
+  rc.verify_crc = true;
+  flox::replay::BinaryLogReader reader(rc);
+
+  uint64_t tapeTrades = 0;
+  __int128 tapeNotional = 0;
+  reader.forEach([&](const flox::replay::ReplayEvent& e)
+                 {
+                   if (e.type == flox::replay::EventType::Trade)
+                   {
+                     ++tapeTrades;
+                     tapeNotional += static_cast<__int128>(e.trade.price_raw) * e.trade.qty_raw;
+                   }
+                   return true; });
+
+  std::printf("live trades=%llu, tape trades=%llu\n", static_cast<unsigned long long>(liveTrades),
+              static_cast<unsigned long long>(tapeTrades));
+  CHECK(tapeTrades == liveTrades);
+  CHECK(tapeNotional == liveNotional);
+  CHECK(liveTrades > 0);
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_tls.cpp
+++ b/venue/tests/test_venue_tls.cpp
@@ -1,0 +1,213 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/ouch_codec.h"
+#include "flox-venue/tls_gateway.h"
+#include "flox/book/matching_book.h"
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <set>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+NewOrder mk(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+void test_tls_roundtrip()
+{
+  std::printf("test_tls\n");
+  std::mutex m;
+  TlsGateway::Responder currentResp;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     std::vector<uint8_t> b;
+                                     OuchCodec::encode(e, b);
+                                     if (!b.empty() && currentResp){ currentResp(b.data(), b.size());
+} });
+
+  TlsGateway gw([](const uint8_t* p, size_t n)
+                { return OuchCodec::decode(p, n); });
+  const int port = gw.start(0, [&](const InboundCommand& c, const TlsGateway::Responder& r)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              currentResp = r;
+                              eng.submit(c);
+                              currentResp = {}; });
+  CHECK(port > 0);
+
+  const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  CHECK(::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) == 0);
+
+  SSL_CTX* cctx = tls::clientCtx();
+  SSL* ssl = SSL_new(cctx);
+  SSL_set_fd(ssl, fd);
+  CHECK(SSL_connect(ssl) == 1);
+  CHECK(std::string(SSL_get_version(ssl)).rfind("TLS", 0) == 0);  // negotiated TLS
+
+  timeval tv{1, 0};
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+
+  auto sendCmd = [&](const InboundCommand& c)
+  {
+    std::vector<uint8_t> b;
+    OuchCodec::encode(c, b);
+    tls::writeFrame(ssl, b.data(), b.size());
+  };
+  sendCmd(InboundCommand{mk(1, Side::SELL, 100, 5, 1)});
+  sendCmd(InboundCommand{mk(2, Side::BUY, 100, 3, 2)});
+
+  std::set<uint8_t> tags;
+  std::vector<uint8_t> frame;
+  while (tls::readFrame(ssl, frame))
+  {
+    if (!frame.empty())
+    {
+      tags.insert(frame[0]);
+    }
+    if (tags.count(uint8_t(OuchOut::Accepted)) && tags.count(uint8_t(OuchOut::Trade)) &&
+        tags.count(uint8_t(OuchOut::Executed)))
+    {
+      break;
+    }
+  }
+  SSL_shutdown(ssl);
+  SSL_free(ssl);
+  ::close(fd);
+  SSL_CTX_free(cctx);
+  gw.stop();
+
+  CHECK(tags.count(uint8_t(OuchOut::Accepted)) == 1);
+  CHECK(tags.count(uint8_t(OuchOut::Trade)) == 1);
+  CHECK(tags.count(uint8_t(OuchOut::Executed)) == 1);
+}
+
+// A market maker quoting over the encrypted path must get the same disconnect
+// safety net as the plaintext path: on drop, its resting quote is pulled.
+void test_tls_cancel_on_disconnect()
+{
+  std::printf("test_tls_cancel_on_disconnect\n");
+  std::mutex m;
+  TlsGateway::Responder currentResp;
+  std::vector<OutboundEvent> events;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     events.push_back(e);
+                                     std::vector<uint8_t> b;
+                                     OuchCodec::encode(e, b);
+                                     if (!b.empty() && currentResp){ currentResp(b.data(), b.size());
+} });
+  TlsGateway gw([](const uint8_t* p, size_t n)
+                { return OuchCodec::decode(p, n); });
+  gw.setCancelOnDisconnect(true);
+  const int port = gw.start(0, [&](const InboundCommand& c, const TlsGateway::Responder& r)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              currentResp = r;
+                              eng.submit(c);
+                              currentResp = {}; });
+  CHECK(port > 0);
+
+  const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  CHECK(::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) == 0);
+  SSL_CTX* cctx = tls::clientCtx();
+  SSL* ssl = SSL_new(cctx);
+  SSL_set_fd(ssl, fd);
+  CHECK(SSL_connect(ssl) == 1);
+  timeval tv{1, 0};
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+
+  std::vector<uint8_t> b;
+  OuchCodec::encode(InboundCommand{mk(1, Side::SELL, 100, 5, 1)}, b);
+  tls::writeFrame(ssl, b.data(), b.size());
+  std::vector<uint8_t> frame;
+  tls::readFrame(ssl, frame);  // wait for Accepted -> resting
+
+  SSL_shutdown(ssl);
+  SSL_free(ssl);
+  ::close(fd);
+  SSL_CTX_free(cctx);
+  gw.stop();  // disconnect -> cancel-on-disconnect fires over TLS
+
+  CHECK(eng.book().empty());
+  bool canceled = false;
+  for (const auto& e : events)
+  {
+    if (const auto* x = std::get_if<OrderCanceled>(&e); x && x->id == 1)
+    {
+      canceled = true;
+    }
+  }
+  CHECK(canceled);
+}
+
+}  // namespace
+
+TEST(Tls, EngineSuite)
+{
+  test_tls_roundtrip();
+  test_tls_cancel_on_disconnect();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_venue.cpp
+++ b/venue/tests/test_venue_venue.cpp
@@ -1,0 +1,285 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/ouch_codec.h"
+#include "flox-venue/resend_buffer.h"
+#include "flox/book/matching_book.h"
+
+#include "flox/backtest/fee_schedule.h"
+
+#include <gtest/gtest.h>
+#include <chrono>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 100;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount base(double v) { return amountOf(qty(v)); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50);
+  c.maxPrice = px(150);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  return c;
+}
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// A representative session of order flow (crossing pairs + a cancel).
+std::vector<std::pair<int64_t, InboundCommand>> session()
+{
+  std::vector<std::pair<int64_t, InboundCommand>> s;
+  s.emplace_back(10, InboundCommand{limit(1, Side::SELL, 100, 5, 1)});
+  s.emplace_back(20, InboundCommand{limit(2, Side::SELL, 101, 3, 1)});
+  s.emplace_back(30, InboundCommand{limit(3, Side::BUY, 99, 4, 2)});
+  s.emplace_back(40, InboundCommand{limit(4, Side::BUY, 100, 6, 2)});  // trades 5@100, rests 1@100
+  s.emplace_back(50, InboundCommand{CancelOrder{2, SYM, 1}});
+  s.emplace_back(60, InboundCommand{limit(5, Side::SELL, 100, 2, 3)});  // trades 1@100 vs id4
+  return s;
+}
+
+uint64_t runReplay(const std::vector<std::pair<int64_t, InboundCommand>>& cmds, Ledger& led)
+{
+  for (int a = 1; a <= 3; ++a)
+  {
+    led.deposit(a, BASE, base(1000));
+    led.deposit(a, QUOTE, quote(100000));
+  }
+  uint64_t h = 1469598103934665603ULL;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { h = hashEvent(h, e); });
+  flox::FeeSchedule fs;
+  fs.addTier(0.0, -1.0, 2.0);
+  eng.setFeeSchedule(fs);
+  eng.setLedger(&led, VENUE);
+  for (const auto& [ts, c] : cmds)
+  {
+    eng.submit(c, ts);
+  }
+  return h;
+}
+
+// An auction driven through the command stream (AdminCmd) must survive journal
+// replay: the uncross fills are produced in BOTH the live run and the replay, so
+// a crash after an opening uncross recovers an identical book/ledger. If AdminCmd
+// were not journaled+dispatched, the uncross would be lost on replay (divergence).
+void test_auction_recovery()
+{
+  std::printf("test_auction_recovery\n");
+  const std::string jpath = "/tmp/flox_test_venue_venue_auction_journal.bin";
+  std::vector<std::pair<int64_t, InboundCommand>> cmds;
+  cmds.emplace_back(10, InboundCommand{AdminCmd{SYM, AdminAction::BeginPreOpen}});
+  cmds.emplace_back(20, InboundCommand{limit(1, Side::SELL, 100, 5, 1)});             // accumulate (no match)
+  cmds.emplace_back(30, InboundCommand{limit(2, Side::BUY, 100, 5, 2)});              // crossed book in pre-open
+  cmds.emplace_back(40, InboundCommand{AdminCmd{SYM, AdminAction::OpenContinuous}});  // uncross @100
+
+  // Live run: journal every command, hash the event stream, count trades.
+  Ledger liveLed;
+  for (int a = 1; a <= 3; ++a)
+  {
+    liveLed.deposit(a, BASE, base(1000));
+    liveLed.deposit(a, QUOTE, quote(100000));
+  }
+  Journal jr(jpath);
+  uint64_t liveHash = 1469598103934665603ULL;
+  int liveTrades = 0;
+  MatchingEngine<MatchingBook> leng(cfg(), [&](const OutboundEvent& e)
+                                    { liveHash = hashEvent(liveHash, e);
+                                      if (std::get_if<Trade>(&e)){ ++liveTrades;
+} });
+  leng.setLedger(&liveLed, VENUE);
+  for (auto& [ts, c] : cmds)
+  {
+    jr.append(c, ts);
+    leng.submit(c, ts);
+  }
+  jr.flush();
+  CHECK(liveTrades > 0);  // the uncross produced fills -> AdminCmd(OpenContinuous) dispatched
+
+  // Recovery: replay the journal into a fresh engine; state must match bit-for-bit.
+  const auto replayed = Journal::loadTimed(jpath);
+  CHECK(replayed.size() == cmds.size());  // AdminCmds round-tripped (not truncated at an unknown tag)
+  Ledger recLed;
+  for (int a = 1; a <= 3; ++a)
+  {
+    recLed.deposit(a, BASE, base(1000));
+    recLed.deposit(a, QUOTE, quote(100000));
+  }
+  uint64_t recHash = 1469598103934665603ULL;
+  int recTrades = 0;
+  MatchingEngine<MatchingBook> reng(cfg(), [&](const OutboundEvent& e)
+                                    { recHash = hashEvent(recHash, e);
+                                      if (std::get_if<Trade>(&e)){ ++recTrades;
+} });
+  reng.setLedger(&recLed, VENUE);
+  for (auto& [ts, c] : replayed)
+  {
+    reng.submit(c, ts);
+  }
+  CHECK(recHash == liveHash);  // replay reproduces the auction uncross exactly
+  CHECK(recTrades == liveTrades);
+  // Ledger conserved and identical post-uncross.
+  CHECK(liveLed.available(1, BASE) == recLed.available(1, BASE));
+  CHECK(liveLed.available(2, QUOTE) == recLed.available(2, QUOTE));
+}
+
+}  // namespace
+
+TEST(Venue, EngineSuite)
+{
+  std::printf("test_venue\n");
+  test_auction_recovery();
+
+  Ledger led;
+  for (int a = 1; a <= 3; ++a)
+  {
+    led.deposit(a, BASE, base(1000));
+    led.deposit(a, QUOTE, quote(100000));
+  }
+  const Amount initBase = base(1000) * 3;
+  const Amount initQuote = quote(100000) * 3;
+
+  Metrics metrics;
+  ResendBuffer resend;
+  MarketDataPublisher<> md([](const MdMessage&) {}, px(0.01), SYM);
+  const std::string journalPath = "/tmp/flox_test_venue_venue_venue_journal.bin";
+  Journal journal(journalPath);
+  const uint64_t clientSession = 7;
+  uint64_t liveHash = 1469598103934665603ULL;
+
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     metrics.observe(e);
+                                     md.onEvent(e);
+                                     resend.append(clientSession, e, /*ts*/ 0);
+                                     liveHash = hashEvent(liveHash, e); });
+  flox::FeeSchedule fs;
+  fs.addTier(0.0, -1.0, 2.0);
+  eng.setFeeSchedule(fs);
+  eng.setLedger(&led, VENUE);
+
+  // Drive the session through the OUCH wire codec, timing each submit.
+  const auto cmds = session();
+  for (const auto& [ts, cmd] : cmds)
+  {
+    std::vector<uint8_t> wire;
+    OuchCodec::encode(cmd, wire);
+    auto decoded = OuchCodec::decode(wire.data(), wire.size());
+    CHECK(decoded.has_value());
+    const auto t0 = std::chrono::steady_clock::now();
+    eng.submit(*decoded, ts);
+    const auto dt = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        std::chrono::steady_clock::now() - t0)
+                        .count();
+    metrics.submitLatency.record(static_cast<uint64_t>(dt));
+    journal.append(cmd, ts);
+  }
+  journal.flush();
+
+  // 1. Market data top-of-book matches the engine book.
+  CHECK(eng.book().bestBid() == md.book().bestBid());
+  CHECK(eng.book().bestAsk() == md.book().bestAsk());
+
+  // 2. Value conserved through settlement + fees.
+  Amount sumBase = led.total(VENUE, BASE);
+  Amount sumQuote = led.total(VENUE, QUOTE);
+  for (int a = 1; a <= 3; ++a)
+  {
+    sumBase += led.total(a, BASE);
+    sumQuote += led.total(a, QUOTE);
+  }
+  CHECK(sumBase == initBase);
+  CHECK(sumQuote == initQuote);
+
+  // 3. Metrics: latency recorded per submit, trades counted.
+  CHECK(metrics.submitLatency.count() == cmds.size());
+  CHECK(metrics.trades > 0);
+  CHECK(metrics.submitLatency.percentileNs(0.5) > 0);
+  std::printf("  submit latency p50=%lluns p99=%lluns; trades=%llu, volume=%.2f\n",
+              (unsigned long long)metrics.submitLatency.percentileNs(0.5),
+              (unsigned long long)metrics.submitLatency.percentileNs(0.99),
+              (unsigned long long)metrics.trades,
+              (double)metrics.volumeRaw / 1e8);
+
+  // 4. Reconnect: client had seen through seq K, resends the remainder.
+  const uint64_t total = resend.lastSeq(clientSession);
+  CHECK(total > 0);
+  const uint64_t k = total / 2;
+  const auto gap = resend.resend(clientSession, k + 1);
+  CHECK(gap.size() == total - k);
+  CHECK(gap.front().seq == k + 1 && gap.back().seq == total);
+
+  // 5. Deterministic recovery: replay the journal reproduces the event stream.
+  const auto replayed = Journal::loadTimed(journalPath);
+  CHECK(replayed.size() == cmds.size());
+  Ledger recovered;
+  CHECK(runReplay(replayed, recovered) == liveHash);
+
+  // 6. Real-money recovery: the recovered ledger balances match the live ledger
+  // EXACTLY (per account + venue, base + quote) -- a recovery that reproduced
+  // the events but not the balances would be catastrophic.
+  for (int a = 1; a <= 3; ++a)
+  {
+    CHECK(recovered.total(a, BASE) == led.total(a, BASE));
+    CHECK(recovered.total(a, QUOTE) == led.total(a, QUOTE));
+    CHECK(recovered.available(a, QUOTE) == led.available(a, QUOTE));
+    CHECK(recovered.reserved(a, QUOTE) == led.reserved(a, QUOTE));
+  }
+  CHECK(recovered.total(VENUE, BASE) == led.total(VENUE, BASE));
+  CHECK(recovered.total(VENUE, QUOTE) == led.total(VENUE, QUOTE));
+
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}


### PR DESCRIPTION
Everything else in flox helps you trade on a market; this module lets you be one. `venue/` adds a matching engine and the machinery around it as an optional module (`FLOX_BUILD_VENUE`, target `flox::venue`, namespace `flox::venue`, include prefix `<flox-venue/...>`), the same shape as `connectors/`.

## What is in the module

- **Matching**: price-time FIFO and pro-rata books, TIF (GTC/IOC/FOK/GTD/post-only), stops, trailing, OCO, iceberg, peg, reduce-only, self-trade prevention (4 modes), last-look, market-maker protection, mass-quote, auctions, LULD.
- **Clearing**: double-entry multi-asset ledger (128-bit fixed point), reservation lifecycle, fees, segregation. Conservation-exact by construction.
- **Derivatives risk**: isolated and cross margin, multi-asset collateral with haircuts, liquidation, insurance fund, ADL, funding (live rate, TWAP, scheduler), manipulation-resistant mark price, stale-feed circuit breaker.
- **Runtime**: single-writer sequenced shard on the flox EventBus, WAL journal, deterministic replay with an event hash, symbol router.
- **Market data and perimeter**: ITCH-style L2 feed, UDP multicast with resend, TCP/WS/TLS gateways, FIX/OUCH/REST codecs, sessions with cancel-on-disconnect, control plane, Prometheus metrics.
- **Per-symbol scale**: symbols whose price or supply range does not fit the default 1e8 scale in int64 set their own price/qty scale; money always settles at a fixed 1e-8 scale.

Order-level books (`flox/book/{resting_order,matching_book,ladder_book}.h`) and a few shared utilities live in core; they are useful on their own.

## Verification

- 42 registered venue tests, including a differential fuzz (reference book vs O(1) ladder must emit byte-identical event streams) and conservation fuzzes across spot, perps, cross margin, and multi-collateral.
- New CI: thread sanitizer added to the matrix for the whole project, a `venue-optional` job proving the `FLOX_BUILD_VENUE=OFF` build stays complete, and a weekly deep-fuzz run.
- The module is off on MSVC/clang-cl (no native 128-bit integers); documented under the build page.

## Fixes in existing code, found by the new coverage

- `LiquidationEngine`: ADL overpaid winners above the bankruptcy price and over-decremented the deficit; non-deterministic ADL tie-break.
- `AtomicLogger`: consumer could read a slot before the producer finished writing it.
- `BinaryLogReader`: unsynchronized lazy scan; `timeRange()` returned empty on a never-scanned reader.
- `BacktestRunner` and `ParallelReader`: lost wakeups (flag stores outside the mutex the wait predicate is checked under); the interactive-runner tests also aborted the whole binary on any failure and used sanitizer-hostile timeouts.
- `LadderBook`: GCC-only bit-scan builtins replaced with `std::countl_zero`/`countr_zero`.
- Demo: latency counters raced across threads; subsystem teardown ran against the data flow.

## Docs and tooling

`docs/venue/` (10 pages: matching, clearing, risk, runtime, market data, perimeter, multi-agent simulation, verification), a one-line README pointer, a multi-agent venue demo (four agent archetypes trading one book), and a `flox_venue_guide` MCP tool.

Generated with [Claude Code](https://claude.com/claude-code)
