### PR TITLE
Honesty audit: real functionality where there was slop (connectors, ws, replay, perf)

### DIFF
--- a/connectors/CMakeLists.txt
+++ b/connectors/CMakeLists.txt
@@ -179,15 +179,16 @@ install(EXPORT flox-connectorsTargets
 
 # ── Tests ────────────────────────────────────────────────────────────
 #
-# Built only when the parent enables tests AND the user explicitly
-# opts in to the integration suite (it hits live exchange endpoints
-# and needs network + credentials). Without
-# FLOX_BUILD_CONNECTOR_INTEGRATION_TESTS=ON the test binaries are not
-# generated and `ctest` still runs only the core suite.
+# Two kinds live in tests/: offline protocol unit tests (unit_test_*,
+# no network -- always built and registered with ctest when the parent
+# builds tests) and the integration suite (integration_test_*, hits
+# live exchange endpoints; built only with
+# FLOX_BUILD_CONNECTOR_INTEGRATION_TESTS=ON and registered with ctest
+# only under FLOX_RUN_CONNECTOR_INTEGRATION_TESTS=ON).
 
 option(FLOX_BUILD_CONNECTOR_INTEGRATION_TESTS
        "Build connector integration tests (require network access)" OFF)
 
-if(FLOX_BUILD_TESTS AND FLOX_BUILD_CONNECTOR_INTEGRATION_TESTS)
+if(FLOX_BUILD_TESTS)
   add_subdirectory(tests)
 endif()

--- a/connectors/include/flox-connectors/bybit/bybit_exchange_connector.h
+++ b/connectors/include/flox-connectors/bybit/bybit_exchange_connector.h
@@ -71,9 +71,19 @@ class BybitExchangeConnector : public IExchangeConnector
 
   SymbolId resolveSymbolId(std::string_view symbol);
 
- private:
+  // Public so protocol behaviour (sequencing, gap resync) is testable offline
+  // by feeding raw frames without a live socket.
   void handleMessage(std::string_view payload);
+
+  // Book deltas whose update id broke continuity (dropped + resync triggered).
+  uint64_t bookGapCount() const noexcept { return _bookGapCount.load(std::memory_order_relaxed); }
+
+ private:
   void handlePrivateMessage(std::string_view payload);
+
+  // Re-subscribe one symbol's orderbook topic so the exchange re-sends a
+  // snapshot (gap recovery). No-op before start() (no socket yet).
+  void resubscribeBook(std::string_view symbolName);
 
   BybitConfig _config;
 
@@ -82,7 +92,18 @@ class BybitExchangeConnector : public IExchangeConnector
 
   SymbolRegistry* _registry = nullptr;
 
-  std::unordered_map<SymbolId, int64_t> _lastBookSeq;
+  // Per-symbol book continuity: Bybit v5 orderbook deltas carry an update id
+  // ("u") that increments by 1 per message; a jump means a dropped frame and a
+  // silently wrong book, so the connector drops the delta and re-subscribes for
+  // a fresh snapshot. resyncInFlight suppresses repeat resubscribes while the
+  // snapshot is on its way.
+  struct BookSeqState
+  {
+    int64_t lastUpdateId{-1};
+    bool resyncInFlight{false};
+  };
+  std::unordered_map<SymbolId, BookSeqState> _bookSeq;
+  std::atomic<uint64_t> _bookGapCount{0};
 
   std::shared_ptr<ILogger> _logger;
 

--- a/connectors/include/flox-connectors/polymarket/polymarket_exchange_connector.h
+++ b/connectors/include/flox-connectors/polymarket/polymarket_exchange_connector.h
@@ -43,9 +43,13 @@ class PolymarketExchangeConnector : public IExchangeConnector
 
   SymbolId resolveSymbolId(std::string_view tokenId);
 
- private:
+  // Public so protocol behaviour (snapshot vs incremental price_change) is
+  // testable offline by feeding raw frames without a live socket.
   void handleMessage(std::string_view payload);
+
+ private:
   void processBookSnapshot(simdjson::ondemand::object obj, uint64_t recvNs);
+  void processPriceChanges(simdjson::ondemand::object obj, uint64_t recvNs);
   void sendSubscribe(const std::vector<std::string>& tokenIds, const std::string& operation);
 
   PolymarketConfig _config;

--- a/connectors/include/flox-connectors/util/safe_parse.h
+++ b/connectors/include/flox-connectors/util/safe_parse.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <flox/common.h>
+
 #include <charconv>
 #include <cstdint>
 #include <cstdlib>
@@ -71,6 +73,115 @@ inline std::optional<double> safeParseDouble(std::string_view sv)
 
   return result;
 #endif
+}
+
+/// Parse a decimal string straight into a fixed-point raw value at `scale`
+/// (a power of ten, e.g. Price::Scale). NO double round-trip and no allocation.
+///
+/// Lenient by design: exchange market data is authoritative, so this ACCEPTS an
+/// over-precise value by truncating fractional digits beyond the scale (toward
+/// zero) rather than rejecting it -- dropping a book level because the venue
+/// sent one extra digit would be worse than a sub-tick rounding. This is the
+/// deliberate opposite of the venue's strict decwire parser, which rejects
+/// untrusted client input. Accepts an optional leading sign.
+///
+/// Returns false only on: empty input, no digits, an integer part that would
+/// overflow the raw range, or trailing non-numeric characters (including
+/// exponent notation, which crypto books do not use for price/size).
+inline bool parseFixedPoint(std::string_view t, int64_t scale, int64_t& out)
+{
+  if (t.empty() || scale <= 0)
+  {
+    return false;
+  }
+  size_t i = 0;
+  bool neg = false;
+  if (t[i] == '+' || t[i] == '-')
+  {
+    neg = (t[i] == '-');
+    ++i;
+  }
+
+  int fracDigits = 0;
+  for (int64_t s = scale; s > 1; s /= 10)
+  {
+    ++fracDigits;
+  }
+
+  const uint64_t kMaxInt = static_cast<uint64_t>(INT64_MAX) / static_cast<uint64_t>(scale);
+  uint64_t ip = 0;
+  size_t intDigits = 0;
+  for (; i < t.size() && t[i] >= '0' && t[i] <= '9'; ++i)
+  {
+    ip = ip * 10 + static_cast<uint64_t>(t[i] - '0');
+    if (ip > kMaxInt)
+    {
+      return false;  // integer part alone would overflow the raw value
+    }
+    ++intDigits;
+  }
+
+  uint64_t frac = 0;
+  int got = 0;
+  if (i < t.size() && t[i] == '.')
+  {
+    ++i;
+    for (; i < t.size() && t[i] >= '0' && t[i] <= '9'; ++i)
+    {
+      if (got < fracDigits)
+      {
+        frac = frac * 10 + static_cast<uint64_t>(t[i] - '0');
+        ++got;
+      }
+      // digits beyond the fixed-point scale are truncated, not rejected
+    }
+  }
+
+  if (intDigits == 0 && got == 0)
+  {
+    return false;  // no numeric digits
+  }
+  if (i != t.size())
+  {
+    return false;  // stray trailing characters (e.g. exponent)
+  }
+  while (got < fracDigits)
+  {
+    frac *= 10;
+    ++got;
+  }
+
+  const uint64_t raw = ip * static_cast<uint64_t>(scale) + frac;
+  if (raw > static_cast<uint64_t>(INT64_MAX))
+  {
+    return false;
+  }
+  out = neg ? -static_cast<int64_t>(raw) : static_cast<int64_t>(raw);
+  return true;
+}
+
+/// Convenience: parse a decimal string directly into a Price (fixed-point, no
+/// double). nullopt on a malformed value; excess precision is truncated.
+inline std::optional<Price> parsePrice(std::string_view sv)
+{
+  int64_t raw = 0;
+  if (!parseFixedPoint(sv, Price::Scale, raw))
+  {
+    return std::nullopt;
+  }
+  return Price::fromRaw(raw);
+}
+
+/// Convenience: parse a decimal string directly into a Quantity (fixed-point,
+/// no double). nullopt on a malformed value; excess precision is truncated.
+inline std::optional<Quantity> parseQty(std::string_view sv)
+{
+  int64_t raw = 0;
+  if (!parseFixedPoint(sv, Quantity::Scale, raw))
+  {
+    return std::nullopt;
+  }
+  return Quantity::fromRaw(raw);
 }
 
 /// Parse int64_t from string_view using std::from_chars (fast, no allocation).

--- a/connectors/src/bitget/bitget_exchange_connector.cpp
+++ b/connectors/src/bitget/bitget_exchange_connector.cpp
@@ -382,15 +382,14 @@ void BitgetExchangeConnector::handleMessage(std::string_view payload)
             ++it;
             std::string_view q = (*it).get_string().value();
 
-            auto priceOpt = util::safeParseDouble(p);
-            auto qtyOpt = util::safeParseDouble(q);
+            auto priceOpt = util::parsePrice(p);
+            auto qtyOpt = util::parseQty(q);
             if (!priceOpt || !qtyOpt)
             {
               _logger->warn("[Bitget] Invalid bid price/qty in book update");
               continue;
             }
-            ev->update.bids.emplace_back(Price::fromDouble(*priceOpt),
-                                         Quantity::fromDouble(*qtyOpt));
+            ev->update.bids.emplace_back(*priceOpt, *qtyOpt);
           }
         }
         auto asksEl = d["asks"];
@@ -404,15 +403,14 @@ void BitgetExchangeConnector::handleMessage(std::string_view payload)
             ++it;
             std::string_view q = (*it).get_string().value();
 
-            auto priceOpt = util::safeParseDouble(p);
-            auto qtyOpt = util::safeParseDouble(q);
+            auto priceOpt = util::parsePrice(p);
+            auto qtyOpt = util::parseQty(q);
             if (!priceOpt || !qtyOpt)
             {
               _logger->warn("[Bitget] Invalid ask price/qty in book update");
               continue;
             }
-            ev->update.asks.emplace_back(Price::fromDouble(*priceOpt),
-                                         Quantity::fromDouble(*qtyOpt));
+            ev->update.asks.emplace_back(*priceOpt, *qtyOpt);
           }
         }
 
@@ -448,8 +446,8 @@ void BitgetExchangeConnector::handleMessage(std::string_view payload)
         std::string_view qtySv = val["size"].get_string().value();
         std::string_view sideSv = val["side"].get_string().value();
 
-        auto priceOpt = util::safeParseDouble(priceSv);
-        auto qtyOpt = util::safeParseDouble(qtySv);
+        auto priceOpt = util::parsePrice(priceSv);
+        auto qtyOpt = util::parseQty(qtySv);
         if (!priceOpt || !qtyOpt)
         {
           _logger->warn("[Bitget] Invalid trade price/qty");
@@ -467,8 +465,8 @@ void BitgetExchangeConnector::handleMessage(std::string_view payload)
           }
         }
 
-        ev.trade.price = Price::fromDouble(*priceOpt);
-        ev.trade.quantity = Quantity::fromDouble(*qtyOpt);
+        ev.trade.price = *priceOpt;
+        ev.trade.quantity = *qtyOpt;
         ev.trade.isBuy = (sideSv == "buy" || sideSv == "Buy");
 
         // Parse timestamp
@@ -576,15 +574,15 @@ void BitgetExchangeConnector::handlePrivateMessage(std::string_view payload)
         }
         ev.order.side = d["side"].get_string().value() == "buy" ? Side::BUY : Side::SELL;
 
-        auto priceOpt = util::safeParseDouble(d["price"].get_string().value());
-        auto qtyOpt = util::safeParseDouble(d["size"].get_string().value());
+        auto priceOpt = util::parsePrice(d["price"].get_string().value());
+        auto qtyOpt = util::parseQty(d["size"].get_string().value());
         if (!priceOpt || !qtyOpt)
         {
           _logger->warn("[Bitget] Invalid price/qty in order event");
           continue;
         }
-        ev.order.price = Price::fromDouble(*priceOpt);
-        ev.order.quantity = Quantity::fromDouble(*qtyOpt);
+        ev.order.price = *priceOpt;
+        ev.order.quantity = *qtyOpt;
         std::string_view status = d["status"].get_string().value();
         if (status == "filled")
         {

--- a/connectors/src/bybit/bybit_exchange_connector.cpp
+++ b/connectors/src/bybit/bybit_exchange_connector.cpp
@@ -446,14 +446,14 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
         ++it;
         std::string_view qsv = (*it).get_string().value();
 
-        auto priceOpt = util::safeParseDouble(psv);
-        auto qtyOpt = util::safeParseDouble(qsv);
+        auto priceOpt = util::parsePrice(psv);
+        auto qtyOpt = util::parseQty(qsv);
         if (!priceOpt || !qtyOpt)
         {
           _logger->warn("[Bybit] Invalid bid price/qty in book update");
           continue;
         }
-        ev->update.bids.emplace_back(Price::fromDouble(*priceOpt), Quantity::fromDouble(*qtyOpt));
+        ev->update.bids.emplace_back(*priceOpt, *qtyOpt);
       }
 
       auto af = data_obj.find_field_unordered("a");
@@ -465,14 +465,14 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
         ++it;
         std::string_view qsv = (*it).get_string().value();
 
-        auto priceOpt = util::safeParseDouble(psv);
-        auto qtyOpt = util::safeParseDouble(qsv);
+        auto priceOpt = util::parsePrice(psv);
+        auto qtyOpt = util::parseQty(qsv);
         if (!priceOpt || !qtyOpt)
         {
           _logger->warn("[Bybit] Invalid ask price/qty in book update");
           continue;
         }
-        ev->update.asks.emplace_back(Price::fromDouble(*priceOpt), Quantity::fromDouble(*qtyOpt));
+        ev->update.asks.emplace_back(*priceOpt, *qtyOpt);
       }
 
       // Continuity check (read after b/a to keep simdjson field access forward-
@@ -561,15 +561,15 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
 
         ev.trade.isBuy = (obj.find_field_unordered("S").get_string().value() == "Buy");
 
-        auto priceOpt = util::safeParseDouble(obj.find_field_unordered("p").get_string().value());
-        auto qtyOpt = util::safeParseDouble(obj.find_field_unordered("v").get_string().value());
+        auto priceOpt = util::parsePrice(obj.find_field_unordered("p").get_string().value());
+        auto qtyOpt = util::parseQty(obj.find_field_unordered("v").get_string().value());
         if (!priceOpt || !qtyOpt)
         {
           _logger->warn("[Bybit] Invalid trade price/qty");
           continue;
         }
-        ev.trade.price = Price::fromDouble(*priceOpt);
-        ev.trade.quantity = Quantity::fromDouble(*qtyOpt);
+        ev.trade.price = *priceOpt;
+        ev.trade.quantity = *qtyOpt;
 
         ev.publishTsNs = nowNsMonotonic();
         auto [res, _] = _tradeBus->tryPublish(ev);
@@ -648,16 +648,16 @@ void BybitExchangeConnector::handlePrivateMessage(std::string_view payload)
         ev.order.id = static_cast<OrderId>(*orderIdOpt);
         ev.order.side = (d["side"].get_string().value() == "Buy") ? Side::BUY : Side::SELL;
 
-        auto priceOpt = util::safeParseDouble(d["price"].get_string().value());
-        auto qtyOpt = util::safeParseDouble(d["qty"].get_string().value());
+        auto priceOpt = util::parsePrice(d["price"].get_string().value());
+        auto qtyOpt = util::parseQty(d["qty"].get_string().value());
         auto filledOpt = util::safeParseDouble(d["cumExecQty"].get_string().value());
         if (!priceOpt || !qtyOpt || !filledOpt)
         {
           _logger->warn("[Bybit] Invalid price/qty in order event");
           continue;
         }
-        ev.order.price = Price::fromDouble(*priceOpt);
-        ev.order.quantity = Quantity::fromDouble(*qtyOpt);
+        ev.order.price = *priceOpt;
+        ev.order.quantity = *qtyOpt;
         ev.order.filledQuantity = Quantity::fromDouble(*filledOpt);
 
         ev.exchangeTsNs = msToNs(d["updatedTime"].get_int64().value());
@@ -714,15 +714,15 @@ void BybitExchangeConnector::handlePrivateMessage(std::string_view payload)
         ev.order.symbol = resolveSymbolId(d["symbol"].get_string().value());
         ev.order.side = d["side"].get_string().value() == "Buy" ? Side::BUY : Side::SELL;
 
-        auto priceOpt = util::safeParseDouble(d["execPrice"].get_string().value());
-        auto qtyOpt = util::safeParseDouble(d["execQty"].get_string().value());
+        auto priceOpt = util::parsePrice(d["execPrice"].get_string().value());
+        auto qtyOpt = util::parseQty(d["execQty"].get_string().value());
         if (!priceOpt || !qtyOpt)
         {
           _logger->warn("[Bybit] Invalid price/qty in execution event");
           continue;
         }
-        ev.order.price = Price::fromDouble(*priceOpt);
-        ev.order.quantity = Quantity::fromDouble(*qtyOpt);
+        ev.order.price = *priceOpt;
+        ev.order.quantity = *qtyOpt;
         ev.order.filledQuantity = ev.order.quantity;
 
         if (auto et = d["execTime"]; !et.error())

--- a/connectors/src/bybit/bybit_exchange_connector.cpp
+++ b/connectors/src/bybit/bybit_exchange_connector.cpp
@@ -1,11 +1,11 @@
 /*
-  * Flox Engine
-  * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
-  *
-  * Copyright (c) 2025 FLOX Foundation
-  * Licensed under the MIT License. See LICENSE file in the project root for full
-  * license information.
-  */
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
 
 #include "flox-connectors/bybit/bybit_exchange_connector.h"
 #include "flox-connectors/net/ix_websocket_client.h"
@@ -317,6 +317,25 @@ void BybitExchangeConnector::stop()
   }
 }
 
+void BybitExchangeConnector::resubscribeBook(std::string_view symbolName)
+{
+  if (!_wsClient)
+  {
+    return;  // not started (offline tests / early frames): next snapshot re-baselines
+  }
+  for (const auto& entry : _config.symbols)
+  {
+    if (entry.name == symbolName)
+    {
+      const std::string topic =
+          "orderbook." + std::to_string(static_cast<int>(entry.depth)) + "." + entry.name;
+      _wsClient->send(R"({"op":"unsubscribe","args":[")" + topic + R"("]})");
+      _wsClient->send(R"({"op":"subscribe","args":[")" + topic + R"("]})");
+      return;
+    }
+  }
+}
+
 void BybitExchangeConnector::handleMessage(std::string_view payload)
 {
   static thread_local simdjson::ondemand::parser parser;
@@ -356,12 +375,10 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
       return;
     }
 
-    auto data_field = root.find_field_unordered("data");
-    if (data_field.error())
-    {
-      return;
-    }
-
+    // `data` is fetched LAST in each branch, after the root scalar fields, so
+    // every simdjson ondemand access is forward-only (grabbing `data` -- the
+    // last field -- early and then reading earlier root fields throws
+    // OUT_OF_ORDER_ITERATION).
     auto topic = topic_field.get_string().value();
 
     if (topic.starts_with("orderbook."))
@@ -387,6 +404,18 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
 
       ev->update.type = updateType;
 
+      // Root scalars first (document order: topic, type, ts, cts, data), then
+      // descend into data -- keeps every access forward-only.
+      auto tsv = root.find_field_unordered("ts").get_int64().value();
+      auto ctsv = root.find_field_unordered("cts").get_int64().value();
+      ev->update.systemTsNs = msToNs(tsv);
+      ev->update.exchangeTsNs = msToNs(ctsv);
+
+      auto data_field = root.find_field_unordered("data");
+      if (data_field.error())
+      {
+        return;
+      }
       auto data_obj = data_field.get_object();
 
       // symbol
@@ -404,33 +433,6 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
           ev->update.optionType = info->optionType;
         }
       }
-
-      auto tsv = root.find_field_unordered("ts").get_int64().value();
-      auto ctsv = root.find_field_unordered("cts").get_int64().value();
-
-      ev->update.systemTsNs = msToNs(tsv);
-      ev->update.exchangeTsNs = msToNs(ctsv);
-
-      int seq = data_obj.find_field_unordered("seq").get_int64().value();
-      int64_t prev = 0;
-      if (updateType == BookUpdateType::SNAPSHOT)
-      {
-        prev = 0;
-        _lastBookSeq[sym] = seq;
-      }
-      else
-      {
-        auto it = _lastBookSeq.find(sym);
-        if (it != _lastBookSeq.end())
-        {
-          prev = it->second;
-        }
-
-        _lastBookSeq[sym] = seq;
-      }
-
-      ev->seq = seq;
-      ev->prevSeq = prev;
 
       ev->update.bids.clear();
       ev->update.asks.clear();
@@ -473,6 +475,43 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
         ev->update.asks.emplace_back(Price::fromDouble(*priceOpt), Quantity::fromDouble(*qtyOpt));
       }
 
+      // Continuity check (read after b/a to keep simdjson field access forward-
+      // only; data field order is s,b,a,u,seq). Bybit v5 update id ("u")
+      // increments by 1 per topic message -- a jump means a dropped frame, so
+      // applying this delta would silently corrupt the local book.
+      const int64_t updateId = data_obj.find_field_unordered("u").get_int64().value();
+      auto& seqState = _bookSeq[sym];
+      int64_t prev = 0;
+      if (updateType == BookUpdateType::SNAPSHOT)
+      {
+        seqState.lastUpdateId = updateId;
+        seqState.resyncInFlight = false;  // fresh baseline; any resync is complete
+      }
+      else
+      {
+        if (seqState.resyncInFlight)
+        {
+          return;  // deltas racing our re-subscribe; wait for the snapshot
+        }
+        if (seqState.lastUpdateId < 0 || updateId != seqState.lastUpdateId + 1)
+        {
+          // Gap: never apply onto a stale book. Drop, invalidate, and force a
+          // fresh snapshot by re-subscribing the topic.
+          _bookGapCount.fetch_add(1, std::memory_order_relaxed);
+          _logger->warn("[Bybit] book gap on " + std::string(ssv) +
+                        ": expected u=" + std::to_string(seqState.lastUpdateId + 1) +
+                        " got u=" + std::to_string(updateId) + " -- resyncing");
+          seqState.lastUpdateId = -1;
+          seqState.resyncInFlight = true;
+          resubscribeBook(ssv);
+          return;
+        }
+        prev = seqState.lastUpdateId;
+        seqState.lastUpdateId = updateId;
+      }
+      ev->seq = updateId;
+      ev->prevSeq = prev;
+
       if (!ev->update.bids.empty() || !ev->update.asks.empty())
       {
         ev->publishTsNs = nowNsMonotonic();
@@ -487,6 +526,11 @@ void BybitExchangeConnector::handleMessage(std::string_view payload)
     }
     else if (topic.starts_with("publicTrade."))
     {
+      auto data_field = root.find_field_unordered("data");
+      if (data_field.error())
+      {
+        return;
+      }
       auto data_arr = data_field.get_array().value();
       for (auto t : data_arr)
       {

--- a/connectors/src/hyperliquid/hyperliquid_exchange_connector.cpp
+++ b/connectors/src/hyperliquid/hyperliquid_exchange_connector.cpp
@@ -250,16 +250,16 @@ void HyperliquidExchangeConnector::handleMessage(std::string_view payload)
             continue;
           }
 
-          auto priceOpt = util::safeParseDouble(pxEl.get_string().value());
-          auto qtyOpt = util::safeParseDouble(szEl.get_string().value());
+          auto priceOpt = util::parsePrice(pxEl.get_string().value());
+          auto qtyOpt = util::parseQty(szEl.get_string().value());
           if (!priceOpt || !qtyOpt)
           {
             _logger->warn("[Hyperliquid] Invalid price/qty in book level");
             continue;
           }
 
-          Price price = Price::fromDouble(*priceOpt);
-          Quantity qty = Quantity::fromDouble(*qtyOpt);
+          Price price = *priceOpt;
+          Quantity qty = *qtyOpt;
 
           if (idx == 0)
           {
@@ -300,8 +300,8 @@ void HyperliquidExchangeConnector::handleMessage(std::string_view payload)
           continue;
         }
 
-        auto priceOpt = util::safeParseDouble(pxEl.get_string().value());
-        auto qtyOpt = util::safeParseDouble(szEl.get_string().value());
+        auto priceOpt = util::parsePrice(pxEl.get_string().value());
+        auto qtyOpt = util::parseQty(szEl.get_string().value());
         if (!priceOpt || !qtyOpt)
         {
           _logger->warn("[Hyperliquid] Invalid trade price/qty");
@@ -312,8 +312,8 @@ void HyperliquidExchangeConnector::handleMessage(std::string_view payload)
 
         TradeEvent ev;
         ev.trade.symbol = sid;
-        ev.trade.price = Price::fromDouble(*priceOpt);
-        ev.trade.quantity = Quantity::fromDouble(*qtyOpt);
+        ev.trade.price = *priceOpt;
+        ev.trade.quantity = *qtyOpt;
         std::string_view side = sideEl.get_string().value();
         ev.trade.isBuy = (side == "B" || side == "buy");
 

--- a/connectors/src/polymarket/polymarket_exchange_connector.cpp
+++ b/connectors/src/polymarket/polymarket_exchange_connector.cpp
@@ -255,6 +255,9 @@ void PolymarketExchangeConnector::handleMessage(std::string_view payload)
 
         if (priceOpt && sizeOpt)
         {
+          // Polymarket trade price/size can arrive as a JSON number, so this
+          // path keeps parseStringOrDouble (string-or-number). Book levels
+          // below are always strings and use the fixed-point parser.
           ev.trade.price = Price::fromDouble(*priceOpt);
           ev.trade.quantity = Quantity::fromDouble(*sizeOpt);
 
@@ -341,26 +344,21 @@ void PolymarketExchangeConnector::processBookSnapshot(simdjson::ondemand::object
     for (auto level : bids.get_array())
     {
       auto lobj = level.get_object();
-      double price = 0, size = 0;
+      std::optional<Price> priceOpt;
+      std::optional<Quantity> sizeOpt;
 
       if (auto p = lobj["price"]; !p.error())
       {
-        if (auto pOpt = util::safeParseDouble(p.get_string().value()))
-        {
-          price = *pOpt;
-        }
+        priceOpt = util::parsePrice(p.get_string().value());
       }
       if (auto s = lobj["size"]; !s.error())
       {
-        if (auto sOpt = util::safeParseDouble(s.get_string().value()))
-        {
-          size = *sOpt;
-        }
+        sizeOpt = util::parseQty(s.get_string().value());
       }
 
-      if (price > 0 && size > 0)
+      if (priceOpt && sizeOpt && priceOpt->raw() > 0 && sizeOpt->raw() > 0)
       {
-        ev->update.bids.push_back({Price::fromDouble(price), Quantity::fromDouble(size)});
+        ev->update.bids.push_back({*priceOpt, *sizeOpt});
       }
     }
   }
@@ -371,26 +369,21 @@ void PolymarketExchangeConnector::processBookSnapshot(simdjson::ondemand::object
     for (auto level : asks.get_array())
     {
       auto lobj = level.get_object();
-      double price = 0, size = 0;
+      std::optional<Price> priceOpt;
+      std::optional<Quantity> sizeOpt;
 
       if (auto p = lobj["price"]; !p.error())
       {
-        if (auto pOpt = util::safeParseDouble(p.get_string().value()))
-        {
-          price = *pOpt;
-        }
+        priceOpt = util::parsePrice(p.get_string().value());
       }
       if (auto s = lobj["size"]; !s.error())
       {
-        if (auto sOpt = util::safeParseDouble(s.get_string().value()))
-        {
-          size = *sOpt;
-        }
+        sizeOpt = util::parseQty(s.get_string().value());
       }
 
-      if (price > 0 && size > 0)
+      if (priceOpt && sizeOpt && priceOpt->raw() > 0 && sizeOpt->raw() > 0)
       {
-        ev->update.asks.push_back({Price::fromDouble(price), Quantity::fromDouble(size)});
+        ev->update.asks.push_back({*priceOpt, *sizeOpt});
       }
     }
   }
@@ -419,8 +412,8 @@ void PolymarketExchangeConnector::processPriceChanges(simdjson::ondemand::object
   {
     SymbolId sym;
     bool isBid;
-    double price;
-    double size;
+    Price price;
+    Quantity qty;
   };
   std::vector<Change> changes;
   for (auto el : pcField.get_array())
@@ -438,21 +431,15 @@ void PolymarketExchangeConnector::processPriceChanges(simdjson::ondemand::object
       continue;
     }
 
-    double price = -1.0;
+    std::optional<Price> priceOpt;
     if (auto p = e["price"]; !p.error())
     {
-      if (auto pOpt = util::safeParseDouble(p.get_string().value()))
-      {
-        price = *pOpt;
-      }
+      priceOpt = util::parsePrice(p.get_string().value());
     }
-    double size = -1.0;
+    std::optional<Quantity> qtyOpt;  // size 0 is a valid level removal
     if (auto s = e["size"]; !s.error())
     {
-      if (auto sOpt = util::safeParseDouble(s.get_string().value()))
-      {
-        size = *sOpt;
-      }
+      qtyOpt = util::parseQty(s.get_string().value());
     }
     bool isBid = true;
     if (auto sd = e["side"]; !sd.error())
@@ -460,11 +447,11 @@ void PolymarketExchangeConnector::processPriceChanges(simdjson::ondemand::object
       isBid = (sd.get_string().value() == "BUY");
     }
 
-    if (price < 0.0 || size < 0.0)
+    if (!priceOpt || !qtyOpt)
     {
       continue;  // unparseable level; skip rather than corrupt the delta
     }
-    changes.push_back({resolveSymbolId(tokenId), isBid, price, size});
+    changes.push_back({resolveSymbolId(tokenId), isBid, *priceOpt, *qtyOpt});
   }
 
   if (changes.empty())
@@ -506,7 +493,7 @@ void PolymarketExchangeConnector::processPriceChanges(simdjson::ondemand::object
       }
       // size 0 -> level removed; forwarded as a zero-quantity level, which the
       // aggregate book erases.
-      const BookLevel lvl{Price::fromDouble(d.price), Quantity::fromDouble(d.size)};
+      const BookLevel lvl{d.price, d.qty};
       if (d.isBid)
       {
         ev->update.bids.push_back(lvl);

--- a/connectors/src/polymarket/polymarket_exchange_connector.cpp
+++ b/connectors/src/polymarket/polymarket_exchange_connector.cpp
@@ -208,15 +208,9 @@ void PolymarketExchangeConnector::handleMessage(std::string_view payload)
 
     auto obj = doc.get_object().value();
 
-    // Check for price_changes (incremental update)
-    if (auto pc = obj["price_changes"]; !pc.error())
-    {
-      // Incremental updates - for now just ignore them
-      // Full book updates will come via "book" event_type
-      return;
-    }
-
-    // Check for event_type
+    // event_type is the first field: read it first so every field access below
+    // stays forward-only (simdjson ondemand throws OUT_OF_ORDER when a later
+    // field is read and then an earlier one).
     auto eventTypeField = obj["event_type"];
     if (eventTypeField.error())
     {
@@ -228,6 +222,12 @@ void PolymarketExchangeConnector::handleMessage(std::string_view payload)
     if (eventType == "book")
     {
       processBookSnapshot(std::move(obj), recvNs);
+    }
+    else if (eventType == "price_change")
+    {
+      // Incremental book updates: apply them (previously dropped, leaving the
+      // book stale between snapshots).
+      processPriceChanges(std::move(obj), recvNs);
     }
     else if (eventType == "last_trade_price" || eventType == "trade")
     {
@@ -399,6 +399,128 @@ void PolymarketExchangeConnector::processBookSnapshot(simdjson::ondemand::object
   ev->publishTsNs = nowNsMonotonic();
 
   _bookUpdateBus->publish(std::move(ev));
+}
+
+// Incremental book update. Each element of price_changes carries its own
+// asset_id, a price level, its new absolute size (0 = level removed), and a
+// side (BUY -> bid, SELL -> ask). A single message may touch several assets;
+// changes are grouped per symbol into one DELTA BookUpdateEvent each so the
+// downstream book applies them atomically.
+void PolymarketExchangeConnector::processPriceChanges(simdjson::ondemand::object obj,
+                                                      uint64_t recvNs)
+{
+  auto pcField = obj["price_changes"];
+  if (pcField.error())
+  {
+    return;
+  }
+
+  struct Change
+  {
+    SymbolId sym;
+    bool isBid;
+    double price;
+    double size;
+  };
+  std::vector<Change> changes;
+  for (auto el : pcField.get_array())
+  {
+    auto e = el.get_object();
+
+    // Field order per element: asset_id, price, size, side (read forward).
+    std::string_view tokenId;
+    if (auto a = e["asset_id"]; !a.error())
+    {
+      tokenId = a.get_string().value();
+    }
+    else
+    {
+      continue;
+    }
+
+    double price = -1.0;
+    if (auto p = e["price"]; !p.error())
+    {
+      if (auto pOpt = util::safeParseDouble(p.get_string().value()))
+      {
+        price = *pOpt;
+      }
+    }
+    double size = -1.0;
+    if (auto s = e["size"]; !s.error())
+    {
+      if (auto sOpt = util::safeParseDouble(s.get_string().value()))
+      {
+        size = *sOpt;
+      }
+    }
+    bool isBid = true;
+    if (auto sd = e["side"]; !sd.error())
+    {
+      isBid = (sd.get_string().value() == "BUY");
+    }
+
+    if (price < 0.0 || size < 0.0)
+    {
+      continue;  // unparseable level; skip rather than corrupt the delta
+    }
+    changes.push_back({resolveSymbolId(tokenId), isBid, price, size});
+  }
+
+  if (changes.empty())
+  {
+    return;
+  }
+
+  // Emit one DELTA event per distinct symbol touched by this message.
+  std::vector<SymbolId> seen;
+  for (const auto& c : changes)
+  {
+    if (std::find(seen.begin(), seen.end(), c.sym) != seen.end())
+    {
+      continue;
+    }
+    seen.push_back(c.sym);
+
+    auto evOpt = _bookPool.acquire();
+    if (!evOpt)
+    {
+      if (_logger)
+      {
+        _logger->warn("[Polymarket] Book pool exhausted (price_change)");
+      }
+      return;
+    }
+    auto& ev = *evOpt;
+    ev->recvNs = recvNs;
+    ev->update.symbol = c.sym;
+    ev->update.type = BookUpdateType::DELTA;
+    ev->update.bids.clear();
+    ev->update.asks.clear();
+
+    for (const auto& d : changes)
+    {
+      if (d.sym != c.sym)
+      {
+        continue;
+      }
+      // size 0 -> level removed; forwarded as a zero-quantity level, which the
+      // aggregate book erases.
+      const BookLevel lvl{Price::fromDouble(d.price), Quantity::fromDouble(d.size)};
+      if (d.isBid)
+      {
+        ev->update.bids.push_back(lvl);
+      }
+      else
+      {
+        ev->update.asks.push_back(lvl);
+      }
+    }
+
+    ev->update.exchangeTsNs = nowNsMonotonic();
+    ev->publishTsNs = nowNsMonotonic();
+    _bookUpdateBus->publish(std::move(ev));
+  }
 }
 
 }  // namespace flox

--- a/connectors/tests/CMakeLists.txt
+++ b/connectors/tests/CMakeLists.txt
@@ -9,7 +9,12 @@ find_package(GTest REQUIRED)
 option(FLOX_RUN_CONNECTOR_INTEGRATION_TESTS
        "Register connector integration tests with ctest" OFF)
 
-file(GLOB TEST_SOURCES CONFIGURE_DEPENDS *.cpp)
+file(GLOB UNIT_TEST_SOURCES CONFIGURE_DEPENDS unit_test_*.cpp)
+set(TEST_SOURCES ${UNIT_TEST_SOURCES})
+if(FLOX_BUILD_CONNECTOR_INTEGRATION_TESTS)
+    file(GLOB INTEGRATION_TEST_SOURCES CONFIGURE_DEPENDS integration_test_*.cpp)
+    list(APPEND TEST_SOURCES ${INTEGRATION_TEST_SOURCES})
+endif()
 
 foreach(test_src IN LISTS TEST_SOURCES)
     get_filename_component(test_name "${test_src}" NAME_WE)
@@ -28,7 +33,11 @@ foreach(test_src IN LISTS TEST_SOURCES)
 
     target_compile_features(${test_name} PRIVATE cxx_std_23)
 
-    if(FLOX_RUN_CONNECTOR_INTEGRATION_TESTS)
+    # unit_test_* are offline (no network) and always registered; the
+    # integration_test_* ones hit live exchanges and stay opt-in.
+    if(test_name MATCHES "^unit_test_")
+        add_test(NAME ${test_name} COMMAND ${test_name})
+    elseif(FLOX_RUN_CONNECTOR_INTEGRATION_TESTS)
         add_test(NAME ${test_name} COMMAND ${test_name})
     endif()
 endforeach()

--- a/connectors/tests/unit_test_bybit_gap.cpp
+++ b/connectors/tests/unit_test_bybit_gap.cpp
@@ -1,0 +1,169 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Offline protocol test: Bybit orderbook update-id continuity. A delta whose
+ * "u" is not lastU+1 means a dropped frame; the connector must DROP it (never
+ * apply onto a stale book), count the gap, and suppress further deltas until a
+ * fresh snapshot re-baselines. No sockets involved: raw frames are fed straight
+ * into handleMessage.
+ */
+
+#include "flox-connectors/bybit/bybit_exchange_connector.h"
+
+#include <flox/book/bus/book_update_bus.h>
+#include <flox/book/bus/trade_bus.h>
+#include <flox/book/events/book_update_event.h>
+#include <flox/common.h>
+#include <flox/log/atomic_logger.h>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using namespace flox;
+
+namespace
+{
+
+std::string tempLogDir()
+{
+  auto dir = std::filesystem::temp_directory_path() / "flox_bybit_gap_test_logs";
+  std::filesystem::create_directories(dir);
+  return dir.string();
+}
+
+class CapturingSub final : public IMarketDataSubscriber
+{
+ public:
+  SubscriberId id() const override { return 7; }
+
+  void onBookUpdate(const BookUpdateEvent& ev) override
+  {
+    std::lock_guard<std::mutex> lk(_m);
+    _events.push_back({ev.update.type, ev.seq});
+  }
+
+  struct Seen
+  {
+    BookUpdateType type;
+    int64_t updateId;
+  };
+
+  std::vector<Seen> events()
+  {
+    std::lock_guard<std::mutex> lk(_m);
+    return _events;
+  }
+
+ private:
+  std::mutex _m;
+  std::vector<Seen> _events;
+};
+
+std::string bookFrame(const char* type, int64_t u, int64_t seq)
+{
+  std::string s = R"({"topic":"orderbook.50.BTCUSDT","type":")";
+  s += type;
+  s +=
+      R"(","ts":1700000000000,"cts":1700000000000,"data":{"s":"BTCUSDT","b":[["100","1"]],"a":[["101","2"]],"u":)";
+  s += std::to_string(u);
+  s += R"(,"seq":)";
+  s += std::to_string(seq);
+  s += "}}";
+  return s;
+}
+
+}  // namespace
+
+TEST(BybitBookGap, DeltaGapDropsAndResyncs)
+{
+  BookUpdateBus bookBus;
+  TradeBus tradeBus;
+  CapturingSub sub;
+  bookBus.subscribe(&sub);
+  bookBus.start();
+  tradeBus.start();
+
+  SymbolRegistry registry;
+  SymbolInfo btc{};
+  btc.symbol = "BTCUSDT";
+  btc.exchange = "bybit";
+  btc.type = InstrumentType::Future;
+  registry.registerSymbol(btc);
+
+  BybitConfig cfg;
+  cfg.publicEndpoint = "wss://unused.invalid";
+  cfg.symbols = {{"BTCUSDT", InstrumentType::Future, BybitConfig::BookDepth::Top50}};
+
+  AtomicLoggerOptions logOpts;
+  logOpts.directory = tempLogDir();
+  logOpts.basename = "bybit_gap_test.log";
+  auto logger = std::make_shared<AtomicLogger>(logOpts);
+
+  BybitExchangeConnector connector(cfg, &bookBus, &tradeBus, nullptr, &registry, logger);
+  // Never started: frames are fed directly; resubscribe is a no-op without a
+  // socket, which is exactly what the offline path needs.
+
+  connector.handleMessage(bookFrame("snapshot", 100, 1000));  // baseline
+  connector.handleMessage(bookFrame("delta", 101, 1001));     // contiguous -> applied
+  connector.handleMessage(bookFrame("delta", 105, 1002));     // GAP -> dropped, resync
+  connector.handleMessage(bookFrame("delta", 106, 1003));     // in-flight -> dropped
+  connector.handleMessage(bookFrame("snapshot", 200, 1010));  // fresh baseline
+  connector.handleMessage(bookFrame("delta", 201, 1011));     // contiguous -> applied
+
+  bookBus.flush();
+  bookBus.stop();
+  tradeBus.stop();
+
+  EXPECT_EQ(connector.bookGapCount(), 1u);  // one gap; in-flight drops don't recount
+
+  const auto seen = sub.events();
+  ASSERT_EQ(seen.size(), 4u);  // the two gap-window deltas never reached the bus
+  EXPECT_EQ(seen[0].type, BookUpdateType::SNAPSHOT);
+  EXPECT_EQ(seen[0].updateId, 100);
+  EXPECT_EQ(seen[1].type, BookUpdateType::DELTA);
+  EXPECT_EQ(seen[1].updateId, 101);
+  EXPECT_EQ(seen[2].type, BookUpdateType::SNAPSHOT);
+  EXPECT_EQ(seen[2].updateId, 200);
+  EXPECT_EQ(seen[3].type, BookUpdateType::DELTA);
+  EXPECT_EQ(seen[3].updateId, 201);
+}
+
+TEST(BybitBookGap, DeltaBeforeSnapshotIsDropped)
+{
+  BookUpdateBus bookBus;
+  TradeBus tradeBus;
+  CapturingSub sub;
+  bookBus.subscribe(&sub);
+  bookBus.start();
+  tradeBus.start();
+
+  SymbolRegistry registry;
+  BybitConfig cfg;
+  cfg.publicEndpoint = "wss://unused.invalid";
+  cfg.symbols = {{"BTCUSDT", InstrumentType::Future, BybitConfig::BookDepth::Top50}};
+
+  AtomicLoggerOptions logOpts;
+  logOpts.directory = tempLogDir();
+  logOpts.basename = "bybit_gap_test2.log";
+  auto logger = std::make_shared<AtomicLogger>(logOpts);
+
+  BybitExchangeConnector connector(cfg, &bookBus, &tradeBus, nullptr, &registry, logger);
+
+  connector.handleMessage(bookFrame("delta", 50, 900));  // no baseline -> gap path
+  bookBus.flush();
+  bookBus.stop();
+  tradeBus.stop();
+
+  EXPECT_EQ(connector.bookGapCount(), 1u);
+  EXPECT_TRUE(sub.events().empty());  // nothing published from a baseline-less delta
+}

--- a/connectors/tests/unit_test_fixed_point_parse.cpp
+++ b/connectors/tests/unit_test_fixed_point_parse.cpp
@@ -1,0 +1,70 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * util::parseFixedPoint: decimal string -> fixed-point raw, no double, lenient
+ * on excess precision (exchange data is authoritative).
+ */
+
+#include "flox-connectors/util/safe_parse.h"
+
+#include <flox/common.h>
+
+#include <gtest/gtest.h>
+
+using namespace flox;
+
+namespace
+{
+constexpr int64_t S = Price::Scale;  // 1e8
+
+int64_t parse(std::string_view sv)
+{
+  int64_t out = -1;
+  EXPECT_TRUE(util::parseFixedPoint(sv, S, out)) << "failed to parse: " << sv;
+  return out;
+}
+}  // namespace
+
+TEST(FixedPointParse, ExactValues)
+{
+  EXPECT_EQ(parse("0"), 0);
+  EXPECT_EQ(parse("1"), S);
+  EXPECT_EQ(parse("50000"), 50000LL * S);
+  EXPECT_EQ(parse("50000.5"), 50000LL * S + S / 2);
+  EXPECT_EQ(parse("0.00000001"), 1);  // one raw unit at 1e-8
+  EXPECT_EQ(parse("100.25"), 10025LL * (S / 100));
+  EXPECT_EQ(parse("-3.5"), -(3LL * S + S / 2));  // sign supported
+}
+
+TEST(FixedPointParse, MatchesFromDoubleWithoutTheDouble)
+{
+  // The value fromDouble would produce, computed without a double round-trip.
+  int64_t raw = 0;
+  ASSERT_TRUE(util::parseFixedPoint("12345.678", S, raw));
+  EXPECT_EQ(Price::fromRaw(raw), Price::fromDouble(12345.678));
+}
+
+TEST(FixedPointParse, TruncatesExcessPrecision)
+{
+  // 9+ fractional digits: digits beyond 1e-8 are truncated toward zero, the
+  // level is NOT dropped.
+  int64_t raw = 0;
+  ASSERT_TRUE(util::parseFixedPoint("0.123456789", S, raw));
+  EXPECT_EQ(raw, 12345678);  // 0.12345678, last digit dropped
+}
+
+TEST(FixedPointParse, Rejects)
+{
+  int64_t out = 0;
+  EXPECT_FALSE(util::parseFixedPoint("", S, out));
+  EXPECT_FALSE(util::parseFixedPoint("abc", S, out));
+  EXPECT_FALSE(util::parseFixedPoint("1.2.3", S, out));
+  EXPECT_FALSE(util::parseFixedPoint("1e5", S, out));          // exponent unsupported
+  EXPECT_FALSE(util::parseFixedPoint("12 ", S, out));          // trailing space
+  EXPECT_FALSE(util::parseFixedPoint("99999999999", S, out));  // int part overflow
+}

--- a/connectors/tests/unit_test_polymarket_delta.cpp
+++ b/connectors/tests/unit_test_polymarket_delta.cpp
@@ -1,0 +1,129 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Offline protocol test: Polymarket price_change (incremental) messages must
+ * mutate the book, not be silently dropped. Raw frames are fed straight into
+ * handleMessage; no sockets.
+ */
+
+#include "flox-connectors/polymarket/polymarket_exchange_connector.h"
+
+#include <flox/book/bus/book_update_bus.h>
+#include <flox/book/bus/trade_bus.h>
+#include <flox/book/events/book_update_event.h>
+#include <flox/common.h>
+#include <flox/log/atomic_logger.h>
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using namespace flox;
+
+namespace
+{
+
+std::string tempLogDir()
+{
+  auto dir = std::filesystem::temp_directory_path() / "flox_poly_delta_test_logs";
+  std::filesystem::create_directories(dir);
+  return dir.string();
+}
+
+struct SeenUpdate
+{
+  BookUpdateType type;
+  std::vector<std::pair<double, double>> bids;
+  std::vector<std::pair<double, double>> asks;
+};
+
+class CapturingSub final : public IMarketDataSubscriber
+{
+ public:
+  SubscriberId id() const override { return 11; }
+
+  void onBookUpdate(const BookUpdateEvent& ev) override
+  {
+    std::lock_guard<std::mutex> lk(_m);
+    SeenUpdate u;
+    u.type = ev.update.type;
+    for (const auto& l : ev.update.bids)
+    {
+      u.bids.emplace_back(l.price.toDouble(), l.quantity.toDouble());
+    }
+    for (const auto& l : ev.update.asks)
+    {
+      u.asks.emplace_back(l.price.toDouble(), l.quantity.toDouble());
+    }
+    _updates.push_back(std::move(u));
+  }
+
+  std::vector<SeenUpdate> updates()
+  {
+    std::lock_guard<std::mutex> lk(_m);
+    return _updates;
+  }
+
+ private:
+  std::mutex _m;
+  std::vector<SeenUpdate> _updates;
+};
+
+}  // namespace
+
+TEST(PolymarketDelta, PriceChangeAppliesAsDelta)
+{
+  BookUpdateBus bookBus;
+  TradeBus tradeBus;
+  CapturingSub sub;
+  bookBus.subscribe(&sub);
+  bookBus.start();
+  tradeBus.start();
+
+  SymbolRegistry registry;
+  AtomicLoggerOptions logOpts;
+  logOpts.directory = tempLogDir();
+  logOpts.basename = "poly_delta.log";
+  auto logger = std::make_shared<AtomicLogger>(logOpts);
+
+  PolymarketConfig cfg;
+  cfg.wsEndpoint = "wss://unused.invalid";
+  cfg.tokenIds = {"TOKEN"};
+  PolymarketExchangeConnector connector(cfg, &bookBus, &tradeBus, &registry, logger);
+
+  // Snapshot first (array form), then an incremental price_change.
+  connector.handleMessage(
+      R"([{"event_type":"book","asset_id":"TOKEN","bids":[{"price":"0.40","size":"100"}],"asks":[{"price":"0.60","size":"80"}]}])");
+  connector.handleMessage(
+      R"({"event_type":"price_change","market":"0xabc","price_changes":[)"
+      R"({"asset_id":"TOKEN","price":"0.41","size":"50","side":"BUY","hash":"h"},)"
+      R"({"asset_id":"TOKEN","price":"0.60","size":"0","side":"SELL","hash":"h"}],"timestamp":1})");
+
+  bookBus.flush();
+  bookBus.stop();
+  tradeBus.stop();
+
+  const auto ups = sub.updates();
+  ASSERT_EQ(ups.size(), 2u);
+
+  EXPECT_EQ(ups[0].type, BookUpdateType::SNAPSHOT);
+  ASSERT_EQ(ups[0].bids.size(), 1u);
+  EXPECT_DOUBLE_EQ(ups[0].bids[0].first, 0.40);
+
+  // The delta carried both a new bid level and a removed ask (size 0).
+  EXPECT_EQ(ups[1].type, BookUpdateType::DELTA);
+  ASSERT_EQ(ups[1].bids.size(), 1u);
+  EXPECT_DOUBLE_EQ(ups[1].bids[0].first, 0.41);
+  EXPECT_DOUBLE_EQ(ups[1].bids[0].second, 50.0);
+  ASSERT_EQ(ups[1].asks.size(), 1u);
+  EXPECT_DOUBLE_EQ(ups[1].asks[0].first, 0.60);
+  EXPECT_DOUBLE_EQ(ups[1].asks[0].second, 0.0);  // level removal
+}

--- a/include/flox/net/receive_path.h
+++ b/include/flox/net/receive_path.h
@@ -16,12 +16,12 @@
 //
 //   - UdpSocketReceivePath (here): non-blocking socket + recvmsg, kernel or
 //     NIC receive timestamps when available. Works everywhere; the default.
-//   - AF_XDP backend (designed, Linux-only, not yet implemented): kernel
+//   - AfXdpReceivePath (flox/net/af_xdp_receive_path.h, Linux-only): kernel
 //     keeps the NIC, an eBPF program redirects to a user-space UMEM ring --
-//     the pragmatic middle between the kernel path and full DPDK. Needs
-//     libxdp, a capable driver, and a Linux host to validate against; the
-//     interface below is shaped so it drops in (poll semantics, borrowed
-//     buffers, explicit rx timestamps).
+//     the pragmatic middle between the kernel path and full DPDK. Implemented
+//     against libxdp (xsk) and validated on a Linux host; needs a capable
+//     driver. The interface below is the seam it plugs into (poll semantics,
+//     borrowed buffers, explicit rx timestamps); see tools/afxdp_probe.cpp.
 //
 // Contract: payload spans are BORROWED -- valid only inside the callback.
 // The decoder consumes or copies before returning; nothing allocates on the

--- a/include/flox/util/crypto.h
+++ b/include/flox/util/crypto.h
@@ -5,6 +5,15 @@
  * Copyright (c) 2025 FLOX Foundation
  * Licensed under the MIT License. See LICENSE file in the project root for full
  * license information.
+ *
+ * SCOPE: these are small, dependency-free SHA-1 / SHA-256 / HMAC-SHA256 /
+ * base64 implementations for the venue PERIMETER only -- the RFC 6455
+ * WebSocket handshake (SHA-1) and the venue session's API-key HMAC logon --
+ * and are covered by test vectors (venue/tests/test_venue_crypto.cpp). They are
+ * NOT for signing production exchange traffic: the live connectors sign their
+ * requests with OpenSSL (e.g. connectors/src/bitget/authenticated_rest_client
+ * .cpp), and any new signing path should do the same rather than reach for
+ * these. Kept hand-rolled so core carries no crypto dependency.
  */
 #pragma once
 

--- a/include/flox/util/performance/core_assignment.h
+++ b/include/flox/util/performance/core_assignment.h
@@ -165,21 +165,6 @@ class CoreAssignmentManager
      * @return Vector of core IDs assigned to the component
      */
   std::vector<int> getCoresFor(const CoreAssignment& assignment, const std::string& component);
-
-  /**
-     * @brief Balance cores across NUMA nodes for optimal performance
-     * @param assignment Core assignment to balance
-     * @param topology NUMA topology information
-     * @return Balanced core assignment
-     */
-  CoreAssignment balanceAcrossNumaNodes(const CoreAssignment& assignment, const NumaTopology& topology);
-
-  /**
-     * @brief Optimize core assignment for cache locality
-     * @param assignment Core assignment to optimize
-     * @return Optimized core assignment
-     */
-  CoreAssignment optimizeForCacheLocality(const CoreAssignment& assignment);
 };
 
 // Inline implementations
@@ -206,7 +191,6 @@ inline CoreAssignment CoreAssignmentManager::getRecommendedCoreAssignment(const 
 inline CoreAssignment CoreAssignmentManager::getNumaAwareCoreAssignment(const CriticalComponentConfig& config)
 {
   CoreAssignment assignment;
-  auto topology = _cpuTopology->getNumaTopology();
   auto isolatedCores = _cpuTopology->getIsolatedCores();
 
   assignment.hasIsolatedCores = !isolatedCores.empty();
@@ -280,7 +264,7 @@ inline CoreAssignment CoreAssignmentManager::getNumaAwareCoreAssignment(const Cr
   assignment.criticalCores.insert(assignment.criticalCores.end(),
                                   assignment.riskCores.begin(), assignment.riskCores.end());
 
-  return balanceAcrossNumaNodes(assignment, topology);
+  return assignment;
 }
 
 inline CoreAssignment CoreAssignmentManager::getBasicCoreAssignment(int numCores, const std::vector<int>& isolatedCores)
@@ -530,27 +514,6 @@ inline std::vector<int> CoreAssignmentManager::getCoresFor(const CoreAssignment&
   }
 
   return {};
-}
-
-inline CoreAssignment CoreAssignmentManager::balanceAcrossNumaNodes(const CoreAssignment& assignment, const NumaTopology& topology)
-{
-  if (!topology.numaAvailable || topology.nodes.size() <= 1)
-  {
-    return assignment;
-  }
-
-  // For now, return assignment as-is
-  // In a full implementation, we would balance cores across NUMA nodes
-  // based on workload characteristics and memory access patterns
-  return assignment;
-}
-
-inline CoreAssignment CoreAssignmentManager::optimizeForCacheLocality(const CoreAssignment& assignment)
-{
-  // For now, return assignment as-is
-  // In a full implementation, we would optimize core assignment
-  // based on cache hierarchy and core topology
-  return assignment;
 }
 
 }  // namespace flox::performance

--- a/include/flox/util/websocket.h
+++ b/include/flox/util/websocket.h
@@ -108,14 +108,29 @@ inline constexpr uint64_t kMaxFramePayload = 16u << 20;  // 16 MiB
 inline constexpr size_t kParseError = static_cast<size_t>(-1);
 
 // Parse one frame; returns bytes consumed (0 if incomplete, kParseError on a
-// protocol violation). Unmasks client payloads.
-inline size_t parseFrame(const uint8_t* p, size_t n, Opcode& op, std::vector<uint8_t>& payload)
+// protocol violation). Unmasks client payloads. When `finOut` is non-null it
+// receives the FIN bit, so the caller can reassemble fragmented messages
+// (RFC 6455 5.4); a caller that ignores it must treat every frame as final.
+// RSV1-3 must be zero (no extension is negotiated) -- a set RSV bit is a
+// protocol violation, not silently ignored.
+inline size_t parseFrame(const uint8_t* p, size_t n, Opcode& op, std::vector<uint8_t>& payload,
+                         bool* finOut = nullptr)
 {
   if (n < 2)
   {
     return 0;
   }
+  if ((p[0] & 0x70) != 0)
+  {
+    return kParseError;  // RSV1/2/3 set without a negotiated extension
+  }
+  const bool fin = (p[0] & 0x80) != 0;
   op = static_cast<Opcode>(p[0] & 0x0F);
+  // Control frames (Close/Ping/Pong) must not be fragmented.
+  if ((static_cast<uint8_t>(op) & 0x08) != 0 && !fin)
+  {
+    return kParseError;
+  }
   const bool masked = (p[1] & 0x80) != 0;
   uint64_t len = p[1] & 0x7F;
   size_t off = 2;
@@ -171,6 +186,10 @@ inline size_t parseFrame(const uint8_t* p, size_t n, Opcode& op, std::vector<uin
   for (uint64_t i = 0; i < len; ++i)
   {
     payload[i] = p[off + i] ^ (masked ? mask[i & 3] : 0);
+  }
+  if (finOut != nullptr)
+  {
+    *finOut = fin;
   }
   return off + len;
 }

--- a/mcp/flox_mcp/data/binding_manifest.json
+++ b/mcp/flox_mcp/data/binding_manifest.json
@@ -16252,11 +16252,6 @@
         },
         {
           "kind": "method",
-          "name": "balanceAcrossNumaNodes",
-          "parent": "CoreAssignmentManager"
-        },
-        {
-          "kind": "method",
           "name": "checkIsolatedCoreRequirements",
           "parent": "CoreAssignmentManager"
         },
@@ -16288,11 +16283,6 @@
         {
           "kind": "method",
           "name": "getRecommendedCoreAssignment",
-          "parent": "CoreAssignmentManager"
-        },
-        {
-          "kind": "method",
-          "name": "optimizeForCacheLocality",
           "parent": "CoreAssignmentManager"
         },
         {

--- a/src/replay/abstract_event_reader.cpp
+++ b/src/replay/abstract_event_reader.cpp
@@ -13,6 +13,8 @@
 #include "flox/replay/readers/parallel_reader.h"
 
 #include <atomic>
+#include <filesystem>
+#include <memory>
 #include <mutex>
 
 namespace flox::replay
@@ -22,37 +24,44 @@ class BinaryLogIteratorAdapter : public ISegmentReader
 {
  public:
   explicit BinaryLogIteratorAdapter(const std::filesystem::path& path)
-      : _iterator(path)
+      : _path(path), _iterator(std::make_unique<BinaryLogIterator>(path))
   {
-    if (_iterator.isValid())
+    if (_iterator->isValid())
     {
-      _iterator.loadIndex();
+      _iterator->loadIndex();
     }
   }
 
-  bool isValid() const override { return _iterator.isValid(); }
+  bool isValid() const override { return _iterator->isValid(); }
 
-  bool isCompressed() const override { return _iterator.isCompressed(); }
+  bool isCompressed() const override { return _iterator->isCompressed(); }
 
-  bool hasIndex() const override { return _iterator.hasIndex(); }
+  bool hasIndex() const override { return _iterator->hasIndex(); }
 
-  bool next(ReplayEvent& out) override { return _iterator.next(out); }
+  bool next(ReplayEvent& out) override { return _iterator->next(out); }
 
+  // BinaryLogIterator has no in-place rewind, so reconstruct it over the same
+  // path: a real reset to the first event, not a silent no-op that would make a
+  // second iteration pass continue from the current position.
   void reset() override
   {
-    // BinaryLogIterator doesn't have reset - recreate would be needed
-    // For now this is a limitation
+    _iterator = std::make_unique<BinaryLogIterator>(_path);
+    if (_iterator->isValid())
+    {
+      _iterator->loadIndex();
+    }
   }
 
   bool seekToTimestamp(int64_t target_ts_ns) override
   {
-    return _iterator.seekToTimestamp(target_ts_ns);
+    return _iterator->seekToTimestamp(target_ts_ns);
   }
 
-  const SegmentHeader& header() const override { return _iterator.header(); }
+  const SegmentHeader& header() const override { return _iterator->header(); }
 
  private:
-  BinaryLogIterator _iterator;
+  std::filesystem::path _path;
+  std::unique_ptr<BinaryLogIterator> _iterator;
 };
 
 class MmapSegmentReaderAdapter : public ISegmentReader

--- a/src/replay/validator.cpp
+++ b/src/replay/validator.cpp
@@ -9,6 +9,8 @@
 
 #include "flox/replay/ops/validator.h"
 
+#include "flox/replay/ops/index_builder.h"
+
 #include <algorithm>
 #include <cstring>
 
@@ -805,9 +807,17 @@ bool SegmentRepairer::fixEventCount(const std::filesystem::path& path,
 
 bool SegmentRepairer::rebuildIndex(const std::filesystem::path& path, RepairResult& result)
 {
-  // Use IndexBuilder to rebuild
-  // For now, just note that it would be done
-  result.actions_taken.push_back("Index rebuild requested (use IndexBuilder)");
+  // Actually rebuild the index (scan the record stream, write a fresh index)
+  // and verify it, instead of claiming success without doing anything.
+  IndexBuilder builder;  // default: verify_crc = true
+  const IndexBuildResult r = builder.buildForSegment(path);
+  if (!r.success)
+  {
+    result.errors.push_back("Index rebuild failed: " + r.error);
+    return false;
+  }
+  result.actions_taken.push_back("Rebuilt index: " + std::to_string(r.index_entries_created) +
+                                 " entries over " + std::to_string(r.events_scanned) + " events");
   return true;
 }
 

--- a/tests/test_binary_log.cpp
+++ b/tests/test_binary_log.cpp
@@ -1454,6 +1454,84 @@ TEST_F(BinaryLogTest, ValidatorValidSegment)
   }
 }
 
+// SegmentRepairer::rebuildIndex must actually rebuild (and verify) the index,
+// not fake success. Corrupt the index region so validation reports a present
+// but invalid index; repair must regenerate it and report the real action.
+TEST_F(BinaryLogTest, RepairerRebuildsCorruptIndex)
+{
+  {
+    WriterConfig config{.output_dir = _test_dir, .index_interval = 50};
+    BinaryLogWriter writer(config);
+    for (int i = 0; i < 300; ++i)
+    {
+      TradeRecord trade{};
+      trade.exchange_ts_ns = 1000000000LL + i * 1000000LL;
+      trade.symbol_id = 1;
+      trade.trade_id = static_cast<uint64_t>(i);
+      writer.writeTrade(trade);
+    }
+    writer.close();
+  }
+
+  std::filesystem::path segment_path;
+  for (const auto& entry : std::filesystem::directory_iterator(_test_dir))
+  {
+    if (entry.path().extension() == ".floxlog")
+    {
+      segment_path = entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(segment_path.empty());
+
+  // Read the header to find the index offset, then flip a byte inside the index.
+  SegmentHeader header{};
+  {
+    std::FILE* f = std::fopen(segment_path.string().c_str(), "rb");
+    ASSERT_NE(f, nullptr);
+    ASSERT_EQ(std::fread(&header, sizeof(header), 1, f), 1u);
+    std::fclose(f);
+  }
+  ASSERT_TRUE(header.hasIndex());
+  {
+    std::FILE* f = std::fopen(segment_path.string().c_str(), "r+b");
+    ASSERT_NE(f, nullptr);
+    std::fseek(f, static_cast<long>(header.index_offset), SEEK_SET);
+    uint8_t b = 0;
+    ASSERT_EQ(std::fread(&b, 1, 1, f), 1u);
+    b ^= 0xFF;
+    std::fseek(f, static_cast<long>(header.index_offset), SEEK_SET);
+    ASSERT_EQ(std::fwrite(&b, 1, 1, f), 1u);
+    std::fclose(f);
+  }
+
+  // Now the index is present but invalid.
+  SegmentValidator validator;
+  auto before = validator.validate(segment_path);
+  EXPECT_TRUE(before.has_index);
+  EXPECT_FALSE(before.index_valid);
+
+  // Repair: rebuild_index is on by default; it must call the real IndexBuilder.
+  RepairConfig rc;
+  rc.backup_before_repair = false;
+  SegmentRepairer repairer(rc);
+  auto rr = repairer.repair(segment_path);
+
+  bool rebuilt = false;
+  for (const auto& a : rr.actions_taken)
+  {
+    if (a.find("Rebuilt index") != std::string::npos)
+    {
+      rebuilt = true;
+    }
+  }
+  EXPECT_TRUE(rebuilt);  // the real action was reported, not a fake "requested"
+
+  auto after = validator.validate(segment_path);
+  EXPECT_TRUE(after.has_index);
+  EXPECT_TRUE(after.index_valid);  // index actually usable again
+}
+
 TEST_F(BinaryLogTest, ValidatorNonExistentFile)
 {
   SegmentValidator validator;
@@ -2354,6 +2432,59 @@ TEST_F(BinaryLogTest, ISegmentReaderFactoryIterator)
     ++count;
   }
   EXPECT_EQ(count, 30);
+}
+
+// reset() on the iterator adapter must rewind to the first event, so a second
+// pass yields the same sequence -- not a silent no-op that continues from the
+// current position (which returned nothing on the second pass).
+TEST_F(BinaryLogTest, IteratorAdapterResetRewinds)
+{
+  {
+    WriterConfig config{.output_dir = _test_dir};
+    BinaryLogWriter writer(config);
+    for (int i = 0; i < 20; ++i)
+    {
+      TradeRecord trade{};
+      trade.exchange_ts_ns = 1000000000LL + i * 1000000LL;
+      trade.symbol_id = 3;
+      trade.trade_id = static_cast<uint64_t>(i);
+      writer.writeTrade(trade);
+    }
+    writer.close();
+  }
+
+  std::filesystem::path segment_path;
+  for (const auto& entry : std::filesystem::directory_iterator(_test_dir))
+  {
+    if (entry.path().extension() == ".floxlog")
+    {
+      segment_path = entry.path();
+      break;
+    }
+  }
+
+  // prefer_mmap=false forces the BinaryLogIteratorAdapter (the one whose reset
+  // was a no-op).
+  auto reader = createSegmentReader(segment_path, /*prefer_mmap*/ false);
+  ASSERT_TRUE(reader->isValid());
+
+  auto drain = [&]
+  {
+    std::vector<uint64_t> ids;
+    ReplayEvent event;
+    while (reader->next(event))
+    {
+      ids.push_back(event.trade.trade_id);
+    }
+    return ids;
+  };
+
+  const auto first = drain();
+  EXPECT_EQ(first.size(), 20u);
+
+  reader->reset();
+  const auto second = drain();
+  EXPECT_EQ(second, first);  // identical, non-empty second pass
 }
 
 TEST_F(BinaryLogTest, IMultiSegmentReaderFactory)

--- a/venue/include/flox-venue/ws_gateway.h
+++ b/venue/include/flox-venue/ws_gateway.h
@@ -85,14 +85,21 @@ class WsGateway
 
     std::vector<uint8_t> buf;
     DisconnectCanceller cod(cancelOnDisconnect_.load());
+    // Fragmentation reassembly (RFC 6455 5.4): a data message may span a
+    // FIN=0 Text/Binary frame followed by Continuation frames; control frames
+    // (Ping/Pong/Close) may interleave and are handled immediately.
+    std::vector<uint8_t> msg;
+    ws::Opcode msgOp{};
+    bool assembling = false;
     while (acceptor_.running())
     {
       ws::Opcode op{};
       std::vector<uint8_t> payload;
-      const size_t consumed = ws::parseFrame(buf.data(), buf.size(), op, payload);
+      bool fin = true;
+      const size_t consumed = ws::parseFrame(buf.data(), buf.size(), op, payload, &fin);
       if (consumed == ws::kParseError)
       {
-        break;  // hostile/oversized frame: drop the connection
+        break;  // hostile/oversized/malformed frame: drop the connection
       }
       if (consumed == 0)
       {
@@ -105,6 +112,8 @@ class WsGateway
         continue;
       }
       buf.erase(buf.begin(), buf.begin() + static_cast<std::ptrdiff_t>(consumed));
+
+      // Control frames are always final and may arrive mid-message.
       if (op == ws::Opcode::Close)
       {
         break;
@@ -115,19 +124,64 @@ class WsGateway
         net::writeAll(fd, pong.data(), pong.size());
         continue;
       }
+      if (op == ws::Opcode::Pong)
+      {
+        continue;
+      }
+
+      // Data frames: Text/Binary start a message, Continuation extends it.
       if (op == ws::Opcode::Text || op == ws::Opcode::Binary)
       {
-        SessionReject rej{};
-        auto cmd = session.handle(payload.data(), payload.size(), ++clock_, rej);
-        if (cmd)
+        if (assembling)
         {
-          cod.track(*cmd);
-          handler_(*cmd, responder);
+          break;  // new data frame before the previous message finished: violation
         }
+        if (fin)
+        {
+          dispatch(session, cod, responder, payload.data(), payload.size());
+          continue;
+        }
+        assembling = true;
+        msgOp = op;
+        msg = std::move(payload);
+        continue;
       }
+      if (op == ws::Opcode::Cont)
+      {
+        if (!assembling)
+        {
+          break;  // continuation with no message in progress: violation
+        }
+        if (msg.size() + payload.size() > ws::kMaxFramePayload)
+        {
+          break;  // reassembled message exceeds the bound
+        }
+        msg.insert(msg.end(), payload.begin(), payload.end());
+        if (fin)
+        {
+          dispatch(session, cod, responder, msg.data(), msg.size());
+          assembling = false;
+          msg.clear();
+        }
+        continue;
+      }
+      break;  // unknown opcode
     }
     cod.flush(handler_);
     ::close(fd);
+  }
+
+  // Decode one fully-assembled message and, if it is a valid command, run it.
+  void dispatch(GatewaySession& session, DisconnectCanceller& cod, const Responder& responder,
+                const uint8_t* p, size_t n)
+  {
+    SessionReject rej{};
+    auto cmd = session.handle(p, n, ++clock_, rej);
+    if (cmd)
+    {
+      cod.track(*cmd);
+      handler_(*cmd, responder);
+    }
   }
 
   GatewaySession::Decoder decoder_;

--- a/venue/tests/test_venue_network.cpp
+++ b/venue/tests/test_venue_network.cpp
@@ -338,6 +338,23 @@ void test_websocket()
   std::vector<uint8_t> partial = {0x82, 0x04, 0xAA, 0xBB};
   CHECK(ws::parseFrame(partial.data(), partial.size(), op, pl) == 0);
 
+  // FIN bit is surfaced via the out-param: a final Text frame reports fin=true,
+  // a fragment start (FIN=0 Text) reports fin=false.
+  bool fin = false;
+  CHECK(ws::parseFrame(f.data(), f.size(), op, pl, &fin) == f.size() && fin);
+  std::vector<uint8_t> frag = {0x01, 0x02, 0xAA, 0xBB};  // FIN=0, Text, 2 bytes
+  CHECK(ws::parseFrame(frag.data(), frag.size(), op, pl, &fin) == frag.size());
+  CHECK(op == ws::Opcode::Text && !fin);
+
+  // RSV1 set without a negotiated extension is a protocol violation, not
+  // silently ignored (0xC2 = FIN + RSV1 + Binary).
+  std::vector<uint8_t> rsv = {0xC2, 0x01, 0x00};
+  CHECK(ws::parseFrame(rsv.data(), rsv.size(), op, pl) == ws::kParseError);
+
+  // A fragmented control frame (FIN=0 on a Ping) is illegal.
+  std::vector<uint8_t> fragPing = {0x09, 0x00};  // FIN=0, Ping
+  CHECK(ws::parseFrame(fragPing.data(), fragPing.size(), op, pl) == ws::kParseError);
+
   // Binary/TLS length-prefix path: a u32 prefix beyond net::kMaxFrame must make
   // readFrame reject rather than resize() up to 4 GiB. Drive it through a pipe.
   {
@@ -441,6 +458,32 @@ void test_md_snapshot()
   CHECK(md.book().askAtPrice(px(100)) == qty(5));  // snapshot agrees with live depth
 }
 
+// Split `s` across two masked frames: [Text FIN=0 | first half] then
+// [Continuation FIN=1 | second half]. The gateway must reassemble them into one
+// message (RFC 6455 5.4). Payload halves stay < 126 bytes (single-byte length).
+std::pair<std::vector<uint8_t>, std::vector<uint8_t>> wsClientFragments(const std::string& s)
+{
+  const uint8_t mask[4] = {9, 8, 7, 6};
+  auto frame = [&](uint8_t b0, const std::string& part)
+  {
+    std::vector<uint8_t> f;
+    f.push_back(b0);
+    f.push_back(static_cast<uint8_t>(0x80 | part.size()));
+    for (int i = 0; i < 4; ++i)
+    {
+      f.push_back(mask[i]);
+    }
+    for (size_t i = 0; i < part.size(); ++i)
+    {
+      f.push_back(static_cast<uint8_t>(part[i] ^ mask[i & 3]));
+    }
+    return f;
+  };
+  const size_t half = s.size() / 2;
+  return {frame(0x01, s.substr(0, half)),  // Text, FIN=0
+          frame(0x80, s.substr(half))};    // Continuation (0x0), FIN=1
+}
+
 std::vector<uint8_t> wsClientFrame(const std::string& s)
 {
   std::vector<uint8_t> f;
@@ -516,9 +559,12 @@ void test_ws_gateway()
   }
   CHECK(resp.find("101 Switching Protocols") != std::string::npos);
 
-  auto sell = wsClientFrame(
+  // Send the sell FRAGMENTED across two frames; reassembly must recombine it
+  // into a valid order that then rests and trades against the buy below.
+  auto [sf1, sf2] = wsClientFragments(
       R"({"action":"new","id":1,"symbol":1,"side":"sell","ordType":"limit","qty":5,"price":100})");
-  ::write(c, sell.data(), sell.size());
+  ::write(c, sf1.data(), sf1.size());
+  ::write(c, sf2.data(), sf2.size());
   auto buy = wsClientFrame(
       R"({"action":"new","id":2,"symbol":1,"side":"buy","ordType":"limit","qty":3,"price":100,"account":2})");
   ::write(c, buy.data(), buy.size());


### PR DESCRIPTION
Follow-up to the venue hardening (#442): a full-codebase sweep for the same defect class -- things that look like functionality but aren't (borrowed names, silent no-ops, fields nobody consumes, fake-success returns, dropped data). Every finding was verified against the code before fixing. Core suite 182/182; new offline connector/replay tests included.

## Live-data integrity
- **T001 Bybit book gaps**: `seq`/`prevSeq` were stamped and never consumed -- a dropped WS frame applied the next delta onto a stale book, invisibly. Now the connector tracks the v5 update-id (`u`) continuity, drops a gapped delta, and re-subscribes for a fresh snapshot (gap counter + log). Fixes an `int` narrowing and a latent simdjson OUT_OF_ORDER in the parser found in passing.
- **T003 Polymarket deltas**: `price_changes` were recognised and dropped ("for now just ignore them"), leaving the book stale between snapshots. Now applied as DELTA updates (size 0 = level removal), grouped per symbol.

## Protocol honesty
- **T002 WebSocket fragmentation**: `parseFrame` ignored the FIN bit, so RFC 6455-fragmented client messages were neither reassembled nor rejected. Now RSV/fragmented-control frames are protocol violations and the gateway reassembles fragments (5.4); e2e test sends a split order that still trades.
- **T004 replay tooling**: `SegmentRepairer::rebuildIndex` fake-succeeded without rebuilding; `AbstractEventReader::reset()` was a silent no-op (second pass read nothing). Both now do the real thing, with tests (corrupt-index repair, iterate-reset-iterate).

## Fake API / precision
- **T005**: deleted the no-op `balanceAcrossNumaNodes` / `optimizeForCacheLocality` (returned their input while claiming to optimise).
- **T006**: all connectors parsed prices/quantities through double (`safeParseDouble` -> `fromDouble`), against the project's own fixed-point rule. Added a lenient `parseFixedPoint` (no double, no alloc, truncates excess precision -- exchange data is authoritative; deliberately NOT the venue's strict decwire) and routed bybit/bitget/polymarket/hyperliquid book+trade through it.
- **T007**: scope note on the hand-rolled perimeter crypto (not for production signing); corrected the stale "AF_XDP not yet implemented" comment (it is, and validated).

Notes: Bitget checksum validation (needs local-book reconstruction, wrong layer for a stateless forwarder) is tracked as a follow-up, not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
