### PR TITLE
fix(mcp): migrate to the mcp 2.0 SDK and gate the dependency range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,19 @@ jobs:
         # to be present in this job for --check to run end-to-end.
         python3 -m pip install --break-system-packages libclang pyyaml
         python3 scripts/sync_mcp_data.py --check
+    - name: Dependency ranges match between package and CI
+      # flox-mcp shipped `mcp>=1.0` while this file installed `mcp>=1.0,<2`, so
+      # CI was green on 1.x and users got the 2.0 SDK, which crashes on start.
+      run: python3 scripts/check_dep_pins.py
+
     - name: flox-mcp unit tests
       # `mcp` was never installed, so flox_mcp.server was unimportable and
       # nothing tested the 38 tool schemas or the dispatch chain that has to
       # match them. test_tool_dispatch.py needs it.
       run: |
-        # Pinned below 2.0: the 2.x SDK dropped the @server.list_tools() /
-        # @server.call_tool() decorators this server is built on.
-        python3 -m pip install --break-system-packages pytest "mcp>=1.0,<2"
+        # Keep this range identical to mcp/pyproject.toml; check_dep_pins.py
+        # enforces that.
+        python3 -m pip install --break-system-packages pytest "mcp>=2.0,<3"
         python3 -m pytest mcp/tests/ -q
 
   linux-gcc:

--- a/mcp/flox_mcp/server.py
+++ b/mcp/flox_mcp/server.py
@@ -6,8 +6,15 @@ import logging
 from typing import Any
 
 import mcp.server.stdio
-from mcp.server import Server
-from mcp.types import TextContent, Tool
+from mcp.server.lowlevel import Server
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
 
 from .tools import (
     analytics,
@@ -37,9 +44,8 @@ def build_server() -> Server:
     """Construct the MCP server with all registered tools."""
     server = Server("flox-mcp")
 
-    @server.list_tools()
-    async def _list_tools() -> list[Tool]:
-        return [
+    async def _list_tools(ctx: Any, params: PaginatedRequestParams | None) -> ListToolsResult:
+        return ListToolsResult(tools=[
             Tool(
                 name="flox_venue_guide",
                 description=(
@@ -1204,10 +1210,11 @@ def build_server() -> Server:
                     },
                 },
             ),
-        ]
+        ])
 
-    @server.call_tool()
-    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    async def _call_tool(ctx: Any, params: CallToolRequestParams) -> CallToolResult:
+        name = params.name
+        arguments = params.arguments or {}
         try:
             if name == "flox_overview":
                 text = overview.flox_overview()
@@ -1425,8 +1432,10 @@ def build_server() -> Server:
             log.exception("tool %s failed", name)
             text = f"flox-mcp error: {type(exc).__name__}: {exc}"
 
-        return [TextContent(type="text", text=text)]
+        return CallToolResult(content=[TextContent(type="text", text=text)])
 
+    server.add_request_handler("tools/list", PaginatedRequestParams, _list_tools)
+    server.add_request_handler("tools/call", CallToolRequestParams, _call_tool)
     return server
 
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "mcp>=1.0",
+    "mcp>=2.0,<3",
     "flox-py>=0.5",
 ]
 

--- a/mcp/tests/test_tool_dispatch.py
+++ b/mcp/tests/test_tool_dispatch.py
@@ -30,17 +30,19 @@ from flox_mcp.server import build_server  # noqa: E402
 
 
 def _handlers() -> tuple[Any, Any]:
+    # mcp 2.0 stores handlers by method string in HandlerEntry records, keyed
+    # off the wire method rather than the request class.
     server = build_server()
-    return (server.request_handlers[mcp_types.ListToolsRequest],
-            server.request_handlers[mcp_types.CallToolRequest])
+    return (server.get_request_handler("tools/list").handler,
+            server.get_request_handler("tools/call").handler)
 
 
 def _tool_names() -> list[str]:
     list_tools, _ = _handlers()
 
     async def go() -> list[str]:
-        res = await list_tools(mcp_types.ListToolsRequest(method="tools/list"))
-        return [t.name for t in res.root.tools]
+        res = await list_tools(None, None)
+        return [t.name for t in res.tools]
 
     return asyncio.run(go())
 
@@ -49,13 +51,9 @@ def _call(name: str, arguments: dict[str, Any] | None = None) -> str:
     _, call_tool = _handlers()
 
     async def go() -> str:
-        req = mcp_types.CallToolRequest(
-            method="tools/call",
-            params=mcp_types.CallToolRequestParams(
-                name=name, arguments=arguments or {}),
-        )
-        res = await call_tool(req)
-        parts = res.root.content
+        params = mcp_types.CallToolRequestParams(name=name, arguments=arguments or {})
+        res = await call_tool(None, params)
+        parts = res.content
         return "\n".join(getattr(p, "text", "") for p in parts)
 
     return asyncio.run(go())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,7 +54,7 @@ classifiers = [
 [project.optional-dependencies]
 ccxt = ["ccxt[pro]>=4.0"]
 mlflow = ["mlflow>=2.0"]
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=2.0,<3"]
 
 [project.urls]
 Homepage = "https://flox-foundation.github.io/flox/"

--- a/scripts/check_dep_pins.py
+++ b/scripts/check_dep_pins.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fail when CI installs a different dependency range than the package declares.
+
+flox-mcp shipped `mcp>=1.0` while CI installed `mcp>=1.0,<2`. CI was therefore
+green against 1.x forever, and the day the SDK released 2.0 -- which dropped the
+decorator API the server is built on -- every fresh `pip install flox-mcp`
+started crashing on startup. Nothing in the repo could notice: the tested range
+and the shipped range were simply different strings in different files.
+
+This gate reads the ranges out of the packaging manifests and out of the CI
+workflow and requires them to agree, so a bound can only be relaxed in both
+places at once.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+# Packages worth guarding: third-party runtime deps whose major version can
+# break us. Extend as new ones appear.
+GUARDED = {"mcp"}
+
+
+def _norm(spec: str) -> str:
+    """Compare specifiers without whitespace or quoting noise."""
+    return re.sub(r"[\s\"']", "", spec)
+
+
+def _declared() -> dict[str, tuple[str, Path]]:
+    out: dict[str, tuple[str, Path]] = {}
+    for manifest in ROOT.rglob("pyproject.toml"):
+        if any(part in {"external", "build", "node_modules", ".venv"} for part in manifest.parts):
+            continue
+        data = tomllib.loads(manifest.read_text())
+        project = data.get("project", {})
+        specs = list(project.get("dependencies", []) or [])
+        # Extras count too: flox-py declares `mcp` under optional-dependencies,
+        # and an unbounded range there breaks `pip install flox-py[mcp]` just
+        # as thoroughly as one in the main list.
+        for extra in (project.get("optional-dependencies", {}) or {}).values():
+            specs.extend(extra or [])
+        for dep in specs:
+            name = re.split(r"[<>=!~\[ ]", dep, maxsplit=1)[0].strip().lower()
+            if name in GUARDED:
+                key = f"{name} ({manifest.parent.name})" if name in out else name
+                out[key] = (_norm(dep), manifest.relative_to(ROOT))
+    return out
+
+
+def _installed_by_ci() -> dict[str, tuple[str, int]]:
+    out: dict[str, tuple[str, int]] = {}
+    if not CI.exists():
+        return out
+    for lineno, line in enumerate(CI.read_text().splitlines(), 1):
+        if "pip install" not in line:
+            continue
+        for spec in re.findall(r"[\"']([A-Za-z0-9_.-]+(?:[<>=!~][^\"']*)?)[\"']", line):
+            name = re.split(r"[<>=!~\[ ]", spec, maxsplit=1)[0].strip().lower()
+            if name in GUARDED:
+                out[name] = (_norm(spec), lineno)
+    return out
+
+
+def main() -> int:
+    declared = _declared()
+    ci = _installed_by_ci()
+    problems: list[str] = []
+
+    for key in sorted(declared):
+        name = key.split(" ")[0]
+        spec, manifest = declared[key]
+        if name not in ci:
+            problems.append(
+                f"{name}: declared as {spec} in {manifest}, but CI never installs it explicitly -- "
+                f"the tested version is whatever a transitive resolve picks")
+            continue
+        ci_spec, lineno = ci[name]
+        if spec != ci_spec:
+            problems.append(
+                f"{name}: {manifest} declares {spec}, CI installs {ci_spec} "
+                f"(.github/workflows/ci.yml:{lineno}). CI is testing a range users do not get.")
+
+    if problems:
+        print("dependency ranges disagree between the package and CI:")
+        for p in problems:
+            print(f"  {p}")
+        print("\nMake both sides identical, then re-run.")
+        return 1
+
+    print(f"OK: {len(declared)} guarded dependency range(s) match between manifests and CI.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`flox-mcp` 0.7.1 does not start on a fresh install — this is the failure the glama build reports:

```
File "flox_mcp/server.py", line 40, in build_server
    @server.list_tools()
AttributeError: 'Server' object has no attribute 'list_tools'
```

## Cause

The package declared `mcp>=1.0` with no upper bound. The SDK released **2.0.0 on 2026-07-28**, so a fresh resolve now installs 2.x, which dropped the `@server.list_tools()` / `@server.call_tool()` decorators this server is built on. Nothing in flox changed; the dependency's major version did.

| SDK | `Server.list_tools` |
|---|---|
| 1.29.0 | present |
| 2.0.0 | gone |

## Migrate, not pin backwards

The SDK surface we touch is small: two registration points. Both decorators become `add_request_handler(method, params_type, handler)`, handlers take `(ctx, params)` and return `ListToolsResult` / `CallToolResult` — the same shape the 2.x SDK uses for its own built-in handlers. `Server.run()`, `create_initialization_options()` and the stdio transport are unchanged, so the serve path is untouched.

Ranges become `mcp>=2.0,<3` in `mcp/pyproject.toml`, in flox-py's `mcp` extra, and in CI.

Verified the way a user hits it: clean venv on Python 3.12 (the glama container's version), `pip install ./mcp` resolves `mcp` to 2.0.0, the server builds, `tools/list` returns all 38 tools, `tools/call` answers, and the `flox-mcp` console script no longer raises. Test suite: 215 passed, 16 skipped.

## The process defect

The SDK bump is not really the bug. CI installed `mcp>=1.0,<2` while the package shipped `mcp>=1.0` — two different strings in two files — so CI stayed green on 1.x forever while users got 2.0. No test could have caught it.

`scripts/check_dep_pins.py` now fails when a guarded dependency's range differs between the packaging manifests and the CI install line, and runs as a step in `verify-docs-current`. It reads extras too, since flox-py declares `mcp` under `optional-dependencies` and an unbounded range there breaks `pip install flox-py[mcp]` just as thoroughly. Verified by mutation against both manifests.

## Note on already-published versions

This fixes installs from 0.7.2 onward. `flox-mcp` 0.7.1 and 0.7.0 stay broken on PyPI for anyone pinning them explicitly, since their metadata still says `mcp>=1.0`. Yanking them is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
