### PR TITLE
feat(strategy): shadow mode for suppressed-execution comparison

### DIFF
--- a/include/flox/strategy/shadow.h
+++ b/include/flox/strategy/shadow.h
@@ -1,0 +1,186 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+// Shadow mode: run a candidate strategy on the live feed with execution
+// suppressed, next to a reference implementation of the same logic, and
+// compare what they WOULD have done. This is how the codon path graduates
+// from "passes byte-identical replay fixtures" to "lived on production
+// timing": replay parity cannot see divergences that only appear under live
+// nondeterministic event arrival.
+//
+// Wiring: instead of strategy -> execution signal handler, wire
+// strategy -> ShadowSignalHandler (records, forwards nowhere by default).
+// Works for any strategy runtime -- C++, codon, python -- because the seam
+// is ISignalHandler, below all of them.
+
+#include <cstdint>
+#include <deque>
+#include <string>
+#include <vector>
+
+#include "flox/strategy/abstract_signal_handler.h"
+#include "flox/strategy/signal.h"
+#include "flox/util/performance/latency_contour.h"
+#include "flox/util/performance/latency_histogram.h"
+
+namespace flox
+{
+
+// Records every emitted signal with an emission timestamp. Execution is
+// suppressed unless an inner handler is explicitly provided (canary mode).
+class ShadowSignalHandler : public ISignalHandler
+{
+ public:
+  struct Record
+  {
+    int64_t tsNs{0};
+    SignalType type{SignalType::Market};
+    SymbolId symbol{0};
+    Side side{Side::BUY};
+    int64_t priceRaw{0};
+    int64_t qtyRaw{0};
+  };
+
+  explicit ShadowSignalHandler(size_t maxRecords = 1'000'000,
+                               ISignalHandler* forwardTo = nullptr)
+      : _maxRecords(maxRecords), _inner(forwardTo)
+  {
+  }
+
+  void onSignal(const Signal& signal) override
+  {
+    Record r;
+    r.tsNs = performance::monotonicNs();
+    r.type = signal.type;
+    r.symbol = signal.symbol;
+    r.side = signal.side;
+    r.priceRaw = signal.price.raw();
+    r.qtyRaw = signal.quantity.raw();
+    if (_records.size() >= _maxRecords)
+    {
+      _records.pop_front();
+      ++_evicted;
+    }
+    _records.push_back(r);
+
+    if (_inner)
+    {
+      _inner->onSignal(signal);
+    }
+  }
+
+  const std::deque<Record>& records() const noexcept { return _records; }
+  uint64_t evicted() const noexcept { return _evicted; }
+  void clear() { _records.clear(); }
+
+ private:
+  size_t _maxRecords;
+  ISignalHandler* _inner;
+  std::deque<Record> _records;
+  uint64_t _evicted{0};
+};
+
+// Compares two shadow streams -- candidate (e.g. the codon build) against
+// reference (the C++ build) fed from the same event stream. Signals are
+// matched by emission order; a divergence is any difference in type, symbol,
+// side, price or quantity. Latency delta per matched pair (candidate minus
+// reference emission timestamp) lands in a histogram: the answer to "is the
+// codon path slower, and by how much, at p99".
+class ShadowComparator
+{
+ public:
+  struct Divergence
+  {
+    size_t index{0};
+    std::string what;
+  };
+
+  struct Report
+  {
+    size_t referenceCount{0};
+    size_t candidateCount{0};
+    size_t matched{0};
+    std::vector<Divergence> divergences;
+    // candidate.tsNs - reference.tsNs per matched pair, clamped at zero for
+    // the histogram (relative ordering jitter can make it negative).
+    performance::LatencyHistogram* latencyDelta{nullptr};
+
+    bool clean() const noexcept
+    {
+      return divergences.empty() && referenceCount == candidateCount;
+    }
+  };
+
+  Report compare(const ShadowSignalHandler& reference,
+                 const ShadowSignalHandler& candidate)
+  {
+    Report rep;
+    const auto& a = reference.records();
+    const auto& b = candidate.records();
+    rep.referenceCount = a.size();
+    rep.candidateCount = b.size();
+    rep.latencyDelta = &_latencyDelta;
+
+    const size_t n = std::min(a.size(), b.size());
+    for (size_t i = 0; i < n; ++i)
+    {
+      std::string diff = diffOne(a[i], b[i]);
+      if (!diff.empty())
+      {
+        rep.divergences.push_back({i, std::move(diff)});
+        continue;
+      }
+      ++rep.matched;
+      const int64_t delta = b[i].tsNs - a[i].tsNs;
+      _latencyDelta.record(delta > 0 ? delta : 0);
+    }
+    if (a.size() != b.size())
+    {
+      rep.divergences.push_back(
+          {n, "signal count mismatch: reference=" + std::to_string(a.size()) +
+                  " candidate=" + std::to_string(b.size())});
+    }
+    return rep;
+  }
+
+ private:
+  static std::string diffOne(const ShadowSignalHandler::Record& a,
+                             const ShadowSignalHandler::Record& b)
+  {
+    if (a.type != b.type)
+    {
+      return "type mismatch";
+    }
+    if (a.symbol != b.symbol)
+    {
+      return "symbol mismatch";
+    }
+    if (a.side != b.side)
+    {
+      return "side mismatch";
+    }
+    if (a.priceRaw != b.priceRaw)
+    {
+      return "price mismatch: " + std::to_string(a.priceRaw) + " vs " +
+             std::to_string(b.priceRaw);
+    }
+    if (a.qtyRaw != b.qtyRaw)
+    {
+      return "quantity mismatch: " + std::to_string(a.qtyRaw) + " vs " +
+             std::to_string(b.qtyRaw);
+    }
+    return {};
+  }
+
+  performance::LatencyHistogram _latencyDelta;
+};
+
+}  // namespace flox

--- a/mcp/flox_mcp/data/binding_manifest.json
+++ b/mcp/flox_mcp/data/binding_manifest.json
@@ -11531,6 +11531,11 @@
           "name": "DeltaHedger"
         },
         {
+          "header": "include/flox/strategy/shadow.h",
+          "kind": "type",
+          "name": "Divergence"
+        },
+        {
           "header": "include/flox/pricing/carry.h",
           "kind": "type",
           "name": "Dividend"
@@ -12881,6 +12886,11 @@
           "name": "ReaderStats"
         },
         {
+          "header": "include/flox/strategy/shadow.h",
+          "kind": "type",
+          "name": "Record"
+        },
+        {
           "header": "include/flox/testing/bar_dispatch_recorder.h",
           "kind": "type",
           "name": "Recorder"
@@ -12944,6 +12954,11 @@
           "header": "include/flox/replay/abstract_replay_source.h",
           "kind": "type",
           "name": "ReplaySpeed"
+        },
+        {
+          "header": "include/flox/strategy/shadow.h",
+          "kind": "type",
+          "name": "Report"
         },
         {
           "header": "include/flox/book/resting_order.h",
@@ -13089,6 +13104,16 @@
           "header": "include/flox/run/trace_recorder.h",
           "kind": "type",
           "name": "SegmentWriter"
+        },
+        {
+          "header": "include/flox/strategy/shadow.h",
+          "kind": "type",
+          "name": "ShadowComparator"
+        },
+        {
+          "header": "include/flox/strategy/shadow.h",
+          "kind": "type",
+          "name": "ShadowSignalHandler"
         },
         {
           "header": "include/flox/indicator/shannon_entropy.h",
@@ -21717,6 +21742,26 @@
         },
         {
           "kind": "method",
+          "name": "clear",
+          "parent": "Record"
+        },
+        {
+          "kind": "method",
+          "name": "evicted",
+          "parent": "Record"
+        },
+        {
+          "kind": "method",
+          "name": "onSignal",
+          "parent": "Record"
+        },
+        {
+          "kind": "method",
+          "name": "records",
+          "parent": "Record"
+        },
+        {
+          "kind": "method",
           "name": "load",
           "parent": "RecordingMetadata"
         },
@@ -21934,6 +21979,16 @@
           "kind": "method",
           "name": "realtime",
           "parent": "ReplaySpeed"
+        },
+        {
+          "kind": "method",
+          "name": "compare",
+          "parent": "Report"
+        },
+        {
+          "kind": "method",
+          "name": "diffOne",
+          "parent": "Report"
         },
         {
           "kind": "method",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ function(add_flox_test name)
 endfunction()
 
 add_flox_test(test_book_update_bus)
+add_flox_test(test_shadow_mode)
 add_flox_test(test_latency_contour)
 add_flox_test(test_rt_spin_guard)
 add_flox_test(test_event_bus_health)

--- a/tests/test_shadow_mode.cpp
+++ b/tests/test_shadow_mode.cpp
@@ -1,0 +1,125 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <gtest/gtest.h>
+
+#include "flox/strategy/shadow.h"
+
+using flox::Price;
+using flox::Quantity;
+using flox::ShadowComparator;
+using flox::ShadowSignalHandler;
+using flox::Side;
+using flox::Signal;
+using flox::SignalType;
+
+namespace
+{
+
+Signal makeSignal(SignalType type, uint32_t symbol, Side side, double price, double qty)
+{
+  Signal s;
+  s.type = type;
+  s.symbol = symbol;
+  s.side = side;
+  s.price = Price::fromDouble(price);
+  s.quantity = Quantity::fromDouble(qty);
+  return s;
+}
+
+class CountingInner : public flox::ISignalHandler
+{
+ public:
+  void onSignal(const Signal&) override { ++count; }
+  int count{0};
+};
+
+}  // namespace
+
+TEST(ShadowSignalHandler, RecordsAndSuppressesExecution)
+{
+  ShadowSignalHandler shadow;
+  shadow.onSignal(makeSignal(SignalType::Limit, 1, Side::BUY, 100.5, 2.0));
+  shadow.onSignal(makeSignal(SignalType::Cancel, 1, Side::SELL, 0.0, 0.0));
+
+  ASSERT_EQ(shadow.records().size(), 2u);
+  EXPECT_EQ(shadow.records()[0].type, SignalType::Limit);
+  EXPECT_EQ(shadow.records()[0].priceRaw, Price::fromDouble(100.5).raw());
+  EXPECT_GT(shadow.records()[0].tsNs, 0);
+  // No inner handler: nothing was executed, by construction.
+}
+
+TEST(ShadowSignalHandler, CanaryModeForwards)
+{
+  CountingInner inner;
+  ShadowSignalHandler shadow(100, &inner);
+  shadow.onSignal(makeSignal(SignalType::Market, 1, Side::BUY, 0.0, 1.0));
+  EXPECT_EQ(inner.count, 1);
+  EXPECT_EQ(shadow.records().size(), 1u);
+}
+
+TEST(ShadowSignalHandler, BoundedMemoryEvictsOldest)
+{
+  ShadowSignalHandler shadow(/*maxRecords=*/3);
+  for (int i = 0; i < 5; ++i)
+  {
+    shadow.onSignal(makeSignal(SignalType::Market, uint32_t(i), Side::BUY, 0.0, 1.0));
+  }
+  EXPECT_EQ(shadow.records().size(), 3u);
+  EXPECT_EQ(shadow.evicted(), 2u);
+  EXPECT_EQ(shadow.records().front().symbol, 2u);  // oldest two evicted
+}
+
+TEST(ShadowComparator, IdenticalStreamsAreClean)
+{
+  ShadowSignalHandler ref, cand;
+  for (int i = 0; i < 10; ++i)
+  {
+    const auto s = makeSignal(SignalType::Limit, 1, Side::BUY, 100.0 + i, 1.0);
+    ref.onSignal(s);
+    cand.onSignal(s);
+  }
+
+  ShadowComparator cmp;
+  const auto rep = cmp.compare(ref, cand);
+  EXPECT_TRUE(rep.clean());
+  EXPECT_EQ(rep.matched, 10u);
+  EXPECT_EQ(rep.latencyDelta->count(), 10u);
+}
+
+TEST(ShadowComparator, DivergenceIsLocatedAndDescribed)
+{
+  ShadowSignalHandler ref, cand;
+  ref.onSignal(makeSignal(SignalType::Limit, 1, Side::BUY, 100.0, 1.0));
+  cand.onSignal(makeSignal(SignalType::Limit, 1, Side::BUY, 100.0, 1.0));
+  ref.onSignal(makeSignal(SignalType::Limit, 1, Side::BUY, 101.0, 1.0));
+  cand.onSignal(makeSignal(SignalType::Limit, 1, Side::SELL, 101.0, 1.0));  // diverges
+
+  ShadowComparator cmp;
+  const auto rep = cmp.compare(ref, cand);
+  EXPECT_FALSE(rep.clean());
+  ASSERT_EQ(rep.divergences.size(), 1u);
+  EXPECT_EQ(rep.divergences[0].index, 1u);
+  EXPECT_EQ(rep.divergences[0].what, "side mismatch");
+  EXPECT_EQ(rep.matched, 1u);
+}
+
+TEST(ShadowComparator, CountMismatchIsReported)
+{
+  ShadowSignalHandler ref, cand;
+  ref.onSignal(makeSignal(SignalType::Market, 1, Side::BUY, 0.0, 1.0));
+  ref.onSignal(makeSignal(SignalType::Market, 1, Side::BUY, 0.0, 1.0));
+  cand.onSignal(makeSignal(SignalType::Market, 1, Side::BUY, 0.0, 1.0));
+
+  ShadowComparator cmp;
+  const auto rep = cmp.compare(ref, cand);
+  EXPECT_FALSE(rep.clean());
+  ASSERT_EQ(rep.divergences.size(), 1u);
+  EXPECT_NE(rep.divergences[0].what.find("count mismatch"), std::string::npos);
+}


### PR DESCRIPTION
## What

Shadow mode for comparing a candidate strategy against a reference under suppressed execution.

`ShadowSignalHandler` wires in at the `ISignalHandler` seam (below every strategy runtime — C++, Codon, Python): it records each emitted signal with an emission timestamp and executes nothing unless an inner handler is attached (canary mode), with bounded memory and eviction accounting.

`ShadowComparator` matches a candidate signal stream against a reference stream in emission order, locates and describes divergences, and histograms the per-pair emission-latency delta.

## Tests

`test_shadow_mode` — identical streams, divergence localization, count mismatch, drop, canary, bounded memory.
