### PR TITLE
fix(eventing): stamp _constructed before the release fence in publishBatch

### DIFF
--- a/include/flox/util/eventing/event_bus.h
+++ b/include/flox/util/eventing/event_bus.h
@@ -528,12 +528,23 @@ class EventBus : public ISubsystem
     }
     else
     {
-      std::atomic_thread_fence(std::memory_order_release);
+      // The _constructed flags must be stored BEFORE the release fence: the
+      // fence only orders writes sequenced before it against the relaxed
+      // _published stamps that consumers acquire. With constructed stamped
+      // after the fence, a consumer on a weakly-ordered CPU can observe
+      // _published == seq while _constructed still reads 0, classify the
+      // slot as reclaimed and silently skip the event.
       for (size_t k = 0; k < count; ++k)
       {
         const int64_t seq = firstSeq + static_cast<int64_t>(k);
         const size_t idx = size_t(seq) & Mask;
         _constructed[idx].store(1, std::memory_order_relaxed);
+      }
+      std::atomic_thread_fence(std::memory_order_release);
+      for (size_t k = 0; k < count; ++k)
+      {
+        const int64_t seq = firstSeq + static_cast<int64_t>(k);
+        const size_t idx = size_t(seq) & Mask;
         _published[idx].store(seq, std::memory_order_relaxed);
       }
     }


### PR DESCRIPTION
## What

Fixes the silent event loss behind the `EventBusBatch.StaticSubscriberMatchesVirtualDelivery` failure on the macOS arm64 runner (main run for #440: 4991/5000 delivered).

`publishBatch` stamped `_constructed` and `_published` relaxed after a single release fence. The fence orders only writes sequenced before it, so on weakly-ordered CPUs a consumer could acquire `_published == seq` while `_constructed` still read 0, classify the slot as reclaimed, and silently skip the event. x86 TSO hides it; the TSan path uses per-slot release stores, so sanitizers could not see it.

Fix: stamp all `_constructed` flags first, then the fence, then `_published`. The acquire on `_published` now makes both the event bytes and the constructed flag visible.

## Evidence

Stress on an M-series host, `--gtest_repeat=5000` of the failing test: 54 failures before, 0 after. Full batch suite x200 clean.
