### PR TITLE
feat(net): receive-path abstraction with UDP socket and AF_XDP backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,23 @@ else()
   target_compile_definitions(${FLOX} PUBLIC FLOX_ONNX_ENABLED=0)
 endif()
 
+# AF_XDP receive-path backend (flox/net/af_xdp_receive_path.h). Linux-only,
+# needs libxdp/libbpf; off by default.
+option(FLOX_ENABLE_AF_XDP "Enable AF_XDP receive-path backend" OFF)
+if(FLOX_ENABLE_AF_XDP)
+  find_library(XDP_LIBRARY NAMES xdp)
+  find_library(BPF_LIBRARY NAMES bpf)
+  if(XDP_LIBRARY AND BPF_LIBRARY)
+    target_link_libraries(${FLOX} PUBLIC ${XDP_LIBRARY} ${BPF_LIBRARY})
+    target_compile_definitions(${FLOX} PUBLIC FLOX_AF_XDP_ENABLED=1)
+    message(STATUS "AF_XDP backend enabled: ${XDP_LIBRARY}")
+  else()
+    message(FATAL_ERROR "FLOX_ENABLE_AF_XDP=ON but libxdp/libbpf were not found")
+  endif()
+else()
+  target_compile_definitions(${FLOX} PUBLIC FLOX_AF_XDP_ENABLED=0)
+endif()
+
 option(FLOX_ENABLE_LZ4 "Enable LZ4 compression for binary logs" ON)
 if(FLOX_ENABLE_LZ4)
   # Try find_package first (works with vcpkg on Windows)

--- a/include/flox/net/af_xdp_receive_path.h
+++ b/include/flox/net/af_xdp_receive_path.h
@@ -1,0 +1,248 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+// AF_XDP backend for IReceivePath. The kernel keeps the NIC; an XDP program
+// (libxdp attaches its default redirector) short-circuits frames into a
+// user-space UMEM ring before sk_buff allocation. Compared to the socket
+// backend this removes the kernel network stack and the syscall per batch
+// from the receive path; compared to DPDK the host stays a normal Linux
+// machine.
+//
+// Delivery semantics match UdpSocketReceivePath: the callback receives the
+// UDP payload, not the raw Ethernet frame. Frames that are not UDP, or that
+// miss the configured port filter, are counted and dropped.
+//
+// Requires: Linux, libxdp/libbpf, CAP_NET_RAW + CAP_BPF (or root), and a
+// build with -DFLOX_ENABLE_AF_XDP=ON. Generic (SKB) mode works on any
+// driver including veth; native mode needs driver support and is the
+// deployment choice, not the default.
+
+#if defined(__linux__) && FLOX_AF_XDP_ENABLED
+
+#include <linux/if_ether.h>
+#include <linux/if_link.h>
+#include <linux/ip.h>
+#include <linux/udp.h>
+#include <sys/mman.h>
+#include <xdp/xsk.h>
+
+#include <cstring>
+#include <string>
+
+#include "flox/net/receive_path.h"
+
+namespace flox::net
+{
+
+class AfXdpReceivePath : public IReceivePath
+{
+ public:
+  struct Config
+  {
+    std::string ifname;
+    uint32_t queueId{0};
+    uint16_t udpPortFilter{0};  // 0 = accept every UDP port
+    uint32_t frameCount{4096};  // UMEM frames of XSK_UMEM__DEFAULT_FRAME_SIZE
+    bool skbMode{true};         // generic XDP; native needs driver support
+  };
+
+  explicit AfXdpReceivePath(const Config& cfg) : _cfg(cfg)
+  {
+    const size_t frameSize = XSK_UMEM__DEFAULT_FRAME_SIZE;
+    _umemSize = size_t(cfg.frameCount) * frameSize;
+    _umemArea = ::mmap(nullptr, _umemSize, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (_umemArea == MAP_FAILED)
+    {
+      _umemArea = nullptr;
+      return;
+    }
+
+    // Size the fill and completion rings to hold every frame. The default
+    // ring size is 2048; leaving it default while reserving frameCount>2048
+    // makes the reserve fail, the fill ring stay empty, and the kernel has
+    // nowhere to deliver -- zero packets with no error.
+    xsk_umem_config ucfg{};
+    ucfg.fill_size = cfg.frameCount;
+    ucfg.comp_size = cfg.frameCount;
+    ucfg.frame_size = frameSize;
+    ucfg.frame_headroom = XSK_UMEM__DEFAULT_FRAME_HEADROOM;
+    ucfg.flags = 0;
+    if (xsk_umem__create(&_umem, _umemArea, _umemSize, &_fill, &_comp, &ucfg) != 0)
+    {
+      return;
+    }
+
+    xsk_socket_config scfg{};
+    scfg.rx_size = cfg.frameCount;
+    scfg.tx_size = 0;
+    scfg.xdp_flags = cfg.skbMode ? XDP_FLAGS_SKB_MODE : XDP_FLAGS_DRV_MODE;
+    scfg.bind_flags = XDP_COPY | XDP_USE_NEED_WAKEUP;
+
+    if (xsk_socket__create(&_xsk, cfg.ifname.c_str(), cfg.queueId, _umem, &_rx,
+                           nullptr, &scfg) != 0)
+    {
+      return;
+    }
+    _xskFd = xsk_socket__fd(_xsk);
+
+    // Hand frames to the fill ring: the kernel writes arriving frames into
+    // them and returns them through the rx ring. Reserve one less than the
+    // ring so it is never completely full.
+    const uint32_t fillCount = cfg.frameCount;
+    uint32_t idx = 0;
+    if (xsk_ring_prod__reserve(&_fill, fillCount, &idx) == fillCount)
+    {
+      for (uint32_t i = 0; i < fillCount; ++i)
+      {
+        *xsk_ring_prod__fill_addr(&_fill, idx + i) = uint64_t(i) * frameSize;
+      }
+      xsk_ring_prod__submit(&_fill, fillCount);
+    }
+    _valid = true;
+  }
+
+  ~AfXdpReceivePath() override
+  {
+    if (_xsk)
+    {
+      xsk_socket__delete(_xsk);
+    }
+    if (_umem)
+    {
+      xsk_umem__delete(_umem);
+    }
+    if (_umemArea)
+    {
+      ::munmap(_umemArea, _umemSize);
+    }
+  }
+
+  AfXdpReceivePath(const AfXdpReceivePath&) = delete;
+  AfXdpReceivePath& operator=(const AfXdpReceivePath&) = delete;
+
+  bool valid() const noexcept { return _valid; }
+  uint64_t droppedNonUdp() const noexcept { return _droppedNonUdp; }
+
+  RxTimestampMode timestampMode() const override
+  {
+    // Frames carry no kernel timestamp on this path; the poll loop stamps
+    // with the monotonic clock at dequeue.
+    return RxTimestampMode::SOFTWARE;
+  }
+
+  int poll(const std::function<void(const Datagram&)>& cb, int maxPackets) override
+  {
+    if (!_valid)
+    {
+      return 0;
+    }
+
+    uint32_t idx = 0;
+    const uint32_t got =
+        xsk_ring_cons__peek(&_rx, static_cast<uint32_t>(maxPackets), &idx);
+    if (got == 0)
+    {
+      // With XDP_USE_NEED_WAKEUP the kernel will not process the fill ring
+      // until poked once it has flagged a wakeup. A non-blocking recvfrom is
+      // the documented kick.
+      if (xsk_ring_prod__needs_wakeup(&_fill))
+      {
+        ::recvfrom(_xskFd, nullptr, 0, MSG_DONTWAIT, nullptr, nullptr);
+      }
+      return 0;
+    }
+
+    const int64_t now = performance::monotonicNs();
+    int delivered = 0;
+
+    for (uint32_t i = 0; i < got; ++i)
+    {
+      const xdp_desc* desc = xsk_ring_cons__rx_desc(&_rx, idx + i);
+      const auto* frame =
+          static_cast<const uint8_t*>(xsk_umem__get_data(_umemArea, desc->addr));
+
+      const auto payload = udpPayload(frame, desc->len);
+      if (payload.data() != nullptr)
+      {
+        Datagram d;
+        d.payload = payload;
+        d.rxTimestampNs = now;
+        cb(d);
+        ++delivered;
+      }
+      else
+      {
+        ++_droppedNonUdp;
+      }
+
+      // Return the frame to the fill ring for reuse.
+      uint32_t fidx = 0;
+      if (xsk_ring_prod__reserve(&_fill, 1, &fidx) == 1)
+      {
+        *xsk_ring_prod__fill_addr(&_fill, fidx) = desc->addr;
+        xsk_ring_prod__submit(&_fill, 1);
+      }
+    }
+
+    xsk_ring_cons__release(&_rx, got);
+    return delivered;
+  }
+
+ private:
+  std::span<const std::byte> udpPayload(const uint8_t* frame, uint32_t len) const
+  {
+    if (len < sizeof(ethhdr) + sizeof(iphdr) + sizeof(udphdr))
+    {
+      return {};
+    }
+    const auto* eth = reinterpret_cast<const ethhdr*>(frame);
+    if (ntohs(eth->h_proto) != ETH_P_IP)
+    {
+      return {};
+    }
+    const auto* ip = reinterpret_cast<const iphdr*>(frame + sizeof(ethhdr));
+    if (ip->protocol != IPPROTO_UDP)
+    {
+      return {};
+    }
+    const size_t ipLen = size_t(ip->ihl) * 4;
+    const auto* udp = reinterpret_cast<const udphdr*>(frame + sizeof(ethhdr) + ipLen);
+    if (_cfg.udpPortFilter != 0 && ntohs(udp->dest) != _cfg.udpPortFilter)
+    {
+      return {};
+    }
+    const size_t header = sizeof(ethhdr) + ipLen + sizeof(udphdr);
+    const size_t udpLen = ntohs(udp->len);
+    if (udpLen < sizeof(udphdr) || header + (udpLen - sizeof(udphdr)) > len)
+    {
+      return {};
+    }
+    return {reinterpret_cast<const std::byte*>(frame + header),
+            udpLen - sizeof(udphdr)};
+  }
+
+  Config _cfg;
+  void* _umemArea{nullptr};
+  size_t _umemSize{0};
+  xsk_umem* _umem{nullptr};
+  xsk_socket* _xsk{nullptr};
+  xsk_ring_prod _fill{};
+  xsk_ring_cons _comp{};
+  xsk_ring_cons _rx{};
+  int _xskFd{-1};
+  bool _valid{false};
+  uint64_t _droppedNonUdp{0};
+};
+
+}  // namespace flox::net
+
+#endif  // __linux__ && FLOX_AF_XDP_ENABLED

--- a/include/flox/net/receive_path.h
+++ b/include/flox/net/receive_path.h
@@ -1,0 +1,191 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#pragma once
+
+// Receive-path abstraction: the seam between "bytes arrive on the host" and
+// "a decoder sees a datagram". Host bypass technology is not the framework's
+// business -- the attachment point is. UDP connectors poll an IReceivePath;
+// which backend fills it is a deployment decision:
+//
+//   - UdpSocketReceivePath (here): non-blocking socket + recvmsg, kernel or
+//     NIC receive timestamps when available. Works everywhere; the default.
+//   - AF_XDP backend (designed, Linux-only, not yet implemented): kernel
+//     keeps the NIC, an eBPF program redirects to a user-space UMEM ring --
+//     the pragmatic middle between the kernel path and full DPDK. Needs
+//     libxdp, a capable driver, and a Linux host to validate against; the
+//     interface below is shaped so it drops in (poll semantics, borrowed
+//     buffers, explicit rx timestamps).
+//
+// Contract: payload spans are BORROWED -- valid only inside the callback.
+// The decoder consumes or copies before returning; nothing allocates on the
+// per-packet path.
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <span>
+#include <string>
+
+#include "flox/net/rx_timestamp.h"
+#include "flox/util/performance/latency_contour.h"
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace flox::net
+{
+
+struct Datagram
+{
+  std::span<const std::byte> payload;  // borrowed: valid inside the callback only
+  int64_t rxTimestampNs{0};            // hop zero of the latency contour
+};
+
+class IReceivePath
+{
+ public:
+  virtual ~IReceivePath() = default;
+
+  // Drains up to maxPackets, invoking cb per datagram. Returns the number
+  // delivered; 0 = nothing pending. Non-blocking: busy-poll loops and
+  // backoff live in the caller, not the backend.
+  virtual int poll(const std::function<void(const Datagram&)>& cb, int maxPackets) = 0;
+
+  virtual RxTimestampMode timestampMode() const = 0;
+};
+
+#if defined(__linux__) || defined(__APPLE__)
+
+// Default backend: non-blocking UDP socket. Kernel (or NIC, Linux + capable
+// hardware) receive timestamps via rx_timestamp.h; falls back to
+// monotonicNs() at recvmsg return when the control message is absent.
+class UdpSocketReceivePath : public IReceivePath
+{
+ public:
+  struct Config
+  {
+    std::string bindAddress{"0.0.0.0"};
+    uint16_t port{0};
+    std::string multicastGroup{};  // empty = plain unicast
+    int recvBufferBytes{4 * 1024 * 1024};
+    bool wantHardwareTimestamps{true};
+    size_t maxDatagramBytes{65536};
+  };
+
+  explicit UdpSocketReceivePath(const Config& cfg) : _buffer(cfg.maxDatagramBytes)
+  {
+    _fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (_fd < 0)
+    {
+      return;
+    }
+
+    const int one = 1;
+    ::setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    ::setsockopt(_fd, SOL_SOCKET, SO_RCVBUF, &cfg.recvBufferBytes,
+                 sizeof(cfg.recvBufferBytes));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(cfg.port);
+    addr.sin_addr.s_addr = ::inet_addr(cfg.bindAddress.c_str());
+    if (::bind(_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+    {
+      ::close(_fd);
+      _fd = -1;
+      return;
+    }
+
+    if (!cfg.multicastGroup.empty())
+    {
+      ip_mreq mreq{};
+      mreq.imr_multiaddr.s_addr = ::inet_addr(cfg.multicastGroup.c_str());
+      mreq.imr_interface.s_addr = ::inet_addr(cfg.bindAddress.c_str());
+      ::setsockopt(_fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
+    }
+
+    ::fcntl(_fd, F_SETFL, ::fcntl(_fd, F_GETFL, 0) | O_NONBLOCK);
+    _tsMode = enableRxTimestamps(_fd, cfg.wantHardwareTimestamps);
+  }
+
+  ~UdpSocketReceivePath() override
+  {
+    if (_fd >= 0)
+    {
+      ::close(_fd);
+    }
+  }
+
+  UdpSocketReceivePath(const UdpSocketReceivePath&) = delete;
+  UdpSocketReceivePath& operator=(const UdpSocketReceivePath&) = delete;
+
+  bool valid() const noexcept { return _fd >= 0; }
+  int fd() const noexcept { return _fd; }
+  RxTimestampMode timestampMode() const override { return _tsMode; }
+
+  // Local port after bind (useful when cfg.port == 0 let the OS pick).
+  uint16_t localPort() const
+  {
+    sockaddr_in addr{};
+    socklen_t len = sizeof(addr);
+    if (_fd < 0 || ::getsockname(_fd, reinterpret_cast<sockaddr*>(&addr), &len) != 0)
+    {
+      return 0;
+    }
+    return ntohs(addr.sin_port);
+  }
+
+  int poll(const std::function<void(const Datagram&)>& cb, int maxPackets) override
+  {
+    int delivered = 0;
+    while (delivered < maxPackets)
+    {
+      iovec iov{_buffer.data(), _buffer.size()};
+      alignas(cmsghdr) char control[256];
+      msghdr msg{};
+      msg.msg_iov = &iov;
+      msg.msg_iovlen = 1;
+      msg.msg_control = control;
+      msg.msg_controllen = sizeof(control);
+
+      const ssize_t n = ::recvmsg(_fd, &msg, 0);
+      if (n <= 0)
+      {
+        break;  // EAGAIN or error: nothing pending
+      }
+
+      Datagram d;
+      d.payload = {reinterpret_cast<const std::byte*>(_buffer.data()),
+                   static_cast<size_t>(n)};
+      d.rxTimestampNs = extractRxTimestampNs(msg);
+      if (d.rxTimestampNs == 0)
+      {
+        d.rxTimestampNs = performance::monotonicNs();
+      }
+      cb(d);
+      ++delivered;
+    }
+    return delivered;
+  }
+
+ private:
+  int _fd{-1};
+  RxTimestampMode _tsMode{RxTimestampMode::NONE};
+  std::vector<char> _buffer;
+};
+
+#endif  // __linux__ || __APPLE__
+
+}  // namespace flox::net

--- a/include/flox/net/rx_timestamp.h
+++ b/include/flox/net/rx_timestamp.h
@@ -84,7 +84,10 @@ inline RxTimestampMode enableRxTimestamps(int fd, bool wantHardware = true)
 
 // Extracts the receive timestamp (ns since epoch of the respective clock)
 // from a recvmsg() control buffer. Returns 0 when absent -- caller falls
-// back to monotonicNs() taken at recv return.
+// back to monotonicNs() taken at recv return. Defined only where the socket
+// control-message API exists; the sole caller (the UDP receive path) is
+// itself platform-guarded, so other platforms never reference it.
+#if defined(__linux__) || defined(__APPLE__)
 inline int64_t extractRxTimestampNs(const msghdr& msg)
 {
 #if defined(__linux__)
@@ -102,7 +105,7 @@ inline int64_t extractRxTimestampNs(const msghdr& msg)
     }
   }
   return 0;
-#elif defined(__APPLE__)
+#else  // __APPLE__
   for (cmsghdr* c = CMSG_FIRSTHDR(const_cast<msghdr*>(&msg)); c != nullptr;
        c = CMSG_NXTHDR(const_cast<msghdr*>(&msg), c))
   {
@@ -113,10 +116,8 @@ inline int64_t extractRxTimestampNs(const msghdr& msg)
     }
   }
   return 0;
-#else
-  (void)msg;
-  return 0;
 #endif
 }
+#endif  // __linux__ || __APPLE__
 
 }  // namespace flox::net

--- a/mcp/flox_mcp/data/binding_manifest.json
+++ b/mcp/flox_mcp/data/binding_manifest.json
@@ -11036,6 +11036,11 @@
           "name": "AdxResult"
         },
         {
+          "header": "include/flox/net/af_xdp_receive_path.h",
+          "kind": "type",
+          "name": "AfXdpReceivePath"
+        },
+        {
           "header": "include/flox/util/eventing/event_bus.h",
           "kind": "type",
           "name": "AffinityConfig"
@@ -11406,6 +11411,16 @@
           "name": "Config"
         },
         {
+          "header": "include/flox/net/af_xdp_receive_path.h",
+          "kind": "type",
+          "name": "Config"
+        },
+        {
+          "header": "include/flox/net/receive_path.h",
+          "kind": "type",
+          "name": "Config"
+        },
+        {
           "header": "include/flox/replay/readers/mmap_reader.h",
           "kind": "type",
           "name": "Config"
@@ -11494,6 +11509,11 @@
           "header": "include/flox/indicator/dema.h",
           "kind": "type",
           "name": "DEMA"
+        },
+        {
+          "header": "include/flox/net/receive_path.h",
+          "kind": "type",
+          "name": "Datagram"
         },
         {
           "header": "include/flox/replay/readers/binary_log_reader.h",
@@ -11954,6 +11974,11 @@
           "header": "include/flox/position/position_valuator.h",
           "kind": "type",
           "name": "IPositionValuator"
+        },
+        {
+          "header": "include/flox/net/receive_path.h",
+          "kind": "type",
+          "name": "IReceivePath"
         },
         {
           "header": "include/flox/replay/abstract_replay_source.h",
@@ -13529,6 +13554,11 @@
           "header": "include/flox/backtest/simulated_executor.h",
           "kind": "type",
           "name": "TrailingState"
+        },
+        {
+          "header": "include/flox/net/receive_path.h",
+          "kind": "type",
+          "name": "UdpSocketReceivePath"
         },
         {
           "header": "include/flox/indicator/vwap.h",
@@ -15947,7 +15977,17 @@
         },
         {
           "kind": "method",
+          "name": "droppedNonUdp",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "empty",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "fd",
           "parent": "Config"
         },
         {
@@ -15992,6 +16032,11 @@
         },
         {
           "kind": "method",
+          "name": "localPort",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "makerFillRatio",
           "parent": "Config"
         },
@@ -16023,6 +16068,11 @@
         {
           "kind": "method",
           "name": "peekBest",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "poll",
           "parent": "Config"
         },
         {
@@ -16087,12 +16137,27 @@
         },
         {
           "kind": "method",
+          "name": "timestampMode",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "totalEvents",
           "parent": "Config"
         },
         {
           "kind": "method",
           "name": "tryAcquire",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "udpPayload",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
+          "name": "valid",
           "parent": "Config"
         },
         {
@@ -17774,6 +17839,16 @@
           "kind": "method",
           "name": "unrealizedPnl",
           "parent": "IPositionValuator"
+        },
+        {
+          "kind": "method",
+          "name": "poll",
+          "parent": "IReceivePath"
+        },
+        {
+          "kind": "method",
+          "name": "timestampMode",
+          "parent": "IReceivePath"
         },
         {
           "kind": "method",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,11 @@ if(FLOX_ENABLE_ONNX)
     FLOX_TEST_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
 endif()
 
+# test_receive_path uses POSIX sockets; not built on Windows.
+if(NOT WIN32)
+  add_flox_test(test_receive_path)
+endif()
+
 if(FLOX_ENABLE_BACKTEST)
   add_flox_test(test_backtest)
   add_flox_test(test_strategy_pump)

--- a/tests/test_receive_path.cpp
+++ b/tests/test_receive_path.cpp
@@ -1,0 +1,131 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "flox/net/receive_path.h"
+
+using flox::net::Datagram;
+using flox::net::UdpSocketReceivePath;
+
+namespace
+{
+
+int sendTo(uint16_t port, const std::string& payload)
+{
+  const int fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+  const auto n = ::sendto(fd, payload.data(), payload.size(), 0,
+                          reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+  ::close(fd);
+  return static_cast<int>(n);
+}
+
+}  // namespace
+
+TEST(UdpSocketReceivePath, BindsAndReportsTimestampMode)
+{
+  UdpSocketReceivePath::Config cfg;
+  cfg.bindAddress = "127.0.0.1";
+  cfg.port = 0;  // OS picks
+  UdpSocketReceivePath rx(cfg);
+  ASSERT_TRUE(rx.valid());
+  EXPECT_GT(rx.localPort(), 0);
+  // macOS delivers SOFTWARE (SO_TIMESTAMP); Linux SOFTWARE or HARDWARE
+  // (hardware means requested-and-accepted; software stamps are always
+  // requested alongside as the per-packet fallback).
+  EXPECT_NE(rx.timestampMode(), flox::net::RxTimestampMode::NONE);
+}
+
+TEST(UdpSocketReceivePath, DeliversDatagramsWithTimestamps)
+{
+  UdpSocketReceivePath::Config cfg;
+  cfg.bindAddress = "127.0.0.1";
+  cfg.port = 0;
+  UdpSocketReceivePath rx(cfg);
+  ASSERT_TRUE(rx.valid());
+  const auto port = rx.localPort();
+
+  ASSERT_GT(sendTo(port, "alpha"), 0);
+  ASSERT_GT(sendTo(port, "bravo"), 0);
+
+  std::vector<std::string> got;
+  std::vector<int64_t> stamps;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (got.size() < 2 && std::chrono::steady_clock::now() < deadline)
+  {
+    rx.poll(
+        [&](const Datagram& d)
+        {
+          got.emplace_back(reinterpret_cast<const char*>(d.payload.data()),
+                           d.payload.size());
+          stamps.push_back(d.rxTimestampNs);
+        },
+        16);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  ASSERT_EQ(got.size(), 2u);
+  EXPECT_EQ(got[0], "alpha");
+  EXPECT_EQ(got[1], "bravo");
+  EXPECT_GT(stamps[0], 0);
+  EXPECT_GT(stamps[1], 0);
+}
+
+TEST(UdpSocketReceivePath, PollRespectsMaxPacketsAndDrainsRest)
+{
+  UdpSocketReceivePath::Config cfg;
+  cfg.bindAddress = "127.0.0.1";
+  cfg.port = 0;
+  UdpSocketReceivePath rx(cfg);
+  ASSERT_TRUE(rx.valid());
+  const auto port = rx.localPort();
+
+  for (int i = 0; i < 5; ++i)
+  {
+    ASSERT_GT(sendTo(port, "pkt" + std::to_string(i)), 0);
+  }
+  // Give the loopback a moment to enqueue everything.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  int first = rx.poll([](const Datagram&) {}, 2);
+  EXPECT_EQ(first, 2);
+
+  int rest = 0;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+  while (rest < 3 && std::chrono::steady_clock::now() < deadline)
+  {
+    rest += rx.poll([](const Datagram&) {}, 16);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  EXPECT_EQ(rest, 3);
+}
+
+TEST(UdpSocketReceivePath, EmptyPollReturnsZero)
+{
+  UdpSocketReceivePath::Config cfg;
+  cfg.bindAddress = "127.0.0.1";
+  cfg.port = 0;
+  UdpSocketReceivePath rx(cfg);
+  ASSERT_TRUE(rx.valid());
+  EXPECT_EQ(rx.poll([](const Datagram&) {}, 16), 0);
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,3 +6,11 @@ if(FLOX_ENABLE_BACKTEST)
     target_link_libraries(preagg_bars PRIVATE flox)
     target_include_directories(preagg_bars PRIVATE ${CMAKE_SOURCE_DIR}/include)
 endif()
+
+# Receive-path integration probe (POSIX sockets; AF_XDP parts compile only
+# with FLOX_ENABLE_AF_XDP). Not built on Windows.
+if(NOT WIN32)
+  add_executable(afxdp_probe afxdp_probe.cpp)
+  target_link_libraries(afxdp_probe PRIVATE flox)
+  target_include_directories(afxdp_probe PRIVATE ${CMAKE_SOURCE_DIR}/include)
+endif()

--- a/tools/afxdp_probe.cpp
+++ b/tools/afxdp_probe.cpp
@@ -1,0 +1,185 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Integration probe and benchmark for the receive-path backends. Not a CI
+// test: AF_XDP needs CAP_NET_RAW/CAP_BPF and an interface, so this runs by
+// hand on a prepared host (veth pair or a real NIC).
+//
+//   afxdp_probe recv-xdp <ifname> <port> <expected>
+//   afxdp_probe recv-socket <bind-ip> <port> <expected>
+//   afxdp_probe send <dst-ip> <port> <count> [payload-bytes]
+//
+// Senders stamp each payload with CLOCK_MONOTONIC ns (valid across network
+// namespaces on one host), receivers report packets, drops, and one-way
+// latency percentiles from those stamps.
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "flox/net/receive_path.h"
+#include "flox/util/performance/latency_histogram.h"
+
+#if defined(__linux__) && FLOX_AF_XDP_ENABLED
+#include "flox/net/af_xdp_receive_path.h"
+#endif
+
+using flox::net::Datagram;
+using flox::performance::LatencyHistogram;
+using flox::performance::monotonicNs;
+
+namespace
+{
+
+struct RecvStats
+{
+  LatencyHistogram oneWay;
+  long received{0};
+};
+
+// One-way latency uses a monotonic dequeue stamp taken here, matching the
+// sender's CLOCK_MONOTONIC payload stamp. d.rxTimestampNs is deliberately not
+// used for this: on the socket backend it is a CLOCK_REALTIME kernel stamp,
+// and mixing it with the monotonic send stamp yields nonsense. The kernel
+// stamp is what the production latency contour consumes; this probe measures
+// send-to-userspace-dequeue on one clock.
+void account(RecvStats& st, const Datagram& d, int64_t dequeueNs)
+{
+  ++st.received;
+  if (d.payload.size() >= sizeof(int64_t))
+  {
+    int64_t sentNs = 0;
+    std::memcpy(&sentNs, d.payload.data(), sizeof(sentNs));
+    const int64_t delta = dequeueNs - sentNs;
+    if (delta > 0)
+    {
+      st.oneWay.record(delta);
+    }
+  }
+}
+
+int report(const RecvStats& st, long expected)
+{
+  std::printf("received=%ld expected=%ld\n", st.received, expected);
+  std::printf("one-way ns: %s\n", st.oneWay.summary().c_str());
+  return st.received == expected ? 0 : 1;
+}
+
+template <typename Path>
+int runReceiver(Path& path, long expected)
+{
+  RecvStats st;
+  const int64_t deadline = monotonicNs() + int64_t(30) * 1'000'000'000;
+  while (st.received < expected && monotonicNs() < deadline)
+  {
+    path.poll([&](const Datagram& d)
+              { account(st, d, monotonicNs()); }, 64);
+  }
+  return report(st, expected);
+}
+
+int runSender(const char* ip, uint16_t port, long count, size_t bytes)
+{
+  const int fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = ::inet_addr(ip);
+
+  std::string payload(bytes < sizeof(int64_t) ? sizeof(int64_t) : bytes, 'x');
+  long sent = 0;
+  for (long i = 0; i < count; ++i)
+  {
+    const int64_t now = monotonicNs();
+    std::memcpy(payload.data(), &now, sizeof(now));
+    if (::sendto(fd, payload.data(), payload.size(), 0,
+                 reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) > 0)
+    {
+      ++sent;
+    }
+    // Light pacing so the veth queue and the fill ring keep up.
+    if ((i & 63) == 0)
+    {
+      ::usleep(50);
+    }
+  }
+  ::close(fd);
+  std::printf("sent=%ld\n", sent);
+  return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  if (argc < 4)
+  {
+    std::fprintf(stderr, "usage: %s recv-xdp|recv-socket|send ... (see header)\n",
+                 argv[0]);
+    return 2;
+  }
+  const std::string mode = argv[1];
+
+  if (mode == "send")
+  {
+    if (argc < 5)
+    {
+      std::fprintf(stderr, "usage: %s send <dst-ip> <port> <count> [payload-bytes]\n",
+                   argv[0]);
+      return 2;
+    }
+    const auto port = uint16_t(std::atoi(argv[3]));
+    const long count = std::atol(argv[4]);
+    const size_t bytes = argc > 5 ? size_t(std::atol(argv[5])) : 64;
+    return runSender(argv[2], port, count, bytes);
+  }
+
+  if (mode == "recv-socket")
+  {
+    flox::net::UdpSocketReceivePath::Config cfg;
+    cfg.bindAddress = argv[2];
+    cfg.port = uint16_t(std::atoi(argv[3]));
+    flox::net::UdpSocketReceivePath path(cfg);
+    if (!path.valid())
+    {
+      std::fprintf(stderr, "socket path init failed\n");
+      return 2;
+    }
+    return runReceiver(path, std::atol(argv[4]));
+  }
+
+#if defined(__linux__) && FLOX_AF_XDP_ENABLED
+  if (mode == "recv-xdp")
+  {
+    flox::net::AfXdpReceivePath::Config cfg;
+    cfg.ifname = argv[2];
+    cfg.udpPortFilter = uint16_t(std::atoi(argv[3]));
+    cfg.skbMode = !(argc > 5 && std::strcmp(argv[5], "native") == 0);
+    flox::net::AfXdpReceivePath path(cfg);
+    if (!path.valid())
+    {
+      std::fprintf(stderr, "af_xdp init failed (need CAP_NET_RAW/CAP_BPF?)\n");
+      return 2;
+    }
+    const int rc = runReceiver(path, std::atol(argv[4]));
+    std::printf("dropped-non-udp=%llu\n",
+                (unsigned long long)path.droppedNonUdp());
+    return rc;
+  }
+#endif
+
+  std::fprintf(stderr, "unknown or unsupported mode: %s\n", mode.c_str());
+  return 2;
+}


### PR DESCRIPTION
## What

A receive-path abstraction with two backends.

`IReceivePath` is the seam between the host receiving bytes and a decoder seeing a datagram: non-blocking `poll`, borrowed payloads, receive timestamps.

- `UdpSocketReceivePath` — the default backend: non-blocking socket, multicast join, kernel/NIC receive timestamps with a monotonic fallback.
- `AfXdpReceivePath` — `FLOX_ENABLE_AF_XDP` (Linux + libxdp, off by default): moves the receive path to a user-space UMEM ring via an XDP redirect — sized fill/completion rings, `NEED_WAKEUP`, UDP payload extraction with a port filter.

## Portability

`rx_timestamp` extraction is guarded to POSIX platforms. `test_receive_path` and the `afxdp_probe` tool build on non-Windows only; the AF_XDP header compiles only under `FLOX_ENABLE_AF_XDP` on Linux.

## Tests

`test_receive_path` over loopback — bind, datagram delivery with timestamps, poll batching, empty poll.
