### PR TITLE
feat(venue): production perimeter -- recovery, delivery, sessions, last look, market data

### DIFF
--- a/docs/venue/market-data.md
+++ b/docs/venue/market-data.md
@@ -28,16 +28,131 @@ md.book();   // flox::NLevelOrderBook kept in step with the venue book
 | `Replace` | an order was repriced/resized | displayed remaining |
 | `Triggered` | a stop fired | — |
 
-Every message carries a monotonically increasing `seq`, so a consumer can
-detect a gap and request a resend.
+Every message carries `(symbol, epoch, seq)`: `seq` is contiguous from 1
+within one publisher lifetime, `epoch` is a random value minted when the
+publisher is constructed. One publisher serves one symbol; several publishers
+may share a multicast group, and the symbol in every root block is what a
+consumer demultiplexes on before any gap accounting.
 
-## Depth is the aggregate, kept in step
+## Sequencing, restarts and epochs
 
-The publisher maintains a `flox::NLevelOrderBook`, the same aggregate book
-type strategies consume elsewhere in FLOX, so market-data depth and the
-venue's internal order-level book stay in agreement. A test drives 300k
-commands and periodically compares the publisher's full depth against the
-engine's book.
+Sequence numbers are deliberately not persisted across restarts. The book is
+rebuildable from matching state, so a restarted publisher mints a new epoch
+and starts over at `seq=1` instead of carrying seq durability it does not
+need. A consumer that sees the epoch change knows every prior seq is void and
+re-snapshots; without the epoch, a restarted feed would look like an endless
+stream of duplicates to a surviving consumer (a live but empty feed).
+
+## Gap detection (client side)
+
+`GapDetector` (`resend_buffer.h`) is the client-side sequencer. Fed the raw
+(possibly reordered, duplicated, gapped) datagram stream, it delivers messages
+strictly in seq order per `(symbol, epoch)`:
+
+- A message ahead of the next expected seq is held, not delivered; when the
+  missing seq arrives — a late, reordered datagram, not a duplicate — the
+  contiguous run drains in order. If held messages exceed `maxHeld`, the gap
+  is abandoned and the held run is delivered in seq order rather than lost.
+- `onGap(symbol, epoch, fromSeq)` fires when a gap opens and re-fires every
+  `reraiseAfter` further messages while it stays unfilled, so a lost resend
+  request does not strand the consumer.
+- An epoch change drops held state, resets the stream to seq 1 and fires
+  `onEpoch` so the consumer can re-snapshot.
+- `reset()` fast-forwards a stream after a snapshot was applied.
+
+`UdpMdSubscriber::setGapDetector` wires this into `recv()`: with a detector
+attached, `recv()` only surfaces in-order messages; without one it is the raw
+decode path, unchanged.
+
+## Snapshot and recovery (TCP)
+
+`MarketDataPublisher::snapshotAtomic()` returns a consistent
+`(orders, lastSeq, epoch)` triple — taken under the same lock as the live
+emit path, so no increment with `seq <= lastSeq` is missing from the snapshot
+and none with `seq > lastSeq` is included. The publisher also keeps a bounded
+ring of recent increments (`resendCapacity`, default 1024) for tail replay.
+
+`MdRecoveryServer` (`md_recovery.h`) serves both over TCP with
+length-prefixed frames, one request per connection:
+
+- client sends `ResendRequest{symbol, fromSeq}` (`fromSeq=0` = late joiner);
+- if `fromSeq` is inside the ring, the server replays the increments with
+  `seq >= fromSeq` and closes (EOF terminates the replay);
+- otherwise it answers `SnapshotRequired` followed by `SnapshotBegin` +
+  `AddOrder` body messages (`seq=0`, epoch set) + `SnapshotEnd{lastSeq}`; the
+  consumer applies the body and resumes the incremental feed at `lastSeq+1`.
+
+`MdRecoveryClient` (same header) is the consumer-side counterpart: one
+`recover(symbol, fromSeq, out)` call opens the connection, sends the request
+and returns the classified reply — `snapshot` flag, the replayed increments or
+the snapshot body, and the `lastSeq`/`epoch` resume point (feed
+`resetSequencer(symbol, epoch, lastSeq + 1)` to the `GapDetector` and continue
+the incremental feed). The socket carries a receive timeout; an unreachable
+server is a `ConnectError` status, a stalled reply a `Timeout`, and a
+truncated snapshot a `ProtocolError` — never an exception. The low-level
+protocol cases in `test_venue_md_recovery` drive it directly (they are the
+protocol's documentation); the late-joiner and publisher-restart cases run
+through `RecoveringMdSubscriber` below.
+
+`MdCounters` tracks the paths: `resendServed`, `snapshotsServed`, and
+`sendDrops` (below).
+
+### Exposing the recovery channel
+
+`MdRecoveryServer::start(port, bindIp)` binds loopback by default
+(`bindIp = nullptr`, the historical behaviour). Passing an explicit address
+(`"0.0.0.0"`, a NIC address) exposes the channel to other hosts, and an
+unparseable address fails the start rather than silently falling back to
+loopback.
+
+The hardening contract is the same as for the order-entry gateways: the
+recovery protocol carries **no authentication and no encryption** of its own,
+so anything reachable off-host must sit behind TLS termination and/or a
+firewall / private network, exactly like the control plane. Binding
+externally is a deployment decision, not a default.
+
+## Automatic client recovery (`RecoveringMdSubscriber`)
+
+`GapDetector` reports; `MdRecoveryClient` fetches; `RecoveringMdSubscriber`
+(`md_recovery.h`) is the two composed into the whole consumer protocol, so a
+subscriber implements neither. It wraps a `UdpMdSubscriber` (which must NOT
+have its own detector attached — this class owns sequencing) and keeps a
+`recv()`-style API: only in-order messages surface, recovery is invisible
+except through the `onSnapshot` callback and the counters.
+
+```cpp
+UdpMdSubscriber sub;
+sub.join(group, port, /*multicast*/ true);
+
+RecoveringMdSubscriber::Config cfg{host, recoveryPort, /*maxGapBeforeSnapshot*/ 256};
+RecoveringMdSubscriber rsub(sub, cfg);
+rsub.onSnapshot([&](SymbolId sym, const MdSnapshotBegin& b, const std::vector<MdMessage>& orders)
+                { book.clear(); for (const auto& m : orders) book.apply(m); });
+
+MdMessage m;
+while (rsub.recv(m)) book.apply(m);   // strictly in seq order, holes already recovered
+```
+
+- **Gap** → `ResendRequest{fromSeq}`; the replayed increments are woven back
+  through the detector, so they fill the hole in seq order and drain whatever
+  was held behind it.
+- **Epoch change** (publisher restart) or a gap deeper than
+  `maxGapBeforeSnapshot` → snapshot recovery (`fromSeq = 0`): the body goes to
+  `onSnapshot`, the sequencer fast-forwards to `lastSeq + 1` and the
+  incremental feed continues. A deep gap takes this path because the server
+  would route it there anyway once the ring has trimmed.
+- **Failure** → bounded retries with doubling backoff (`maxAttempts`,
+  `initialBackoff`), never an eternal loop. On exhaustion the incident is
+  counted in `recoveriesFailed()` and the stream falls back to plain gap
+  semantics — the detector re-raises on further traffic and recovery re-arms
+  (a test drives exactly that: server down → bounded failure → clean `recv()`
+  timeout → server back → the re-raised gap recovers through the ring).
+- Counters: `gapsDetected`, `epochChanges`, `resendsRecovered`,
+  `snapshotsRecovered`, `recoveriesFailed`.
+
+Single-threaded like the subscriber itself: all recovery work happens inside
+`recv()` on the calling thread (the backoff sleeps block the caller, as any
+synchronous recovery would).
 
 ## Icebergs and the public feed
 
@@ -55,21 +170,39 @@ The publisher drives depth from `displayLeaves`. Using the whole remaining
 would leak the reserve and, on a partial peak fill, corrupt the level
 aggregate.
 
+## Depth is the aggregate, kept in step
+
+The publisher maintains a `flox::NLevelOrderBook`, the same aggregate book
+type strategies consume elsewhere in FLOX, so market-data depth and the
+venue's internal order-level book stay in agreement. A test drives 300k
+commands and periodically compares the publisher's full depth against the
+engine's book.
+
 ## SBE codec and multicast
 
 `sbe_md_codec.h` encodes `MdMessage` in SBE (Simple Binary Encoding): a
 canonical SBE message header (`blockLength`, `templateId`, `schemaId`,
 `version`) followed by a per-type little-endian root block. One template per
-`MdType`, each carrying only the fields that type needs. The schema in
-`venue/schema/md-sbe.xml` is the source of truth; the codec is hand-written
-against it (no Java codegen in the build). This is the venue's own SBE schema,
-not Nasdaq ITCH.
+`MdType`, each carrying only the fields that type needs, plus the recovery
+templates (`ResendRequest`, `SnapshotBegin`, `SnapshotEnd`,
+`SnapshotRequired`). Schema version 1 appended a trailing `epoch` (u64) to
+every incremental template — the SBE-sanctioned extension path: a version-0
+reader skips it via the header's `blockLength`, and the decoder accepts v0
+frames (epoch reads as 0). The schema in `venue/schema/md-sbe.xml` is the
+source of truth; the codec is hand-written against it (no Java codegen in the
+build). This is the venue's own SBE schema, not Nasdaq ITCH.
 
 `UdpMdPublisher` (`udp_multicast.h`) publishes frames over IP multicast, with
 `UdpMdSubscriber` on the receiving end. Both take an optional interface selector
 (`ifaceIp`): the default (`nullptr`) lets the kernel routing table pick the
 egress NIC -- the production default so the feed reaches co-located clients on
 other hosts; pass `"127.0.0.1"` to pin loopback for same-host use.
+
+The publisher socket is non-blocking and `publish()` checks the `sendto`
+result: a datagram that cannot be handed to the kernel (full socket buffer,
+closed fd) is a counted drop (`MdCounters::sendDrops`), never a stall of the
+matching thread and never a silent loss the venue cannot see. Consumers
+recover the hole through gap detection and the recovery channel.
 
 ```cpp
 std::vector<uint8_t> buf;
@@ -86,6 +219,8 @@ hostile input alongside the FIX / SBE order-entry / REST parsers.
 
 ## Tape
 
-`tape_recorder.h` writes the outbound stream through `BinaryLogWriter`, so a
-venue session records into the same binary format the rest of FLOX reads. The
-tape a venue produces can be replayed by ordinary FLOX tooling.
+`tape_recorder.h` records trade prints only: it filters `Trade` events out of
+the outbound stream and persists them through `BinaryLogWriter`, the same
+binary format the rest of FLOX reads. The trade tape a venue produces can be
+replayed by ordinary FLOX tooling; the non-trade events (adds, cancels,
+replaces) are not on the tape.

--- a/docs/venue/matching.md
+++ b/docs/venue/matching.md
@@ -32,12 +32,28 @@ LadderBook book(LadderBook::Config{
 - **Price-time (FIFO)**, the default. Best price first; within a price, oldest
   order first.
 - **Pro-rata.** Allocation at a level is proportional to resting size, with the
-  usual leftover pass.
+  usual leftover pass. Last-look orders are refused at admission on pro-rata
+  instruments (`LastLookUnsupported`): a held slice cannot be carved out of a
+  proportional round, and silently filling the maker as firm -- the old
+  behaviour -- misrepresented the quote. **Defensive second line**: a resting
+  `lastLook` maker met by a pro-rata allocation (reachable only if a caller
+  bypassed `validate()`) is **skipped, never filled as firm** -- it is
+  excluded from the level total and from the allocation, the remaining firm
+  participants split the aggressor exactly as they otherwise would, and
+  `Matcher::skippedLastLookProRata()` (surfaced as
+  `MatchingEngine::skippedLastLookProRata()`) counts the event. A level whose
+  firm size is zero stops the sweep, so the aggressor residual follows its
+  TIF instead of a fabricated fill.
 
 ```cpp
 Matcher<MatchingBook> m(MatchPolicy::ProRata);
 m.setStpGroup(/*account*/ 10, /*firm*/ 1);   // firm-scope self-trade prevention
 ```
+
+Firm-group STP membership is engine state, not startup wiring: runtime
+changes arrive as the sequenced `SetStpGroup` command (control-plane
+`setStpGroup` verb), so they journal, ride checkpoints and replay with the
+rest of matching. `group = 0` removes a membership.
 
 ### Self-trade prevention
 
@@ -90,8 +106,8 @@ venue.submit(InboundCommand{order}, tsNs);
 
 Every state-mutating input is an `InboundCommand`: `NewOrder`, `CancelOrder`,
 `ModifyOrder`, `MassCancel`, `Quote`, `LastLookDecision`, `SetMark`,
-`ApplyFunding`, `AdminCmd`. That is what makes deterministic replay possible;
-see [Runtime and recovery](runtime.md).
+`ApplyFunding`, `AdminCmd`, `TimeTick` (idle time sweep). That is what makes
+deterministic replay possible; see [Runtime and recovery](runtime.md).
 
 ### Pre-trade risk
 
@@ -121,12 +137,90 @@ Before the first trade there is no reference price, so no band exists yet.
 ### Market-maker features
 
 - **Last look.** `lastLookWindowNs`: the maker holds a fill and answers with
-  `LastLookDecision`. On reject or timeout the held quantity does not trade,
-  and both sides' reservations are returned.
+  `LastLookDecision`. See the full lifecycle below.
 - **MMP.** `setMmp(account, qtyLimit, windowNs)`: if an account is filled
   faster than its limit inside the window, its book is pulled and
   `MmpTriggered` fires.
 - **Mass quote.** `Quote` replaces both sides of a two-sided quote atomically.
+
+### Last-look lifecycle
+
+`lastLookWindowNs > 0` enables last look venue-wide; `0` disables it entirely
+(the matcher hook is never installed, so a `lastLook`-flagged order fills like
+any other maker). When an aggressor hits a resting `lastLook` maker, the hit
+size is reserved OUT of the book, `FillHeld` is emitted (with `heldId` and the
+maker's `makerDisplayAfter` for the public feed), and the maker has the window
+to answer with `LastLookDecision{heldId, accept}`.
+
+- **Ownership.** Only the maker account that owns the held quote may decide;
+  any other account gets `OrderRejected{NotOrderOwner}` and the hold stands.
+- **Accept** prints the trade at the held price/size and settles normally.
+- **Reject / timeout** (`lastLookAcceptOnTimeout=false`) destroys no
+  liquidity:
+  - The maker's held quantity returns to its price level **at the tail**
+    (as-if the maker re-entered; time priority is lost). If the maker order was
+    canceled between hold and reject there is nothing to restore -- but the
+    cancel paths below resolve holds *first*, so that case cannot arise: a
+    missing maker here means it was fully held out of the book, and it is
+    rebuilt.
+  - The taker's held quantity returns and follows the order's TIF: GTC/GTD
+    rest at the taker's limit (tail; combined with any already-resting
+    remainder via `OrderModified`), IOC/FOK/MARKET residuals are canceled with
+    the matching residual reason. The restored taker rests **passively** -- it
+    does not re-aggress, so the book may be transiently crossed against the
+    rejecting maker until new flow arrives.
+  - `FillRejected{heldId, takerId, makerId, price, qty}` reports what did not
+    happen.
+- **Timeout on a quiet symbol.** Hold expiry runs on every submit AND on
+  `tick(nowNs)` (idempotent sweep). Under `SequencedShard`, pass
+  `idleSweepIntervalNs > 0` to arm the idle sweeper: while holds are open it
+  injects a `TimeTick` command through the sequenced stream (journaled, so
+  replay reproduces the timeout at the same point).
+- **Cancel-while-held.** Every path that removes or reshapes an order --
+  `CancelOrder`, `ModifyOrder`, `Quote` replace, GTD expiry, OCO, peg reprice,
+  `MassCancel`/MMP/liquidation (account scope), `HaltAndCancelAll` (all) --
+  deterministically resolves (rejects) the affected holds FIRST. An accept
+  after the cancel is impossible (`UnknownOrder`), and reservations release
+  exactly once: the held slice stays reserved until its hold resolves, then
+  either settles (accept) or is released/re-rests (reject).
+- **FOK vs last look.** Last-look liquidity is non-firm: it never counts
+  toward the FOK all-or-none precheck, and a FOK whose crossing range contains
+  ANY last-look maker is rejected `FillOrKillUnfulfillable` outright -- the
+  sweep is strict price-time, so a last-look maker inside the range could be
+  hit before the FOK completes, and a partial execution followed by a hold
+  would violate all-or-none. A last-look maker priced outside the crossing
+  range does not affect the FOK.
+- **Public feed.** `MarketDataPublisher` shrinks the maker's level on
+  `FillHeld` (by `makerDisplayAfter`) and follows the restore events
+  (`OrderModified`/`OrderAccepted`) on reject -- after any sequence of
+  hold/accept/reject the published depth equals the matching book.
+- **Wire.** SBE templates 17 (`FillHeld`) / 18 (`FillRejected`) in
+  `order-entry-sbe.xml`; REST/JSON `{"type":"fillHeld"|"fillRejected", ...}`.
+  FIX has no honest ExecType for a pending held fill, so `FillHeld` uses the
+  documented custom value `150=U` and `FillRejected` uses `150=H` (Trade
+  Cancel), both with custom tags `20001=heldId`, `20002=makerId`.
+- Pro-rata instruments do not honour last look (documented matcher scope
+  limitation), and admission refuses the combination. If one appears anyway
+  (admission bypassed), the pro-rata allocation SKIPS that maker rather than
+  filling it as firm, bumping `skippedLastLookProRata()` -- see the pro-rata
+  policy above.
+
+### Client order id dedup
+
+`clientOrderId` (FIX tag 11, SBE/REST `clientOrderId`) is deduplicated **per
+account** at the engine: a `NewOrder` whose `clientOrderId` was already seen by
+that account rejects with `DuplicateClientOrderId` and leaves the book
+untouched -- whether the original is still resting, filled, or canceled. That
+is what makes a client resend after an ambiguous disconnect safe.
+`clientOrderId == 0` means "not set" and is never deduplicated. The dedup
+window is the engine session (uptime): the index is rebuilt by the same
+submits during journal replay, so post-restart behaviour is identical to live;
+rotating/compacting the index is a future checkpoint concern.
+
+Internal `OrderId`s (`NewOrder.id`) are a separate namespace: the engine
+requires them to be **globally unique across accounts** (duplicates reject only
+while the earlier order is alive). Generating unique ids is the
+gateway's/client's responsibility -- that is the honest boundary.
 
 ### Auctions and halts
 

--- a/docs/venue/perimeter.md
+++ b/docs/venue/perimeter.md
@@ -37,6 +37,179 @@ connection and the process keeps running.
 - **Cancel-on-disconnect** optionally pulls the session's resting orders when
   the connection drops.
 
+## Exec-report delivery (SessionRegistry)
+
+The per-frame `Responder` answers only the connection whose frame is being
+handled; an asynchronous event -- a maker fill from a foreign aggressor, a
+stop trigger, a GTD expiry, a liquidation cancel, a `FillHeld` -- has no
+request context. `SessionRegistry` (`session_registry.h`) is the account ->
+session router that closes that hole:
+
+```
+engine sink -> registry.route(event) -> AccountStream (per account)
+  -> seq stamp + event log + encode -> SessionWriter (per connection)
+    -> bounded queue -> writer thread -> socket
+```
+
+- Every outbound event carries its owner account (appended fields on the
+  event structs, folded into the determinism hash). `Trade`, `FillHeld` and
+  `FillRejected` route to both parties; account `0` is unrouteable.
+- The **matching thread never blocks on a client socket**: `route()` encodes
+  and enqueues under the account-stream mutex; the write happens on the
+  session's writer thread. A full queue is a slow consumer -- the connection
+  is shut down, `GatewayCounters::slowConsumerDisconnects` is bumped, and the
+  client recovers the gap via `ResendRequest` after reconnecting.
+- Gateways enter this mode via `setDelivery(&registry, encoder)`; the
+  connection loop attaches the bound account on connect and detaches on
+  disconnect. Without a registry a gateway stays in the embedded per-frame
+  responder mode.
+- **Rejects are not silent**: a frame that fails decode / admission answers
+  with a sequenced `OrderRejected` (id 0, reason `MalformedMessage` /
+  `RateLimited` / `Unauthenticated`) on the session's own stream.
+- `TlsGateway` supports delivery mode too. OpenSSL forbids CONCURRENT
+  `SSL_read`/`SSL_write` on one `SSL*`, not serialized use: each connection
+  carries a mutex over its `SSL*`, the read loop takes it only for the
+  duration of a single `SSL_read` poll (a short `SO_RCVTIMEO` makes the call
+  return periodically), and the writer thread takes it per frame written --
+  the two interleave, never overlap. On teardown the writer is detached and
+  joined before `SSL_free`.
+
+## Sequencing and session-layer recovery
+
+Every exec report delivered through the registry carries a per-session
+monotonic `seq`:
+
+- **SBE** -- schema version 1 appends a trailing `seq` (u64, `sinceVersion=1`)
+  to every outbound template's root block. A version-0 reader skips it via the
+  header's `blockLength`; no wrapper template, no re-layout
+  (`venue/schema/order-entry-sbe.xml`, `SbeOrderEntryCodec::seqOf`).
+- **The resend log stores events, not frames.** The `AccountStream` retains
+  `(seq, OutboundEvent, first-send timestamp)`; frames are (re)encoded per
+  the session's protocol at send and at resend time. SBE encoding is
+  deterministic, so an SBE resend is byte-identical to the original
+  transmission; FIX *requires* re-encoding on resend (PossDupFlag `43=Y` and
+  OrigSendingTime `122` change BodyLength and CheckSum, so a byte replay was
+  never viable there).
+- **Recovery verbs (SBE, session layer -- never matched or journaled):**
+  `ResendRequest{fromSeq}` replays the retained events with their original
+  seqs from the account's resend log (which survives disconnects: an event
+  that fires while the account is offline is still sequenced and logged). A
+  `fromSeq` older than the retained log answers `SnapshotRequired{lastSeq}`
+  -- an explicit signal, never a silent hole. `AccountSnapshotRequest`
+  replies with the account's open orders (a series of `Accepted` frames,
+  `restingOnBook=0` for pending stops) terminated by
+  `SnapshotEnd{position, lastSeq}`, built from
+  `MatchingEngine::snapshotAccount`. Snapshot frames are unsequenced (seq 0)
+  and deliberately NOT in the resend log -- a resend replays what was
+  originally sequenced; a point-in-time snapshot replayed there would be
+  stale. `SnapshotEnd.lastSeq` (schema v2, trailing field) carries the
+  stream's last assigned outbound seq, so the client resumes gap detection
+  from the exact point. Wired via
+  `setSessionVerbs(makeSbeSessionVerbs(engine))`.
+- **Session config on the wire (SBE `SetSessionConfig{codEnabled}`)**:
+  per-session cancel-on-disconnect negotiation, handled at the gateway via
+  `setSessionConfigVerb(makeSbeSessionConfigVerb())`. Fire-and-forget by
+  design: the update takes effect immediately and has no reply frame -- its
+  effect is observable (a later disconnect sweeps or keeps the session's
+  orders). The FIX equivalent is Logon tag 20003 (below).
+- **FIX** -- a full session layer (`fix_session.h`: `FixSessionHost` +
+  `FixConnection`, wired via `setFixSession` on `TcpGateway`, `TlsGateway`
+  and `WsGateway`; requires delivery mode). The `FixConnection` is
+  transport-independent; the wire shape per transport:
+  - **TCP / TLS**: one FIX message per length-prefixed frame (TLS inside the
+    encrypted stream, using the existing per-connection `sslMu` writer path
+    and poll-before-lock read loop; the FIX timers run on the read loop's
+    poll tick).
+  - **WebSocket**: one FIX message per WebSocket data frame. The venue sends
+    Text frames (FIX tag=value is ASCII; Text keeps the messages readable in
+    WS tooling) and accepts inbound FIX in Text or Binary frames alike.
+    FIX liveness (Heartbeat/TestRequest death) replaces the WS Ping probe on
+    these connections.
+  - **Logon (35=A)**: HeartBtInt (108) adoption; ResetSeqNumFlag (141=Y)
+    resets both sequence directions to 1 and clears the outbound stream.
+    Without 141, the client's `34` is checked against the expected inbound
+    seq: above -> the venue's own `ResendRequest (35=2)` after the Logon
+    reply; below -> Logout (35=5) with the reason in `58`, disconnect.
+  - **Custom tag 20003 (CancelOnDisconnect=Y/N) on the Logon**: wire
+    negotiation of the session's cancel-on-disconnect, overriding the
+    gateway default in either direction (sits next to the custom last-look
+    tags 20001 heldId / 20002 makerId). Applied on any accepted Logon,
+    before order flow exists.
+  - **Restart**: the sequence counters (per-account inbound `expectedIn` +
+    outbound `lastSeq`) can be persisted across a venue restart via the FIX
+    session sidecar (`FixSessionSidecar`, file `<journal base>.fixsessions`):
+    the gateway harness hooks `SequencedShard::onCheckpoint` and writes the
+    sidecar at every checkpoint boundary with the journal's durability
+    discipline (tmp -> fsync -> atomic rename, trailing CRC32; a torn or
+    corrupt sidecar loads as absent). With a restored sidecar, a Logon
+    without 141=Y that continues the pre-restart sequence space WORKS. The
+    EVENT LOG is deliberately not persisted: a ResendRequest that reaches
+    into the pre-restart range is answered with `SequenceReset-GapFill` --
+    the honest signal for history the venue no longer holds; full state
+    reconciliation is the snapshot path. Without a sidecar the old rule
+    stands: the first Logon after a restart MUST carry 141=Y or it is
+    answered with `Logout "session state lost (venue restart): Logon must
+    set ResetSeqNumFlag (141=Y)"`.
+  - **Liveness**: outbound Heartbeat every HeartBtInt on the gateway's
+    `SO_RCVTIMEO` tick; no inbound traffic for 1.2 intervals -> TestRequest
+    (35=1); no answer for another 1.2 intervals -> disconnect, and COD sweeps
+    normally. An inbound TestRequest is answered with a Heartbeat echoing
+    `112`.
+  - **Their ResendRequest (35=2, `7`..`16`, 16=0 = infinity)**: application
+    messages replay from the event log re-encoded with `43=Y` +
+    `122=OrigSendingTime` (the logged first-send time) and their ORIGINAL
+    `34`; admin seq ranges (Heartbeats, Logon replies -- sequenced but not
+    logged) collapse into `SequenceReset-GapFill (35=4, 123=Y)`. A range
+    older than the retained log is gap-filled up to the first available seq
+    -- the client sees the trimmed part as an explicit gap-filled hole; full
+    state reconciliation is the SBE `AccountSnapshotRequest` path. A served
+    FIX resend bumps `GatewayCounters::resendServed`, same as the SBE path.
+  - **Our inbound gap**: no reorder buffer -- the venue sends `35=2` and
+    DROPS every message above the hole (repeating the request at most once
+    per HeartBtInt) until the counterparty's PossDup replay closes it. This
+    is deliberate: buffering out-of-order application traffic would run
+    orders outside admission order, and the peer must resend anyway. A
+    PossDup whose `34` was already seen is silently dropped; an inbound
+    `SequenceReset-GapFill` advances the expectation; a Reset-mode
+    `SequenceReset` (no 123=Y) is accepted with a WARN log.
+  - **Unknown MsgType**: an in-sequence message whose `35` is outside the
+    known set (admin 0/1/2/4/5/A, application D/F/G) is answered with a
+    session `Reject (35=3)` carrying `45=RefSeqNum`, `372=RefMsgType` and a
+    `58` text -- never silently consumed, never a session kill. Application
+    messages keep their own path: a decode failure there answers with an
+    exec-report reject, not 35=3.
+  - **BalanceUpdate has no FIX mapping** (documented as unsupported): an
+    ExecutionReport is semantically an order-event report and carrying a
+    pure balance change in one would be dishonest; FIX sessions reconcile
+    balances out-of-band (the SBE/REST feeds carry `BalanceUpdate`). The
+    event is simply not encoded on FIX sessions (no seq is consumed).
+  - The sequencing/framing building block (`FixSession` in `fix_codec.h`)
+    stays for embedded/test use.
+
+The old `ResendBuffer` (an event-level log reachable from no wire path) was
+removed; the client-side `GapDetector` stays in `resend_buffer.h` for the
+market-data path.
+
+## Liveness and cancel-on-disconnect
+
+- **Idle timeout** (`setIdleTimeout`, default 30s): `SO_RCVTIMEO` on every
+  connection fd; a peer with no inbound bytes for the whole window is
+  disconnected (`GatewayCounters::idleDisconnects`), and COD then sweeps its
+  orders normally -- a half-open peer can no longer hold orders and a thread
+  forever. The WebSocket gateway pings at half the window first; any inbound
+  (Pong or data) before the deadline keeps the session alive.
+- **Shutdown**: `SocketAcceptor` tracks connection fds and owns their
+  lifecycle; `stop()` shuts every one of them down before joining, so a
+  silent client cannot hang `stop()`. Gateway handlers must not close the fd.
+- **`DisconnectCanceller` is bounded**: the per-session delivery observer
+  prunes an order on its terminal report (complete fill / cancel / reject),
+  so the disconnect flush cancels only what is actually still live.
+- **COD is per-session**: `GatewaySession::setCancelOnDisconnect` carries the
+  flag; the gateway-wide atomic is only the default seeded into new sessions.
+  Wire-level negotiation overrides the default in either direction: FIX Logon
+  tag 20003 (CancelOnDisconnect=Y/N) or the SBE `SetSessionConfig{codEnabled}`
+  verb (fire-and-forget, no reply frame).
+
 ## Wire protocols
 
 | Codec | Notes |
@@ -79,9 +252,14 @@ api.handle(R"({"method":"setBand","symbol":1,"minPrice":90,"maxPrice":110})");
 ```
 
 Actions that change matchable state (auction transitions, emergency
-cancel-all, halts) go through the sequenced `AdminCmd` path instead, so they
-are journalled and survive replay. Configuration knobs recover from the
-configuration store. See [Runtime and recovery](runtime.md).
+cancel-all, halts) go through the sequenced `AdminCmd` path, so they are
+journalled and survive replay. Configuration mutations are sequenced the same
+way: `ControlApi` applies a successful mutation to the registry and forwards
+the equivalent command (`ListInstrument`, `SetBands`, `SetTriggerRef`,
+`AdminCmd` halt/resume)
+to its command sink, which the deployment wires into the journaled stream --
+on restart, `InstrumentRegistry::apply` replays those records. There is no
+separate configuration store. See [Runtime and recovery](runtime.md).
 
 Deploy the control plane on an internal interface: it has no authentication of
 its own.

--- a/docs/venue/runtime.md
+++ b/docs/venue/runtime.md
@@ -35,7 +35,12 @@ and hot standby work, and the tests enforce it:
   cancels, quotes, last-look decisions, and also `SetMark`, `ApplyFunding`, and
   `AdminCmd` (auction transitions, halts, emergency cancel-all). A crash after
   an opening uncross must recover the same book, so the uncross has to be in
-  the stream.
+  the stream. The same holds for money and configuration: `Deposit` /
+  `Withdraw` (balance genesis; a withdraw exceeding `available` is rejected and
+  changes nothing) and `ListInstrument` / `SetBands` / `SetTriggerRef`
+  (instrument configuration) are commands too. Even time is a command: the shard's idle
+  sweeper injects `TimeTick` records so a last-look hold that expires on a
+  quiet symbol expires identically on replay.
 - **No order-sensitive decision reads an unordered container.** Anywhere output
   depends on processing order (ADL victim choice, liquidation order, peg
   repricing, expiry, mass cancel) the ids are collected and sorted first, so a
@@ -43,9 +48,13 @@ and hot standby work, and the tests enforce it:
 - **`event_hash.h`** folds the outbound stream into a rolling hash, so two runs
   can be compared in one comparison.
 
-Persistent instrument configuration (tick, lot, bands, risk limits) is
-recovered from the configuration store, so it stays out of the WAL and is not
-an `AdminCmd`.
+There is no separate configuration store: the journaled command stream is the
+source of truth for instrument configuration as well. Listing, band changes,
+trigger-reference switches and halts arrive as `ListInstrument` / `SetBands` /
+`SetTriggerRef` / `AdminCmd` records; `InstrumentRegistry::apply` rebuilds the
+registry from the same stream the engines replay. Structural knobs the control
+plane cannot express (assets, scales, margin parameters, fee schedule) are
+startup configuration supplied when a shard is constructed.
 
 ## Journal and replay
 
@@ -63,10 +72,123 @@ sequencer timestamp is stored, so `loadTimed` reproduces time-dependent
 behaviour (GTD expiry, last-look windows, MMP windows, LULD pauses) at the
 same points it happened live.
 
+A `SequencedShard` opens its journal in append mode and, on `start()`, replays
+whatever the file already holds into the engine before serving traffic
+(`recoveredCommands()` reports how much; gate ingress on `ready()`). Each
+accepted command is stamped by the shard's injectable clock (system time by
+default, strictly monotonic), and the SAME timestamp is journaled and fed to
+the engine -- so GTD expiry, last-look and MMP windows, and LULD pauses replay
+exactly. Replayed events are not re-published outbound; reconnecting clients
+reconcile via snapshots.
+
 Replaying from empty must reconstruct an identical ledger, book, positions,
-and reservations. `test_venue_engine` asserts the event-stream hash and the
-ledger match after a round trip; `test_venue_venue` covers the auction case,
-replaying a journal whose stream contains an `AdminCmd` uncross.
+and reservations -- including balances, which enter the stream as `Deposit`
+commands rather than out-of-band seeding. `test_venue_engine` asserts the
+event-stream hash and the ledger match after a round trip; `test_venue_venue`
+covers the auction case, replaying a journal whose stream contains an
+`AdminCmd` uncross; `test_venue_recovery` covers hard process death (fork +
+`_exit`), the append-mode restart, timed replay, and genesis replay from an
+empty ledger.
+
+## Checkpoint and journal rotation
+
+An unbounded WAL means unbounded restart time. A checkpoint bounds both: it
+serializes the engine into a **journal-format snapshot** -- the same
+`[ts][tag][len][body][crc]` framing, applied on load through the same engine
+paths live traffic uses. There is no second binary format and no second
+deserializer to drift; the torn-tail/CRC machinery guards snapshots for free.
+
+Snapshot contents, in canonical order (price levels best-first, FIFO within a
+level; everything else sorted by key -- the file is byte-for-byte
+deterministic):
+
+- `SnapshotBegin{formatVersion, lastAppliedTs, stateHash, configHash}`.
+  `configHash` digests the engine's CONSTRUCTOR configuration (fixed-point
+  scales, assets, tick/lot/minQty, last-look window, perp mode, match
+  policy); the loader compares it against the recovering engine and rejects
+  the snapshot with a clear log on mismatch -- restoring raw fixed-point
+  state into an engine built with different scales would silently
+  reinterpret every price and quantity;
+- instrument config as the **existing** records (`ListInstrument`, `SetBands`,
+  `SetTriggerRef`, `SetStpGroup` firm-group STP memberships, `AdminCmd`
+  halt/auction state);
+- balances as snapshot-only `RestoreBalance` records, one per account x asset
+  carrying the EXACT signed `(available, reserved)` split -- every live
+  moment is representable, including a negative wallet mid-liquidation.
+  `RestoreReservation` / `RestorePosition` then only rebuild the engine-side
+  reservation and position tables (the records still carry the exact live
+  amounts: partial fills, held slices and STP interactions make a formula
+  re-derivation unfaithful). Snapshots written by format v1 carried `Deposit`
+  totals instead; those records still apply (read compatibility) and
+  reconstitute `reserved` by re-reservation;
+- snapshot-only `Restore*` records: book orders (applied straight to the tail
+  of their level, no matching pass -- a crossing restore marks the file
+  corrupt), pending stops with their current triggers, peg specs, open
+  last-look holds, perp positions, MMP config, MMP sliding-window fills
+  (`RestoreMmpFills`, exact -- a maker one fill from its limit is still one
+  fill from it after recovery), and the clientOrderId dedup sets in
+  fixed-size batches;
+- `SnapshotEnd{stateHash, tradeSeq, heldSeq, ...}` -- sequence counters,
+  last/mark price, pending timed halt.
+
+`stateHash` is an event-hash-style FNV fold over the same canonical traversal
+(book, stops, holds, positions, balances available+reserved, MMP windows,
+STP groups, config, sequence counters). The loader re-verifies it at
+`SnapshotEnd`; a mismatch rejects the generation. Startup wiring
+(`setLedger`, `setFeeSchedule`, ladder config) is construction state, not
+snapshot state -- re-apply it before `start()`, exactly as for plain journal
+replay. STP groups are NOT startup wiring anymore: runtime mutations arrive
+as the sequenced `SetStpGroup` command, journal, snapshot and replay like any
+other matching-relevant state.
+
+Checkpoint protocol (`SequencedShard`, asynchronous, crash-safe at every
+step):
+
+1. At a command boundary on the consumer thread (natural quiescence), CLONE
+   the engine state (`cloneForSnapshot`: deep copy of every container, ledger
+   by value) and rotate the journal onto `<base>.journal.<ts>` (fsync the
+   directory). The pause is O(clone), not O(serialize+fsync); the
+   `onCheckpoint` hook (sidecars) also runs here, at the boundary. A
+   `fork()`-based copy-on-write snapshot was rejected deliberately: the
+   process is multi-threaded, and `fork()` clones only the calling thread
+   while a malloc-arena lock held elsewhere deadlocks the child on its first
+   allocation. A segment's numeric suffix names its base snapshot: the naming
+   convention plus per-record CRC IS the manifest -- no manifest file to tear.
+2. On a background thread, serialize the clone to `<base>.snapshot.<ts>.tmp`,
+   fsync, rename (atomic publish), then delete generations beyond the
+   retention window (`CheckpointConfig::retainGenerations`, default 2). The
+   pre-checkpoint single file `<base>` is the oldest generation and is read
+   as one during recovery until enough snapshot generations exist. At most
+   one publish is in flight: the next checkpoint waits for the previous one
+   (no snapshot queue). `checkpointNow()` still returns only once the new
+   generation is on disk.
+
+Crash window of the asynchronous publish: between the rotation and the
+background rename the disk holds "segment `ts` exists, snapshot `ts` absent
+(a torn `.tmp` at most)". Recovery tolerates exactly that: the `.tmp` never
+parses as a generation, the previous valid snapshot is chosen and BOTH tail
+segments replay after it, reproducing the state; the snapshot only ever
+appears atomically via rename (pinned by `test_venue_checkpoint`).
+
+Recovery scans the directory: the newest snapshot that validates end-to-end
+(structure + configHash + stateHash, applied into a scratch engine first so a
+corrupt file never pollutes the real one) plus every segment at or after it.
+An invalid snapshot falls back a generation with a WARN; with no valid
+snapshot at all, recovery replays the full retained history from scratch.
+
+Triggers: `SequencedShard::checkpointNow()` (surfaced as the control-plane
+`snapshotNow` verb -- deliberately NOT journaled, a snapshot must never be
+replay-visible), and an automatic record/byte threshold on the current
+segment checked by the idle sweeper (`CheckpointConfig`; automatic
+checkpoints therefore require the sweeper armed).
+
+The consumer pause is the clone alone (`lastCheckpointPauseNs()` gauges it);
+`test_venue_checkpoint` measures both the clone pause and the old synchronous
+serialize time on a 100k-order book rather than guessing (the clone is a
+small fraction of the serialize+fsync cost). Snapshot-only `Restore*` records
+arriving through live `submit` are dropped and counted
+(`droppedSnapshotRecords()`): a client must never be able to "restore" itself
+an order or a balance.
 
 ## Clock
 

--- a/include/flox/book/ladder_book.h
+++ b/include/flox/book/ladder_book.h
@@ -266,6 +266,31 @@ class LadderBook
     }
   }
 
+  // Enumerate every resting order in canonical book order: bids best-first,
+  // then asks best-first, FIFO within each level. Same seam as
+  // MatchingBook::forEachOrder -- the venue checkpoint serializer and state
+  // hash iterate through it (not a hot path).
+  template <class Fn>
+  void forEachOrder(Fn&& fn) const
+  {
+    for (int32_t l = bestBidLevel_; l >= 0; l = highestSetAtOrBelow(bidBits_, l - 1))
+    {
+      for (int32_t i = bidLevels_[static_cast<size_t>(l)].head; i >= 0;
+           i = nodes_[static_cast<size_t>(i)].next)
+      {
+        fn(nodes_[static_cast<size_t>(i)].order);
+      }
+    }
+    for (int32_t l = bestAskLevel_; l >= 0; l = lowestSetAtOrAbove(askBits_, l + 1))
+    {
+      for (int32_t i = askLevels_[static_cast<size_t>(l)].head; i >= 0;
+           i = nodes_[static_cast<size_t>(i)].next)
+      {
+        fn(nodes_[static_cast<size_t>(i)].order);
+      }
+    }
+  }
+
   std::optional<Price> bestBid() const noexcept
   {
     return bestBidLevel_ < 0 ? std::nullopt : std::optional<Price>{priceOf(bestBidLevel_)};
@@ -299,9 +324,10 @@ class LadderBook
     return total;
   }
 
-  // availableWithin, skipping makers for which skip(acct) is true. Iterates the
+  // availableWithin, skipping makers for which skip(order) is true. Iterates the
   // per-level node lists (not the aggregate totalQty) so an STP-aware FOK
-  // precheck can exclude same-scope liquidity. See MatchingBook::availableWithinExcl.
+  // precheck can exclude same-scope liquidity, and a last-look-aware one can
+  // exclude non-firm liquidity. See MatchingBook::availableWithinExcl.
   template <class Skip>
   Quantity availableWithinExcl(Side takerSide, Price limit, bool isMarket, Skip skip) const noexcept
   {
@@ -316,7 +342,7 @@ class LadderBook
              idx = nodes_[static_cast<size_t>(idx)].next)
         {
           const RestingOrder& o = nodes_[static_cast<size_t>(idx)].order;
-          if (!skip(o.accountId))
+          if (!skip(o))
           {
             total += o.leaves + o.hidden;
           }
@@ -333,7 +359,7 @@ class LadderBook
              idx = nodes_[static_cast<size_t>(idx)].next)
         {
           const RestingOrder& o = nodes_[static_cast<size_t>(idx)].order;
-          if (!skip(o.accountId))
+          if (!skip(o))
           {
             total += o.leaves + o.hidden;
           }

--- a/mcp/flox_mcp/data/binding_manifest.json
+++ b/mcp/flox_mcp/data/binding_manifest.json
@@ -16002,6 +16002,11 @@
         },
         {
           "kind": "method",
+          "name": "forEachOrder",
+          "parent": "Config"
+        },
+        {
+          "kind": "method",
           "name": "forEachRawTrade",
           "parent": "Config"
         },

--- a/venue/include/flox-venue/cancel_on_disconnect.h
+++ b/venue/include/flox-venue/cancel_on_disconnect.h
@@ -10,16 +10,29 @@
 
 #include "flox-venue/messages.h"
 
+#include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <utility>
+#include <mutex>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
 namespace flox::venue
 {
 
+// Tracks the session's live orders so a disconnect can pull them.
+//
+// Memory is bounded by pruning: untrack(id) drops an order once a terminal
+// exec report (complete fill / cancel / reject) is observed for it -- the
+// gateway wires this through the per-session delivery observer. Without
+// pruning this grew one entry per NewOrder forever and the disconnect flush
+// sent cancels for orders that had been gone for hours.
+//
+// Thread-safe: track/flush run on the connection reader thread, untrack is
+// called from the delivery (matching-side) path.
 class DisconnectCanceller
 {
  public:
@@ -28,39 +41,102 @@ class DisconnectCanceller
 
   explicit DisconnectCanceller(bool enabled) noexcept : enabled_(enabled) {}
 
+  // Wire-negotiated cancel-on-disconnect (FIX Logon tag 20003 / SBE
+  // SetSessionConfig): flips the live flag. Negotiation happens at logon /
+  // before order flow, so there is no tracked backlog to reconcile; orders
+  // placed while disabled are simply never tracked.
+  void setEnabled(bool on) noexcept { enabled_.store(on, std::memory_order_relaxed); }
+
   // Record a command placed on this session (only NewOrders are cancellable).
   void track(const InboundCommand& cmd)
   {
-    if (!enabled_)
+    if (!enabled())
     {
       return;
     }
     if (const auto* n = std::get_if<NewOrder>(&cmd))
     {
-      placed_.push_back(CancelOrder{n->id, n->symbol, n->accountId});
+      std::lock_guard<std::mutex> lk(m_);
+      placed_[n->id] = CancelOrder{n->id, n->symbol, n->accountId};
     }
   }
 
-  // On disconnect, cancel everything this session left resting.
-  void flush(const Handler& handler)
+  // Terminal exec report seen for `id`: no cancel needed on disconnect.
+  void untrack(OrderId id)
   {
-    if (!enabled_)
+    if (!enabled())
     {
       return;
     }
+    std::lock_guard<std::mutex> lk(m_);
+    placed_.erase(id);
+  }
+
+  // Observe a routed outbound event and prune terminally-resolved orders.
+  void observe(const OutboundEvent& e)
+  {
+    if (!enabled())
+    {
+      return;
+    }
+    if (const auto* x = std::get_if<OrderExecuted>(&e))
+    {
+      if (x->complete)
+      {
+        untrack(x->id);
+      }
+    }
+    else if (const auto* c = std::get_if<OrderCanceled>(&e))
+    {
+      untrack(c->id);
+    }
+    else if (const auto* r = std::get_if<OrderRejected>(&e))
+    {
+      untrack(r->id);
+    }
+  }
+
+  // On disconnect, cancel everything this session still has live.
+  void flush(const Handler& handler)
+  {
+    if (!enabled())
+    {
+      return;
+    }
+    std::unordered_map<OrderId, CancelOrder> live;
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      live.swap(placed_);
+    }
+    // Deterministic cancel order (id-sorted), independent of map layout.
+    std::vector<CancelOrder> ordered;
+    ordered.reserve(live.size());
+    for (const auto& [id, c] : live)
+    {
+      (void)id;
+      ordered.push_back(c);
+    }
+    std::sort(ordered.begin(), ordered.end(),
+              [](const CancelOrder& a, const CancelOrder& b)
+              { return a.id < b.id; });
     const Responder noop = [](const uint8_t*, size_t) {};
-    for (const auto& c : placed_)
+    for (const auto& c : ordered)
     {
       handler(InboundCommand{c}, noop);
     }
-    placed_.clear();
   }
 
-  bool enabled() const noexcept { return enabled_; }
+  bool enabled() const noexcept { return enabled_.load(std::memory_order_relaxed); }
+  size_t tracked() const
+  {
+    std::lock_guard<std::mutex> lk(m_);
+    return placed_.size();
+  }
 
  private:
-  bool enabled_;
-  std::vector<CancelOrder> placed_;
+  std::atomic<bool> enabled_;
+  mutable std::mutex m_;
+  std::unordered_map<OrderId, CancelOrder> placed_;
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/control_api.h
+++ b/venue/include/flox-venue/control_api.h
@@ -12,8 +12,10 @@
 
 #include <cctype>
 #include <cstdlib>
+#include <functional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace flox::venue
 {
@@ -21,7 +23,23 @@ namespace flox::venue
 class ControlApi
 {
  public:
-  explicit ControlApi(InstrumentRegistry& reg) : reg_(reg) {}
+  // Configuration mutations must survive a restart, so every successful
+  // mutation is also forwarded as an InboundCommand to `sink` -- the caller
+  // wires it into the sequenced/journaled path (and to the live engines). On
+  // replay, InstrumentRegistry::apply consumes the same records. A read-only
+  // deployment may omit the sink.
+  using CommandSink = std::function<void(const InboundCommand&)>;
+
+  explicit ControlApi(InstrumentRegistry& reg, CommandSink sink = {})
+      : reg_(reg), sink_(std::move(sink))
+  {
+  }
+
+  // SnapshotNow support: the hook triggers SequencedShard::checkpointNow for
+  // the symbol's shard. Deliberately NOT forwarded to the command sink -- a
+  // snapshot must never become a journaled, replay-visible record.
+  using SnapshotHook = std::function<bool(SymbolId)>;
+  void setSnapshotHook(SnapshotHook hook) { snapshotHook_ = std::move(hook); }
 
   std::string handle(const std::string& request)
   {
@@ -39,22 +57,73 @@ class ControlApi
       c.tickSize = priceOf(f, "tick");
       c.minPrice = priceOf(f, "minPrice");
       c.maxPrice = priceOf(f, "maxPrice");
-      return reg_.listInstrument(c) ? ok() : err("exists");
+      if (!reg_.listInstrument(c))
+      {
+        return err("exists");
+      }
+      forward(InboundCommand{ListInstrument{c.id, c.tickSize, c.lotSize, c.minPrice, c.maxPrice}});
+      return ok();
     }
     if (method == "halt")
     {
-      return reg_.halt(symOf(f, "symbol"), get(f, "halted") == "true") ? ok() : err("unknown_symbol");
+      const SymbolId sym = symOf(f, "symbol");
+      const bool halted = get(f, "halted") == "true";
+      if (!reg_.halt(sym, halted))
+      {
+        return err("unknown_symbol");
+      }
+      forward(InboundCommand{AdminCmd{sym, halted ? AdminAction::Halt : AdminAction::Resume}});
+      return ok();
     }
     if (method == "setBand")
     {
-      return reg_.setPriceBand(symOf(f, "symbol"), priceOf(f, "minPrice"), priceOf(f, "maxPrice"))
-                 ? ok()
-                 : err("unknown_symbol");
+      const SymbolId sym = symOf(f, "symbol");
+      const Price lo = priceOf(f, "minPrice");
+      const Price hi = priceOf(f, "maxPrice");
+      if (!reg_.setPriceBand(sym, lo, hi))
+      {
+        return err("unknown_symbol");
+      }
+      forward(InboundCommand{SetBands{sym, lo, hi}});
+      return ok();
     }
     if (method == "setTriggerRef")
     {
+      const SymbolId sym = symOf(f, "symbol");
       const TriggerRef ref = (get(f, "ref") == "mark") ? TriggerRef::Mark : TriggerRef::Last;
-      return reg_.setTriggerRef(symOf(f, "symbol"), ref) ? ok() : err("unknown_symbol");
+      if (!reg_.setTriggerRef(sym, ref))
+      {
+        return err("unknown_symbol");
+      }
+      forward(InboundCommand{SetTriggerRef{sym, ref}});
+      return ok();
+    }
+    if (method == "setStpGroup")
+    {
+      // Firm-group STP membership (group 0 removes it). Engine state, not
+      // registry state: the forwarded SetStpGroup rides the sequenced /
+      // journaled stream and is re-emitted by checkpoints, so it survives
+      // replay and recovery like every other matching-relevant mutation.
+      const SymbolId sym = symOf(f, "symbol");
+      if (!reg_.get(sym))
+      {
+        return err("unknown_symbol");
+      }
+      forward(InboundCommand{SetStpGroup{sym, u64Of(f, "account"), u64Of(f, "group")}});
+      return ok();
+    }
+    if (method == "snapshotNow")
+    {
+      const SymbolId sym = symOf(f, "symbol");
+      if (!reg_.get(sym))
+      {
+        return err("unknown_symbol");
+      }
+      if (!snapshotHook_)
+      {
+        return err("unsupported");
+      }
+      return snapshotHook_(sym) ? ok() : err("snapshot_failed");
     }
     if (method == "get")
     {
@@ -81,6 +150,14 @@ class ControlApi
   }
 
  private:
+  void forward(const InboundCommand& cmd)
+  {
+    if (sink_)
+    {
+      sink_(cmd);
+    }
+  }
+
   static std::string ok() { return "{\"ok\":true}"; }
   static std::string err(const char* e) { return std::string("{\"ok\":false,\"error\":\"") + e + "\"}"; }
 
@@ -102,6 +179,10 @@ class ControlApi
   static SymbolId symOf(const std::unordered_map<std::string, std::string>& f, const char* k)
   {
     return static_cast<SymbolId>(std::strtoul(get(f, k).c_str(), nullptr, 10));
+  }
+  static uint64_t u64Of(const std::unordered_map<std::string, std::string>& f, const char* k)
+  {
+    return std::strtoull(get(f, k).c_str(), nullptr, 10);
   }
   static Price priceOf(const std::unordered_map<std::string, std::string>& f, const char* k)
   {
@@ -191,6 +272,8 @@ class ControlApi
   }
 
   InstrumentRegistry& reg_;
+  CommandSink sink_;
+  SnapshotHook snapshotHook_;
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/control_plane.h
+++ b/venue/include/flox-venue/control_plane.h
@@ -73,6 +73,52 @@ class InstrumentRegistry
     return true;
   }
 
+  // Rebuild registry state from the journaled command stream. Listing, band
+  // changes, trigger-reference switches and halts are sequenced commands
+  // (forwarded by ControlApi), so a restart replays the same journal into the
+  // registry that the engines replay -- the WAL is the configuration source of
+  // truth, not an external store.
+  bool apply(const InboundCommand& cmd)
+  {
+    if (const auto* li = std::get_if<ListInstrument>(&cmd))
+    {
+      SymbolConfig c;
+      c.id = li->symbol;
+      c.tickSize = li->tickSize;
+      c.lotSize = li->lotSize;
+      c.minPrice = li->minPrice;
+      c.maxPrice = li->maxPrice;
+      return listInstrument(c);
+    }
+    if (const auto* sb = std::get_if<SetBands>(&cmd))
+    {
+      return setPriceBand(sb->symbol, sb->minPrice, sb->maxPrice);
+    }
+    if (const auto* st = std::get_if<SetTriggerRef>(&cmd))
+    {
+      return setTriggerRef(st->symbol, st->ref);
+    }
+    if (const auto* ad = std::get_if<AdminCmd>(&cmd))
+    {
+      switch (ad->action)
+      {
+        case AdminAction::Halt:
+        case AdminAction::HaltAndCancelAll:
+          return halt(ad->symbol, true);
+        case AdminAction::Resume:
+        case AdminAction::ResumeAuction:
+          return halt(ad->symbol, false);
+        default:
+          return true;  // auction transitions carry no registry state
+      }
+    }
+    if (std::get_if<SetStpGroup>(&cmd) != nullptr)
+    {
+      return true;  // engine-owned state: the shards consume it, no registry state
+    }
+    return false;  // not a configuration command
+  }
+
   std::vector<SymbolId> list() const
   {
     std::vector<SymbolId> out;

--- a/venue/include/flox-venue/event_hash.h
+++ b/venue/include/flox-venue/event_hash.h
@@ -40,6 +40,7 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, static_cast<uint64_t>(x->leavesQty.raw()));
     h = mix(h, x->restingOnBook ? 1U : 0U);
     h = mix(h, static_cast<uint64_t>(x->displayQty.raw()));
+    h = mix(h, x->account);
   }
   else if (const auto* x = std::get_if<OrderRejected>(&e))
   {
@@ -47,6 +48,7 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, x->id);
     h = mix(h, x->symbol);
     h = mix(h, static_cast<uint64_t>(x->reason));
+    h = mix(h, x->account);
   }
   else if (const auto* x = std::get_if<Trade>(&e))
   {
@@ -72,6 +74,7 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, x->complete ? 1U : 0U);
     h = mix(h, static_cast<uint64_t>(x->lastPx.raw()));
     h = mix(h, static_cast<uint64_t>(x->displayLeaves.raw()));
+    h = mix(h, x->account);
   }
   else if (const auto* x = std::get_if<OrderCanceled>(&e))
   {
@@ -79,6 +82,7 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, x->id);
     h = mix(h, x->symbol);
     h = mix(h, static_cast<uint64_t>(x->reason));
+    h = mix(h, x->account);
   }
   else if (const auto* x = std::get_if<OrderModified>(&e))
   {
@@ -88,6 +92,7 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, static_cast<uint64_t>(x->price.raw()));
     h = mix(h, static_cast<uint64_t>(x->leavesQty.raw()));
     h = mix(h, x->priorityKept ? 1U : 0U);
+    h = mix(h, x->account);
   }
   else if (const auto* x = std::get_if<OrderTriggered>(&e))
   {
@@ -95,6 +100,7 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, x->id);
     h = mix(h, x->symbol);
     h = mix(h, static_cast<uint64_t>(x->refPrice.raw()));
+    h = mix(h, x->account);
   }
   else if (const auto* x = std::get_if<FillHeld>(&e))
   {
@@ -105,6 +111,9 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, x->takerId);
     h = mix(h, static_cast<uint64_t>(x->price.raw()));
     h = mix(h, static_cast<uint64_t>(x->qty.raw()));
+    h = mix(h, static_cast<uint64_t>(x->makerDisplayAfter.raw()));
+    h = mix(h, x->makerAccount);
+    h = mix(h, x->takerAccount);
   }
   else if (const auto* x = std::get_if<FillRejected>(&e))
   {
@@ -112,6 +121,11 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, x->heldId);
     h = mix(h, x->symbol);
     h = mix(h, x->takerId);
+    h = mix(h, x->makerId);
+    h = mix(h, static_cast<uint64_t>(x->price.raw()));
+    h = mix(h, static_cast<uint64_t>(x->qty.raw()));
+    h = mix(h, x->takerAccount);
+    h = mix(h, x->makerAccount);
   }
   else if (const auto* x = std::get_if<MmpTriggered>(&e))
   {
@@ -126,6 +140,7 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, x->symbol);
     h = mix(h, static_cast<uint64_t>(x->fee.raw()));
     h = mix(h, x->maker ? 1U : 0U);
+    h = mix(h, x->account);
   }
   else if (const auto* x = std::get_if<Liquidation>(&e))
   {
@@ -136,6 +151,15 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, static_cast<uint64_t>(x->price.raw()));
     h = mix(h, x->bankrupt ? 1U : 0U);
     h = mix(h, x->adl ? 1U : 0U);
+  }
+  else if (const auto* x = std::get_if<BalanceUpdate>(&e))
+  {
+    h = mix(h, 13);
+    h = mix(h, x->account);
+    h = mix(h, x->asset);
+    h = mix(h, static_cast<uint64_t>(x->availableRaw));
+    h = mix(h, static_cast<uint64_t>(x->reservedRaw));
+    h = mix(h, static_cast<uint64_t>(x->reason));
   }
   return h;
 }

--- a/venue/include/flox-venue/fix_codec.h
+++ b/venue/include/flox-venue/fix_codec.h
@@ -23,10 +23,14 @@
 #include "flox-venue/messages.h"
 
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
+#include <ctime>
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace flox::venue
 {
@@ -36,8 +40,8 @@ class FixCodec
  public:
   static constexpr char SOH = '\x01';
 
-  // ---- inbound: FIX message -> InboundCommand ----
-  static std::optional<InboundCommand> decode(const std::string& msg)
+  // tag=value fields of a raw FIX message (last occurrence wins on repeats).
+  static std::unordered_map<int, std::string> parseFields(const std::string& msg)
   {
     std::unordered_map<int, std::string> f;
     size_t i = 0;
@@ -57,32 +61,42 @@ class FixCodec
       f[tag] = msg.substr(eq + 1, soh - eq - 1);
       i = soh + 1;
     }
+    return f;
+  }
+
+  // FIX integrity: if a CheckSum (tag 10) is present it MUST be correct --
+  // sum of every byte up to and including the SOH before "10=", mod 256.
+  // Lenient when absent, for internal/test callers that don't append one.
+  static bool checksumValid(const std::string& msg)
+  {
+    const std::string marker = std::string(1, SOH) + "10=";
+    const size_t p = msg.rfind(marker);
+    if (p == std::string::npos)
+    {
+      return true;
+    }
+    unsigned sum = 0;
+    for (size_t k = 0; k <= p; ++k)
+    {
+      sum += static_cast<unsigned char>(msg[k]);
+    }
+    return (sum % 256) ==
+           static_cast<unsigned>(std::atoi(msg.c_str() + p + marker.size()));
+  }
+
+  // ---- inbound: FIX message -> InboundCommand ----
+  static std::optional<InboundCommand> decode(const std::string& msg)
+  {
+    std::unordered_map<int, std::string> f = parseFields(msg);
 
     auto has = [&](int t)
     { return f.count(t) != 0; };
     auto s = [&](int t)
     { return has(t) ? f[t] : std::string{}; };
 
-    // FIX integrity: if a CheckSum (tag 10) is present it MUST be correct --
-    // sum of every byte up to and including the SOH before "10=", mod 256. A
-    // corrupted message with a bad checksum is rejected. (Lenient when absent,
-    // for internal/test callers that don't append one.)
-    if (has(10))
+    if (!checksumValid(msg))
     {
-      const std::string marker = std::string(1, SOH) + "10=";
-      const size_t p = msg.rfind(marker);
-      if (p != std::string::npos)
-      {
-        unsigned sum = 0;
-        for (size_t k = 0; k <= p; ++k)
-        {
-          sum += static_cast<unsigned char>(msg[k]);
-        }
-        if ((sum % 256) != static_cast<unsigned>(std::atoi(f[10].c_str())))
-        {
-          return std::nullopt;  // checksum mismatch -> reject
-        }
-      }
+      return std::nullopt;  // checksum mismatch -> reject
     }
 
     auto u64 = [&](int t)
@@ -245,7 +259,83 @@ class FixCodec
     return std::nullopt;
   }
 
+  // MsgSeqNum (34) of a raw FIX message; 0 when absent (a structurally
+  // incomplete message -- FIX 4.4 requires 34 on every message).
+  static uint64_t msgSeqNum(const std::string& msg)
+  {
+    return tagValueU64(msg, 34);
+  }
+
   // ---- outbound: OutboundEvent -> ExecutionReport (35=8) ----
+  // Session-framed variant: injects the FIX 4.4 required header fields --
+  // MsgSeqNum (34), SenderCompID (49), TargetCompID (56), SendingTime (52) --
+  // that the bare encode() (embedded/test use) omits. Empty on events with no
+  // exec-report mapping. A resend replay sets possDup (PossDupFlag 43=Y) and
+  // origSendingTime (OrigSendingTime 122, the first transmission's 52) -- the
+  // reason resends re-encode instead of replaying bytes: 43/122 change
+  // BodyLength and CheckSum.
+  static std::string encode(const OutboundEvent& ev, uint64_t seq, const std::string& senderCompId,
+                            const std::string& targetCompId, const std::string& sendingTime,
+                            bool possDup = false, const std::string& origSendingTime = {})
+  {
+    const std::string bare = encode(ev);
+    if (bare.empty())
+    {
+      return bare;
+    }
+    // Re-frame: keep the body after 35=8, prepend the session header fields.
+    const std::string marker = std::string("35=8") + SOH;
+    const size_t p = bare.find(marker);
+    if (p == std::string::npos)
+    {
+      return {};
+    }
+    const size_t bodyStart = p + marker.size();
+    const size_t csum = bare.rfind(std::string(1, SOH) + "10=");
+    const std::string tail =
+        bare.substr(bodyStart, (csum == std::string::npos ? bare.size() : csum + 1) - bodyStart);
+    std::string b = marker;
+    b += "34=" + std::to_string(seq) + SOH;
+    b += "49=" + senderCompId + SOH;
+    b += "56=" + targetCompId + SOH;
+    b += "52=" + sendingTime + SOH;
+    if (possDup)
+    {
+      b += std::string("43=Y") + SOH;
+    }
+    if (!origSendingTime.empty())
+    {
+      b += "122=" + origSendingTime + SOH;
+    }
+    b += tail;
+    return frame(b);
+  }
+
+  // Session/admin message (Logon 35=A, Heartbeat 35=0, TestRequest 35=1,
+  // ResendRequest 35=2, SequenceReset 35=4, Logout 35=5) with the full FIX 4.4
+  // header and body `fields`, framed with BodyLength and CheckSum.
+  static std::string encodeAdmin(const std::string& msgType, uint64_t seq,
+                                 const std::string& senderCompId, const std::string& targetCompId,
+                                 const std::string& sendingTime,
+                                 const std::vector<std::pair<int, std::string>>& fields = {},
+                                 bool possDup = false)
+  {
+    std::string b = "35=" + msgType + SOH;
+    b += "34=" + std::to_string(seq) + SOH;
+    b += "49=" + senderCompId + SOH;
+    b += "56=" + targetCompId + SOH;
+    b += "52=" + sendingTime + SOH;
+    if (possDup)
+    {
+      b += std::string("43=Y") + SOH;
+    }
+    for (const auto& [tag, val] : fields)
+    {
+      b += std::to_string(tag) + "=" + val + SOH;
+    }
+    return frame(b);
+  }
+
   static std::string encode(const OutboundEvent& ev)
   {
     std::string b;  // body after 35
@@ -308,6 +398,37 @@ class FixCodec
       add(151, qn(m->leavesQty));
       add(44, px(m->price));
     }
+    else if (const auto* fh = std::get_if<FillHeld>(&ev))
+    {
+      // Last-look hold: FIX has no honest ExecType for "fill pending the
+      // maker's confirmation", so this uses the documented custom value
+      // ExecType=U plus custom tags 20001 (heldId) / 20002 (makerId); see
+      // docs/venue/matching.md. The order is still working (39=0); 32/31
+      // carry the held size and price.
+      add(37, std::to_string(fh->takerId));
+      add(55, std::to_string(fh->symbol));
+      add(150, "U");  // custom ExecType: fill held pending last look
+      add(39, "0");   // OrdStatus New/working -- nothing has executed yet
+      add(32, qn(fh->qty));
+      add(31, px(fh->price));
+      add(20001, std::to_string(fh->heldId));
+      add(20002, std::to_string(fh->makerId));
+    }
+    else if (const auto* fr = std::get_if<FillRejected>(&ev))
+    {
+      // Held fill rejected/timed out: the pending fill is busted, which maps
+      // honestly onto ExecType=H (Trade Cancel). Same custom tags identify the
+      // held fill being cancelled.
+      add(37, std::to_string(fr->takerId));
+      add(55, std::to_string(fr->symbol));
+      add(150, "H");  // ExecType Trade Cancel: the held fill will not stand
+      add(39, "0");
+      add(32, qn(fr->qty));
+      add(31, px(fr->price));
+      add(20001, std::to_string(fr->heldId));
+      add(20002, std::to_string(fr->makerId));
+      add(58, "LastLookRejected");
+    }
     else
     {
       return {};  // Trade/Triggered are market-data, not exec reports
@@ -316,7 +437,6 @@ class FixCodec
     return frame(b);
   }
 
- private:
   // Prepend 8/9, append 10 with correct BodyLength and CheckSum.
   static std::string frame(const std::string& body)
   {
@@ -333,6 +453,101 @@ class FixCodec
     msg += std::string("10=") + cs + SOH;
     return msg;
   }
+
+ private:
+  // Value of the first `tag=` field as u64 (0 when absent / non-numeric).
+  static uint64_t tagValueU64(const std::string& msg, int tag)
+  {
+    const std::string needle = std::to_string(tag) + "=";
+    size_t p = 0;
+    while ((p = msg.find(needle, p)) != std::string::npos)
+    {
+      if (p == 0 || msg[p - 1] == SOH)  // field boundary, not a substring of another tag
+      {
+        return std::strtoull(msg.c_str() + p + needle.size(), nullptr, 10);
+      }
+      p += needle.size();
+    }
+    return 0;
+  }
+};
+
+// FIX session-layer state: monotonic outbound MsgSeqNum, inbound MsgSeqNum
+// validation, CompIDs from the gateway configuration and SendingTime.
+//
+// Scope: sequencing/framing building block for embedded and test use. The
+// full session layer -- Logon negotiation, Heartbeat/TestRequest liveness,
+// ResendRequest 35=2 / SequenceReset-GapFill 35=4, PossDup replay -- lives in
+// fix_session.h (FixSessionHost / FixConnection), wired into the gateways via
+// setFixSession. See docs/venue/perimeter.md.
+class FixSession
+{
+ public:
+  FixSession(std::string senderCompId, std::string targetCompId)
+      : sender_(std::move(senderCompId)), target_(std::move(targetCompId))
+  {
+  }
+
+  // Encode an exec report as the next sequenced session message. Empty string
+  // = the event has no FIX mapping (the seq is NOT consumed).
+  std::string encode(const OutboundEvent& ev, int64_t wallClockNs)
+  {
+    const std::string msg =
+        FixCodec::encode(ev, nextOut_, sender_, target_, sendingTime(wallClockNs));
+    if (!msg.empty())
+    {
+      ++nextOut_;
+    }
+    return msg;
+  }
+
+  uint64_t nextOutboundSeq() const noexcept { return nextOut_; }
+
+  enum class InSeq : uint8_t
+  {
+    Ok,         // expected seq (or first message)
+    Gap,        // seq jumped forward: messages lost -> reject the session
+    Duplicate,  // seq at or below the last accepted one
+    Missing,    // no tag 34: structurally invalid FIX 4.4
+  };
+
+  // Validate the inbound MsgSeqNum. Ok advances the expectation; anything else
+  // leaves it unchanged so the caller can terminate the session.
+  InSeq acceptInbound(const std::string& msg)
+  {
+    const uint64_t seq = FixCodec::msgSeqNum(msg);
+    if (seq == 0)
+    {
+      return InSeq::Missing;
+    }
+    if (seq == expectedIn_)
+    {
+      ++expectedIn_;
+      return InSeq::Ok;
+    }
+    return seq > expectedIn_ ? InSeq::Gap : InSeq::Duplicate;
+  }
+
+  uint64_t expectedInboundSeq() const noexcept { return expectedIn_; }
+
+  // UTCTimestamp for tag 52: YYYYMMDD-HH:MM:SS.sss from wall-clock ns.
+  static std::string sendingTime(int64_t wallClockNs)
+  {
+    const time_t secs = static_cast<time_t>(wallClockNs / 1'000'000'000);
+    const int millis = static_cast<int>((wallClockNs / 1'000'000) % 1000);
+    tm g{};
+    gmtime_r(&secs, &g);
+    char buf[32];
+    std::snprintf(buf, sizeof buf, "%04d%02d%02d-%02d:%02d:%02d.%03d", g.tm_year + 1900,
+                  g.tm_mon + 1, g.tm_mday, g.tm_hour, g.tm_min, g.tm_sec, millis);
+    return buf;
+  }
+
+ private:
+  std::string sender_;
+  std::string target_;
+  uint64_t nextOut_{1};
+  uint64_t expectedIn_{1};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/fix_session.h
+++ b/venue/include/flox-venue/fix_session.h
@@ -1,0 +1,709 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * FIX 4.4 session layer with recovery, on top of the FixCodec framing and the
+ * SessionRegistry event log:
+ *
+ *  - Logon (35=A): HeartBtInt (108) adoption, ResetSeqNumFlag (141=Y) resets
+ *    both sequence directions to 1 (the registry stream is cleared). Without
+ *    141, the client's 34 is checked against the expected inbound seq: above
+ *    -> our ResendRequest (35=2) after the Logon reply; below -> Logout with
+ *    text and disconnect.
+ *  - Liveness: outbound Heartbeat every HeartBtInt on the gateway's idle
+ *    tick; no inbound traffic for 1.2 * HeartBtInt -> TestRequest (35=1); no
+ *    answer for another 1.2 intervals -> disconnect (COD sweeps normally).
+ *  - Their ResendRequest (35=2): application messages replay from the
+ *    registry event log with PossDupFlag (43=Y) and OrigSendingTime (122);
+ *    admin seq ranges collapse into SequenceReset-GapFill (35=4, 123=Y). A
+ *    range older than the retained log is gap-filled up to the first
+ *    available seq -- the client sees the trimmed part as an explicit hole;
+ *    full state reconciliation is the SBE snapshot path. Served resends bump
+ *    GatewayCounters::resendServed (same counter as the SBE path).
+ *  - Our inbound gap: NO reorder buffer -- we send 35=2 and DROP every
+ *    message above the hole (repeating the request at most once per
+ *    HeartBtInt); the counterparty replays with PossDup, and a PossDup whose
+ *    34 was already seen is silently dropped. Buffering out-of-order
+ *    application traffic would let a gapped session run orders out of
+ *    admission order; dropping is valid because the peer must resend anyway.
+ *  - Unknown MsgType: an in-sequence message whose 35 is outside the known
+ *    set (admin 0/1/2/4/5/A, application D/F/G) is answered with a session
+ *    Reject (35=3: 45=RefSeqNum, 372=RefMsgType, 58=text) instead of being
+ *    silently consumed. Application messages still flow through the normal
+ *    decoder path -- a decode failure there answers with an exec-report
+ *    reject, not 35=3.
+ *  - Logon may carry the custom tag 20003 (CancelOnDisconnect=Y/N): wire
+ *    negotiation of the session's cancel-on-disconnect (see
+ *    docs/venue/perimeter.md, next to the 20001/20002 last-look tags). The
+ *    gateway wires the negotiated value into the live session via
+ *    setCodListener.
+ *
+ * State split: the outbound side (seq counter + event log) lives in
+ * SessionRegistry::AccountStream; the inbound expectation lives in
+ * FixSessionHost::AccountState. Both survive a disconnect. Across a process
+ * restart, the SEQUENCE COUNTERS (per-account expectedIn + outbound lastSeq)
+ * can be persisted into a sidecar file written at checkpoint time
+ * (FixSessionSidecar; the gateway harness hooks
+ * SequencedShard::onCheckpoint) and restored on startup -- then a Logon
+ * without 141=Y that continues the pre-restart sequence space WORKS. The
+ * EVENT LOG is deliberately not persisted: a resend that reaches into the
+ * pre-restart range is answered with SequenceReset-GapFill -- the honest
+ * signal for history the venue no longer holds; full state reconciliation is
+ * the snapshot path. Without a sidecar the old rule stands: the first Logon
+ * after a restart must carry 141=Y or it is answered with a Logout naming
+ * the reason. See docs/venue/perimeter.md.
+ *
+ * Transport: FixConnection is transport-independent -- Tcp/Tls carry one FIX
+ * message per length-prefixed frame (the framing is added by the writer's
+ * WriteFn), Ws carries one FIX message per WebSocket Text frame (the framing
+ * is added at enqueue time via setWireWrap, matching the gateway's
+ * frame-at-encode model).
+ */
+#pragma once
+
+#include "flox-venue/fix_codec.h"
+#include "flox-venue/session_registry.h"
+
+#include "flox/util/crc32.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <system_error>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+struct FixSessionConfig
+{
+  std::string senderCompId{"VENUE"};
+  std::string targetCompId{"CLIENT"};
+  uint32_t defaultHeartBtIntSec{30};       // until the Logon negotiates one
+  int64_t logonTimeoutNs{10'000'000'000};  // no Logon within this -> disconnect
+};
+
+// Per-account FIX session state that OUTLIVES a connection (the inbound
+// mirror of the outbound seq + log living in SessionRegistry::AccountStream):
+// the expected inbound MsgSeqNum survives a disconnect so a reconnect without
+// ResetSeqNumFlag resumes the same sequence space. Across a process restart
+// it survives only through serialize()/restore() (the checkpoint sidecar,
+// FixSessionSidecar) -- see the file comment.
+class FixSessionHost
+{
+ public:
+  explicit FixSessionHost(FixSessionConfig cfg = {}) : cfg_(std::move(cfg)) {}
+
+  const FixSessionConfig& config() const noexcept { return cfg_; }
+
+  struct AccountState
+  {
+    std::mutex m;
+    uint64_t expectedIn{1};
+    bool established{false};  // a Logon completed since process start (or restored state)
+  };
+
+  std::shared_ptr<AccountState> stateOf(uint64_t account)
+  {
+    std::lock_guard<std::mutex> lk(m_);
+    auto it = states_.find(account);
+    if (it != states_.end())
+    {
+      return it->second;
+    }
+    auto s = std::make_shared<AccountState>();
+    states_.emplace(account, s);
+    return s;
+  }
+
+  // ---- restart persistence (inbound side of the FIX sidecar) ----
+  // Blob: [u32 count]{u64 account, u64 expectedIn}... -- one entry per
+  // account that completed a Logon (only established sequence spaces are
+  // worth carrying across a restart).
+  void serialize(std::vector<uint8_t>& out)
+  {
+    std::vector<std::pair<uint64_t, uint64_t>> entries;
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      for (const auto& [account, state] : states_)
+      {
+        std::lock_guard<std::mutex> slk(state->m);
+        if (state->established)
+        {
+          entries.emplace_back(account, state->expectedIn);
+        }
+      }
+    }
+    const uint32_t count = static_cast<uint32_t>(entries.size());
+    append(out, &count, sizeof count);
+    for (const auto& [account, expectedIn] : entries)
+    {
+      append(out, &account, sizeof account);
+      append(out, &expectedIn, sizeof expectedIn);
+    }
+  }
+
+  // Restore per-account expected inbound seqs into a fresh host (before any
+  // connection is accepted). Restored accounts are marked established, so a
+  // Logon that continues the pre-restart sequence space (no 141=Y) passes the
+  // 34 check against the restored expectedIn. Returns bytes consumed, 0 on a
+  // malformed blob.
+  size_t restore(const uint8_t* p, size_t n)
+  {
+    uint32_t count = 0;
+    if (n < sizeof count)
+    {
+      return 0;
+    }
+    std::memcpy(&count, p, sizeof count);
+    const size_t need = sizeof count + static_cast<size_t>(count) * 16;
+    if (n < need)
+    {
+      return 0;
+    }
+    const uint8_t* b = p + sizeof count;
+    for (uint32_t i = 0; i < count; ++i, b += 16)
+    {
+      uint64_t account = 0;
+      uint64_t expectedIn = 0;
+      std::memcpy(&account, b, sizeof account);
+      std::memcpy(&expectedIn, b + 8, sizeof expectedIn);
+      auto s = stateOf(account);
+      std::lock_guard<std::mutex> lk(s->m);
+      s->expectedIn = expectedIn;
+      s->established = true;
+    }
+    return need;
+  }
+
+ private:
+  static void append(std::vector<uint8_t>& out, const void* p, size_t n)
+  {
+    const auto* b = static_cast<const uint8_t*>(p);
+    out.insert(out.end(), b, b + n);
+  }
+
+  FixSessionConfig cfg_;
+  std::mutex m_;
+  std::unordered_map<uint64_t, std::shared_ptr<AccountState>> states_;
+};
+
+// The FIX session sidecar: per-account sequence counters (inbound expectedIn
+// from FixSessionHost, outbound lastSeq from SessionRegistry) persisted next
+// to the shard journal as `<base>.fixsessions`. Written by the gateway
+// harness at every checkpoint boundary (SequencedShard::onCheckpoint) with
+// the journal's durability discipline -- tmp file, fsync, atomic rename --
+// and a trailing CRC32 over the whole payload (same integrity posture as a
+// journal record: a torn or corrupted sidecar loads as "absent", which
+// degrades to the old 141=Y requirement, never to a wrong sequence space).
+// The event log is NOT in the sidecar (see the file comment: pre-restart
+// ranges resend as GapFill).
+class FixSessionSidecar
+{
+ public:
+  static constexpr uint32_t kMagic = 0x46495853;  // "FIXS"
+
+  static std::string pathFor(const std::string& journalBase) { return journalBase + ".fixsessions"; }
+
+  static bool write(const std::string& path, FixSessionHost& host, SessionRegistry& registry)
+  {
+    std::vector<uint8_t> body;
+    const uint32_t magic = kMagic;
+    body.insert(body.end(), reinterpret_cast<const uint8_t*>(&magic),
+                reinterpret_cast<const uint8_t*>(&magic) + sizeof magic);
+    host.serialize(body);
+    registry.serializeSeqs(body);
+    const uint32_t crc = flox::util::Crc32::compute(body.data(), body.size());
+    body.insert(body.end(), reinterpret_cast<const uint8_t*>(&crc),
+                reinterpret_cast<const uint8_t*>(&crc) + sizeof crc);
+
+    const std::string tmp = path + ".tmp";
+    const int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0)
+    {
+      return false;
+    }
+    size_t off = 0;
+    while (off < body.size())
+    {
+      const ssize_t w = ::write(fd, body.data() + off, body.size() - off);
+      if (w <= 0)
+      {
+        ::close(fd);
+        return false;
+      }
+      off += static_cast<size_t>(w);
+    }
+    ::fsync(fd);
+    ::close(fd);
+    std::error_code ec;
+    std::filesystem::rename(tmp, path, ec);
+    return !ec;
+  }
+
+  // Load a sidecar into a fresh host + registry (before any connection is
+  // accepted). False = absent / torn / corrupt: nothing is applied and the
+  // session layer falls back to requiring 141=Y after the restart.
+  static bool load(const std::string& path, FixSessionHost& host, SessionRegistry& registry)
+  {
+    std::ifstream in(path, std::ios::binary);
+    if (!in)
+    {
+      return false;
+    }
+    std::vector<uint8_t> body((std::istreambuf_iterator<char>(in)),
+                              std::istreambuf_iterator<char>());
+    if (body.size() < sizeof(uint32_t) * 2)
+    {
+      return false;
+    }
+    uint32_t crc = 0;
+    std::memcpy(&crc, body.data() + body.size() - sizeof crc, sizeof crc);
+    body.resize(body.size() - sizeof crc);
+    if (flox::util::Crc32::compute(body.data(), body.size()) != crc)
+    {
+      return false;
+    }
+    uint32_t magic = 0;
+    std::memcpy(&magic, body.data(), sizeof magic);
+    if (magic != kMagic)
+    {
+      return false;
+    }
+    const uint8_t* p = body.data() + sizeof magic;
+    size_t left = body.size() - sizeof magic;
+    const size_t usedHost = host.restore(p, left);
+    if (usedHost == 0)
+    {
+      return false;
+    }
+    p += usedHost;
+    left -= usedHost;
+    return registry.restoreSeqs(p, left) != 0;
+  }
+};
+
+// One live FIX connection. Owned by the gateway's connection loop: onFrame()
+// gates every inbound message (session-layer traffic is consumed here;
+// in-sequence application messages fall through to the normal decoder path),
+// onTick() runs the heartbeat timers on the gateway's SO_RCVTIMEO idle tick.
+// All outbound traffic goes through the SessionRegistry (seq allocation and
+// enqueue are atomic on the account-stream mutex), so the single-writer
+// contract of SessionWriter is preserved.
+class FixConnection
+{
+ public:
+  enum class Verdict : uint8_t
+  {
+    Handled,     // session-layer message, fully consumed
+    App,         // in-sequence application message: decode + submit as usual
+    Disconnect,  // session over (Logout exchanged / fatal): close the socket
+  };
+
+  // Transport framing applied to every outbound FIX message at enqueue time.
+  // Default (unset) = the raw FIX bytes (Tcp/Tls: the writer's WriteFn adds
+  // the length prefix). The WS gateway wraps each message in a WebSocket Text
+  // frame here, because its registry carries fully-framed WS bytes.
+  using WireWrap = std::function<std::vector<uint8_t>(const uint8_t*, size_t)>;
+  // Wire-negotiated cancel-on-disconnect (Logon tag 20003): the gateway
+  // applies the value to the live session + DisconnectCanceller.
+  using CodListener = std::function<void(bool)>;
+
+  FixConnection(FixSessionHost& host, SessionRegistry& registry, uint64_t account, int64_t nowNs)
+      : cfg_(host.config()),
+        registry_(registry),
+        account_(account),
+        state_(host.stateOf(account)),
+        lastInNs_(nowNs),
+        lastOutNs_(nowNs)
+  {
+    hbNs_ = static_cast<int64_t>(cfg_.defaultHeartBtIntSec) * 1'000'000'000LL;
+  }
+
+  void setWireWrap(WireWrap wrap) { wrap_ = std::move(wrap); }
+  void setCodListener(CodListener l) { codListener_ = std::move(l); }
+
+  Verdict onFrame(const std::string& msg, int64_t nowNs)
+  {
+    lastInNs_ = nowNs;
+    testReqPending_ = false;  // any inbound traffic proves liveness
+    if (!FixCodec::checksumValid(msg))
+    {
+      return Verdict::Handled;  // corrupt frame: drop; the seq gap machinery recovers the hole
+    }
+    auto f = FixCodec::parseFields(msg);
+    const std::string type = f.count(35) != 0 ? f[35] : std::string{};
+    if (!loggedOn_)
+    {
+      if (type != "A")
+      {
+        return logout("Logon required", nowNs);
+      }
+      return onLogon(f, nowNs);
+    }
+    const uint64_t seq = u64(f, 34);
+    const bool possDup = f.count(43) != 0 && f[43] == "Y";
+
+    std::lock_guard<std::mutex> lk(state_->m);
+    if (type == "4")
+    {
+      // SequenceReset repairs the inbound sequence itself: handled before the
+      // seq gate.
+      onSequenceReset(f, seq, nowNs);
+      return Verdict::Handled;
+    }
+    if (seq == 0)
+    {
+      return logout("MsgSeqNum (34) missing", nowNs);
+    }
+    if (seq < state_->expectedIn)
+    {
+      if (possDup)
+      {
+        return Verdict::Handled;  // already-seen PossDup replay: silent drop
+      }
+      return logout("MsgSeqNum too low, expected " + std::to_string(state_->expectedIn), nowNs);
+    }
+    if (seq > state_->expectedIn)
+    {
+      // Inbound gap: no reorder buffer -- request a resend and drop everything
+      // above the hole (the peer replays it with PossDup); the request repeats
+      // at most once per HeartBtInt. TestRequest is still answered so liveness
+      // survives an open gap.
+      requestResend(nowNs);
+      if (type == "1")
+      {
+        heartbeatReply(f, nowNs);
+      }
+      return Verdict::Handled;
+    }
+    ++state_->expectedIn;
+    gapPending_ = false;
+
+    if (type == "0")
+    {
+      return Verdict::Handled;  // Heartbeat: liveness already refreshed above
+    }
+    if (type == "1")
+    {
+      heartbeatReply(f, nowNs);  // TestRequest -> Heartbeat echoing 112
+      return Verdict::Handled;
+    }
+    if (type == "2")
+    {
+      serveResend(f, nowNs);
+      return Verdict::Handled;
+    }
+    if (type == "5")
+    {
+      logoutSent_ = true;
+      sendAdmin("5", {}, nowNs);  // confirming Logout; the loop exit runs COD
+      return Verdict::Disconnect;
+    }
+    if (type == "A")
+    {
+      return Verdict::Handled;  // duplicate Logon on a live session: ignore
+    }
+    if (type == "D" || type == "F" || type == "G")
+    {
+      return Verdict::App;
+    }
+    // Unknown / unsupported MsgType: consumed in sequence, answered with a
+    // session Reject (35=3) naming the offending seq and type -- never a
+    // silent swallow, never a session kill.
+    sendAdmin("3",
+              {{45, std::to_string(seq)},
+               {372, type.empty() ? std::string("?") : type},
+               {58, "unsupported MsgType"}},
+              nowNs);
+    return Verdict::Handled;
+  }
+
+  // Timer pass on the gateway idle tick. False = liveness lost, disconnect.
+  bool onTick(int64_t nowNs)
+  {
+    if (!loggedOn_)
+    {
+      return nowNs - lastInNs_ < cfg_.logonTimeoutNs;
+    }
+    if (nowNs - lastOutNs_ >= hbNs_)
+    {
+      sendAdmin("0", {}, nowNs);
+    }
+    const int64_t grace = hbNs_ + hbNs_ / 5;  // 1.2 * HeartBtInt
+    if (nowNs - lastInNs_ >= grace)
+    {
+      if (!testReqPending_)
+      {
+        testReqPending_ = true;
+        testReqNs_ = nowNs;
+        sendAdmin("1", {{112, std::to_string(nowNs)}}, nowNs);
+      }
+      else if (nowNs - testReqNs_ >= grace)
+      {
+        return false;  // TestRequest unanswered for another 1.2 intervals
+      }
+    }
+    return true;
+  }
+
+  bool loggedOn() const noexcept { return loggedOn_; }
+
+ private:
+  static uint64_t u64(std::unordered_map<int, std::string>& f, int tag)
+  {
+    return f.count(tag) != 0 ? std::strtoull(f[tag].c_str(), nullptr, 10) : 0;
+  }
+
+  Verdict onLogon(std::unordered_map<int, std::string>& f, int64_t nowNs)
+  {
+    if (f.count(108) != 0)
+    {
+      const long hb = std::atol(f[108].c_str());
+      if (hb > 0)
+      {
+        hbNs_ = static_cast<int64_t>(hb) * 1'000'000'000LL;
+      }
+    }
+    // Custom tag 20003 (CancelOnDisconnect=Y/N): per-session COD negotiation
+    // on the wire. Applied on any accepted Logon, before order flow exists.
+    const bool hasCod = f.count(20003) != 0;
+    const bool codOn = hasCod && f[20003] == "Y";
+    const auto applyCod = [&]
+    {
+      if (hasCod && codListener_)
+      {
+        codListener_(codOn);
+      }
+    };
+    const uint64_t seq = u64(f, 34);
+    const bool reset = f.count(141) != 0 && f[141] == "Y";
+    std::lock_guard<std::mutex> lk(state_->m);
+    if (reset)
+    {
+      // ResetSeqNumFlag: both directions restart at 1. The outbound stream
+      // (seq counter + resend log) is cleared -- nothing from the previous
+      // sequence space may replay into the new one.
+      registry_.resetStream(account_);
+      state_->expectedIn = (seq == 0 ? 1 : seq) + 1;
+      state_->established = true;
+      loggedOn_ = true;
+      applyCod();
+      logonReply(true, nowNs);
+      return Verdict::Handled;
+    }
+    if (seq == 0)
+    {
+      return logout("MsgSeqNum (34) missing", nowNs);
+    }
+    if (seq < state_->expectedIn)
+    {
+      return logout("MsgSeqNum too low on Logon, expected " + std::to_string(state_->expectedIn),
+                    nowNs);
+    }
+    if (seq > state_->expectedIn && !state_->established)
+    {
+      // In-memory session state was lost (venue restart): the counterparty
+      // still runs the old sequence space and continuing would corrupt both
+      // directions. Require an explicit reset.
+      return logout("session state lost (venue restart): Logon must set ResetSeqNumFlag (141=Y)",
+                    nowNs);
+    }
+    state_->established = true;
+    loggedOn_ = true;
+    applyCod();
+    logonReply(false, nowNs);
+    if (seq == state_->expectedIn)
+    {
+      ++state_->expectedIn;
+    }
+    else
+    {
+      requestResend(nowNs);  // their gap: recover it right after the Logon reply
+    }
+    return Verdict::Handled;
+  }
+
+  // state_->m held by the caller.
+  void onSequenceReset(std::unordered_map<int, std::string>& f, uint64_t seq, int64_t nowNs)
+  {
+    const uint64_t newSeq = u64(f, 36);
+    if (f.count(123) != 0 && f[123] == "Y")
+    {
+      if (seq > state_->expectedIn)
+      {
+        requestResend(nowNs);  // the GapFill itself sits beyond a hole
+        return;
+      }
+      if (newSeq > state_->expectedIn)
+      {
+        state_->expectedIn = newSeq;
+        gapPending_ = false;
+      }
+      return;  // stale / duplicate GapFill: ignore
+    }
+    // Reset mode (no 123=Y): hard sequence override. Accept it, loudly -- it
+    // abandons messages without the GapFill accounting.
+    std::fprintf(stderr,
+                 "[fix] WARN account %llu: SequenceReset-Reset to %llu (expected %llu)\n",
+                 static_cast<unsigned long long>(account_),
+                 static_cast<unsigned long long>(newSeq),
+                 static_cast<unsigned long long>(state_->expectedIn));
+    if (newSeq != 0)
+    {
+      state_->expectedIn = newSeq;
+      gapPending_ = false;
+    }
+  }
+
+  // Their 35=2: replay [7=BeginSeqNo, 16=EndSeqNo] (16=0 -> everything).
+  // Logged application events re-encode with PossDup + OrigSendingTime; seqs
+  // absent from the log (admin traffic, trimmed history) collapse into
+  // SequenceReset-GapFill. Replay frames carry ORIGINAL seqs and bypass seq
+  // allocation (enqueueRaw).
+  void serveResend(std::unordered_map<int, std::string>& f, int64_t nowNs)
+  {
+    const uint64_t last = registry_.lastSeq(account_);
+    const uint64_t beginReq = u64(f, 7);
+    const uint64_t endReq = u64(f, 16);
+    const uint64_t begin = beginReq == 0 ? 1 : beginReq;
+    const uint64_t end = (endReq == 0 || endReq > last) ? last : endReq;
+    if (begin > end)
+    {
+      return;  // nothing in range (or nothing ever sent)
+    }
+    const std::string now52 = FixSession::sendingTime(nowNs);
+    uint64_t cur = begin;
+    for (const auto& logged : registry_.logSlice(account_, begin, end))
+    {
+      if (logged.seq > cur)
+      {
+        gapFill(cur, logged.seq, now52);
+      }
+      const std::string m =
+          FixCodec::encode(logged.event, logged.seq, cfg_.senderCompId, cfg_.targetCompId, now52,
+                           /*possDup*/ true, FixSession::sendingTime(logged.tsNs));
+      if (!m.empty())
+      {
+        registry_.enqueueRaw(account_, toWire(m));
+      }
+      cur = logged.seq + 1;
+    }
+    if (cur <= end)
+    {
+      gapFill(cur, end + 1, now52);
+    }
+    registry_.noteResendServed();  // same counter as the SBE resend path
+  }
+
+  void gapFill(uint64_t seq, uint64_t newSeq, const std::string& now52)
+  {
+    const std::string m =
+        FixCodec::encodeAdmin("4", seq, cfg_.senderCompId, cfg_.targetCompId, now52,
+                              {{123, "Y"}, {36, std::to_string(newSeq)}}, /*possDup*/ true);
+    registry_.enqueueRaw(account_, toWire(m));
+  }
+
+  // state_->m held by the caller.
+  void requestResend(int64_t nowNs)
+  {
+    if (gapPending_ && nowNs - lastGapReqNs_ < hbNs_)
+    {
+      return;  // at most one 35=2 per HeartBtInt while the hole stays open
+    }
+    gapPending_ = true;
+    lastGapReqNs_ = nowNs;
+    sendAdmin("2", {{7, std::to_string(state_->expectedIn)}, {16, "0"}}, nowNs);
+  }
+
+  void heartbeatReply(std::unordered_map<int, std::string>& f, int64_t nowNs)
+  {
+    std::vector<std::pair<int, std::string>> fields;
+    if (f.count(112) != 0)
+    {
+      fields.emplace_back(112, f[112]);  // TestReqID echo
+    }
+    sendAdmin("0", fields, nowNs);
+  }
+
+  void logonReply(bool reset, int64_t nowNs)
+  {
+    std::vector<std::pair<int, std::string>> fields{
+        {108, std::to_string(hbNs_ / 1'000'000'000LL)}};
+    if (reset)
+    {
+      fields.emplace_back(141, "Y");
+    }
+    sendAdmin("A", fields, nowNs);
+  }
+
+  Verdict logout(const std::string& text, int64_t nowNs)
+  {
+    if (!logoutSent_)
+    {
+      logoutSent_ = true;
+      sendAdmin("5", {{58, text}}, nowNs);
+    }
+    return Verdict::Disconnect;
+  }
+
+  bool sendAdmin(const std::string& type, const std::vector<std::pair<int, std::string>>& fields,
+                 int64_t nowNs)
+  {
+    lastOutNs_ = nowNs;
+    return registry_.sendSequencedRaw(
+        account_,
+        [&](uint64_t seq, int64_t tsNs, std::vector<uint8_t>& out)
+        {
+          const std::string m = FixCodec::encodeAdmin(type, seq, cfg_.senderCompId,
+                                                      cfg_.targetCompId,
+                                                      FixSession::sendingTime(tsNs), fields);
+          out = toWire(m);
+          return true;
+        });
+  }
+
+  // Transport framing for a raw FIX message (see setWireWrap).
+  std::vector<uint8_t> toWire(const std::string& m) const
+  {
+    if (wrap_)
+    {
+      return wrap_(reinterpret_cast<const uint8_t*>(m.data()), m.size());
+    }
+    return std::vector<uint8_t>(m.begin(), m.end());
+  }
+
+  FixSessionConfig cfg_;
+  SessionRegistry& registry_;
+  uint64_t account_;
+  std::shared_ptr<FixSessionHost::AccountState> state_;
+  WireWrap wrap_;
+  CodListener codListener_;
+  int64_t hbNs_;
+  int64_t lastInNs_;
+  int64_t lastOutNs_;
+  bool loggedOn_{false};
+  bool logoutSent_{false};
+  bool testReqPending_{false};
+  int64_t testReqNs_{0};
+  bool gapPending_{false};
+  int64_t lastGapReqNs_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/journal.h
+++ b/venue/include/flox-venue/journal.h
@@ -34,6 +34,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -56,6 +57,29 @@ static_assert(std::is_trivially_copyable_v<LastLookDecision>, "LastLookDecision 
 static_assert(std::is_trivially_copyable_v<SetMark>, "SetMark must be blittable");
 static_assert(std::is_trivially_copyable_v<ApplyFunding>, "ApplyFunding must be blittable");
 static_assert(std::is_trivially_copyable_v<AdminCmd>, "AdminCmd must be blittable");
+static_assert(std::is_trivially_copyable_v<Deposit>, "Deposit must be blittable");
+static_assert(std::is_trivially_copyable_v<Withdraw>, "Withdraw must be blittable");
+static_assert(std::is_trivially_copyable_v<ListInstrument>, "ListInstrument must be blittable");
+static_assert(std::is_trivially_copyable_v<SetBands>, "SetBands must be blittable");
+static_assert(std::is_trivially_copyable_v<TimeTick>, "TimeTick must be blittable");
+static_assert(std::is_trivially_copyable_v<SetTriggerRef>, "SetTriggerRef must be blittable");
+static_assert(std::is_trivially_copyable_v<SnapshotBegin>, "SnapshotBegin must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreOrder>, "RestoreOrder must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreStop>, "RestoreStop must be blittable");
+static_assert(std::is_trivially_copyable_v<RestorePeg>, "RestorePeg must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreHeld>, "RestoreHeld must be blittable");
+static_assert(std::is_trivially_copyable_v<RestorePosition>, "RestorePosition must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreMmpCfg>, "RestoreMmpCfg must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreClOrdIds>, "RestoreClOrdIds must be blittable");
+static_assert(std::is_trivially_copyable_v<SnapshotEnd>, "SnapshotEnd must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreReservation>,
+              "RestoreReservation must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreBalance>, "RestoreBalance must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreMmpFills>, "RestoreMmpFills must be blittable");
+static_assert(std::is_trivially_copyable_v<SetStpGroup>, "SetStpGroup must be blittable");
+static_assert(std::variant_size_v<InboundCommand> == 28,
+              "new InboundCommand alternative: extend expectedBodySize/appendDecoded and the "
+              "blittable asserts above");
 
 class Journal
 {
@@ -66,11 +90,23 @@ class Journal
     Full,  // + fsync per record (survives power loss); production WAL default
   };
 
+  // A recovering writer MUST open in Append: Truncate erases the very log the
+  // process is supposed to replay. SequencedShard always uses Append; Truncate
+  // is for starting a fresh log on a path the caller knows is disposable.
+  enum class OpenMode
+  {
+    Truncate,
+    Append,
+  };
+
   static constexpr size_t kHeaderSize = sizeof(int64_t) + 1 + sizeof(uint32_t);  // ts+tag+len = 13
 
-  explicit Journal(const std::string& path, Sync sync = Sync::Off) : sync_(sync)
+  explicit Journal(const std::string& path, Sync sync = Sync::Off,
+                   OpenMode mode = OpenMode::Truncate)
+      : sync_(sync)
   {
-    fd_ = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    const int flags = O_WRONLY | O_CREAT | (mode == OpenMode::Truncate ? O_TRUNC : O_APPEND);
+    fd_ = ::open(path.c_str(), flags, 0644);
     if (fd_ < 0)
     {
       throw std::runtime_error("Journal: cannot open '" + path + "' for writing");
@@ -87,6 +123,27 @@ class Journal
 
   Journal(const Journal&) = delete;
   Journal& operator=(const Journal&) = delete;
+
+  // Close the current file and continue on `path` (segment rotation at a
+  // checkpoint). Resets the per-segment record/byte counters; they count
+  // appends since open, so on an Append reopen of an existing file they
+  // approximate the segment size from this process's perspective only.
+  void reopen(const std::string& path, OpenMode mode)
+  {
+    if (fd_ >= 0)
+    {
+      ::fsync(fd_);
+      ::close(fd_);
+    }
+    const int flags = O_WRONLY | O_CREAT | (mode == OpenMode::Truncate ? O_TRUNC : O_APPEND);
+    fd_ = ::open(path.c_str(), flags, 0644);
+    if (fd_ < 0)
+    {
+      throw std::runtime_error("Journal: cannot open '" + path + "' for writing");
+    }
+    count_.store(0, std::memory_order_relaxed);
+    bytes_.store(0, std::memory_order_relaxed);
+  }
 
   void append(const InboundCommand& c) { append(c, 0); }
 
@@ -113,7 +170,8 @@ class Journal
     {
       ::fsync(fd_);
     }
-    ++count_;
+    count_.fetch_add(1, std::memory_order_relaxed);
+    bytes_.fetch_add(rec_.size(), std::memory_order_relaxed);
   }
 
   void flush()
@@ -123,7 +181,10 @@ class Journal
       ::fsync(fd_);
     }
   }
-  uint64_t count() const noexcept { return count_; }
+  // Records/bytes appended since open (atomic: the shard's idle sweeper reads
+  // them from another thread for the checkpoint auto-trigger).
+  uint64_t count() const noexcept { return count_.load(std::memory_order_relaxed); }
+  uint64_t bytes() const noexcept { return bytes_.load(std::memory_order_relaxed); }
 
   static std::vector<InboundCommand> load(const std::string& path)
   {
@@ -211,6 +272,44 @@ class Journal
         return sizeof(ApplyFunding);
       case 8:
         return sizeof(AdminCmd);
+      case 9:
+        return sizeof(Deposit);
+      case 10:
+        return sizeof(Withdraw);
+      case 11:
+        return sizeof(ListInstrument);
+      case 12:
+        return sizeof(SetBands);
+      case 13:
+        return sizeof(TimeTick);
+      case 14:
+        return sizeof(SetTriggerRef);
+      case 15:
+        return sizeof(SnapshotBegin);
+      case 16:
+        return sizeof(RestoreOrder);
+      case 17:
+        return sizeof(RestoreStop);
+      case 18:
+        return sizeof(RestorePeg);
+      case 19:
+        return sizeof(RestoreHeld);
+      case 20:
+        return sizeof(RestorePosition);
+      case 21:
+        return sizeof(RestoreMmpCfg);
+      case 22:
+        return sizeof(RestoreClOrdIds);
+      case 23:
+        return sizeof(SnapshotEnd);
+      case 24:
+        return sizeof(RestoreReservation);
+      case 25:
+        return sizeof(RestoreBalance);
+      case 26:
+        return sizeof(RestoreMmpFills);
+      case 27:
+        return sizeof(SetStpGroup);
       default:
         return 0;
     }
@@ -256,6 +355,63 @@ class Journal
       case 8:
         v.emplace_back(ts, fromBody<AdminCmd>(body));
         break;
+      case 9:
+        v.emplace_back(ts, fromBody<Deposit>(body));
+        break;
+      case 10:
+        v.emplace_back(ts, fromBody<Withdraw>(body));
+        break;
+      case 11:
+        v.emplace_back(ts, fromBody<ListInstrument>(body));
+        break;
+      case 12:
+        v.emplace_back(ts, fromBody<SetBands>(body));
+        break;
+      case 13:
+        v.emplace_back(ts, fromBody<TimeTick>(body));
+        break;
+      case 14:
+        v.emplace_back(ts, fromBody<SetTriggerRef>(body));
+        break;
+      case 15:
+        v.emplace_back(ts, fromBody<SnapshotBegin>(body));
+        break;
+      case 16:
+        v.emplace_back(ts, fromBody<RestoreOrder>(body));
+        break;
+      case 17:
+        v.emplace_back(ts, fromBody<RestoreStop>(body));
+        break;
+      case 18:
+        v.emplace_back(ts, fromBody<RestorePeg>(body));
+        break;
+      case 19:
+        v.emplace_back(ts, fromBody<RestoreHeld>(body));
+        break;
+      case 20:
+        v.emplace_back(ts, fromBody<RestorePosition>(body));
+        break;
+      case 21:
+        v.emplace_back(ts, fromBody<RestoreMmpCfg>(body));
+        break;
+      case 22:
+        v.emplace_back(ts, fromBody<RestoreClOrdIds>(body));
+        break;
+      case 23:
+        v.emplace_back(ts, fromBody<SnapshotEnd>(body));
+        break;
+      case 24:
+        v.emplace_back(ts, fromBody<RestoreReservation>(body));
+        break;
+      case 25:
+        v.emplace_back(ts, fromBody<RestoreBalance>(body));
+        break;
+      case 26:
+        v.emplace_back(ts, fromBody<RestoreMmpFills>(body));
+        break;
+      case 27:
+        v.emplace_back(ts, fromBody<SetStpGroup>(body));
+        break;
     }
   }
 
@@ -281,7 +437,8 @@ class Journal
 
   int fd_{-1};
   Sync sync_{Sync::Off};
-  uint64_t count_{0};
+  std::atomic<uint64_t> count_{0};
+  std::atomic<uint64_t> bytes_{0};
   std::vector<uint8_t> rec_;
 };
 

--- a/venue/include/flox-venue/ledger.h
+++ b/venue/include/flox-venue/ledger.h
@@ -123,6 +123,18 @@ class Ledger
 
   void credit(uint64_t account, AssetId asset, Amount raw) { bal(account, asset).avail += raw; }
 
+  // RECOVERY-ONLY: overwrite an (account, asset) balance with an exact signed
+  // available/reserved split (snapshot RestoreBalance application). This is a
+  // direct write, not a flow -- it deliberately bypasses the reserve/release
+  // discipline so any live moment restores bit-for-bit, including a negative
+  // wallet mid-liquidation. Never call it on the live trading path.
+  void restore(uint64_t account, AssetId asset, Amount avail, Amount rsvd)
+  {
+    Bal& b = bal(account, asset);
+    b.avail = avail;
+    b.rsvd = rsvd;
+  }
+
   // Enumerate every (account, asset, total) balance -- for reconciliation and
   // segregation reporting (compliance). Not on the hot path.
   template <class Fn>
@@ -131,6 +143,18 @@ class Ledger
     for (const auto& [k, b] : bal_)
     {
       fn(k >> 16, static_cast<AssetId>(k & 0xFFFF), b.avail + b.rsvd);
+    }
+  }
+
+  // Enumerate every (account, asset, available, reserved) balance -- for the
+  // venue checkpoint (balances serialize as totals; reserved reconstitutes by
+  // re-reservation) and its state hash. Not on the hot path.
+  template <class Fn>
+  void forEachBalanceSplit(Fn&& fn) const
+  {
+    for (const auto& [k, b] : bal_)
+    {
+      fn(k >> 16, static_cast<AssetId>(k & 0xFFFF), b.avail, b.rsvd);
     }
   }
 

--- a/venue/include/flox-venue/market_data.h
+++ b/venue/include/flox-venue/market_data.h
@@ -14,11 +14,17 @@
 #include "flox/book/events/book_update_event.h"
 #include "flox/book/nlevel_order_book.h"
 
+#include <chrono>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory_resource>
+#include <mutex>
+#include <optional>
+#include <random>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace flox::venue
 {
@@ -43,21 +49,51 @@ struct MdMessage
   Price price{};
   Quantity qty{};     // AddOrder: shown qty; Trade: exec qty; Executed/Replace: leaves
   OrderId makerId{};  // Trade only
+  uint64_t epoch{};   // publisher lifetime id; changes on restart (consumer re-snapshots)
 };
 
+// Consistent (snapshot, lastSeq) pair from MarketDataPublisher::snapshotAtomic:
+// apply `orders`, then resume the incremental feed at lastSeq+1 under `epoch`.
+struct MdSnapshot
+{
+  uint64_t epoch{};
+  uint64_t lastSeq{};
+  std::vector<MdMessage> orders;  // AddOrder body messages (seq=0, epoch set)
+};
+
+// One publisher per symbol. Each emitted message carries (symbol, epoch, seq):
+// seq is contiguous from 1 within one publisher lifetime, epoch is a random
+// value minted at construction. Sequence numbers are deliberately NOT
+// persisted across restarts -- the book is rebuildable from matching state, so
+// a restart mints a new epoch and starts over at seq=1; a consumer that sees
+// the epoch change knows every prior seq is void and re-snapshots via the
+// recovery channel (md_recovery.h). Without the epoch a restarted feed would
+// look like an endless stream of duplicates to a surviving consumer.
+//
+// onEvent runs on the matching thread; snapshotAtomic/resendFrom are called
+// from recovery-server connection threads. The internal mutex makes the
+// (snapshot, lastSeq) pair and the resend ring consistent with the live feed.
 template <size_t Levels = (1u << 16)>
 class MarketDataPublisher
 {
  public:
   using MdSink = std::function<void(const MdMessage&)>;
 
-  MarketDataPublisher(MdSink sink, Price tickSize, SymbolId symbol)
-      : sink_(std::move(sink)), symbol_(symbol), book_(tickSize)
+  // epoch 0 -> mint one; pass a fixed epoch only in tests. resendCapacity
+  // bounds the ring of recent increments the recovery channel can replay.
+  MarketDataPublisher(MdSink sink, Price tickSize, SymbolId symbol, uint64_t epoch = 0,
+                      size_t resendCapacity = 1024)
+      : sink_(std::move(sink)),
+        symbol_(symbol),
+        book_(tickSize),
+        epoch_(epoch != 0 ? epoch : makeEpoch()),
+        resendCapacity_(resendCapacity)
   {
   }
 
   void onEvent(const OutboundEvent& e)
   {
+    std::lock_guard<std::mutex> lk(m_);
     if (const auto* x = std::get_if<OrderAccepted>(&e))
     {
       onAccepted(*x);
@@ -82,28 +118,88 @@ class MarketDataPublisher
     {
       onTriggered(*x);
     }
+    else if (const auto* x = std::get_if<FillHeld>(&e))
+    {
+      onFillHeld(*x);
+    }
+    // FillRejected itself has no direct market impact: when a rejected hold
+    // returns quantity to the book the engine emits OrderModified (combine /
+    // rebuild at the tail) or OrderAccepted (taker residual rests), which the
+    // handlers above apply -- so after any hold/accept/reject sequence the
+    // published depth equals the matching book.
     // OrderRejected: no market impact
   }
 
   // flox NLevelOrderBook: bestBid/bestAsk, bidAtPrice/askAtPrice, consumeAsks/
   // consumeBids (VWAP sweep), isCrossed, spread, mid.
   const flox::NLevelOrderBook<Levels>& book() const noexcept { return book_; }
-  uint64_t seq() const noexcept { return seq_; }
-
-  // Full book snapshot as AddOrder messages -- a late-joining subscriber applies
-  // these, then resumes the incremental feed from `seq()`.
-  std::vector<MdMessage> snapshot() const
+  uint64_t seq() const
   {
-    std::vector<MdMessage> out;
-    out.reserve(orders_.size());
+    std::lock_guard<std::mutex> lk(m_);
+    return seq_;
+  }
+  uint64_t epoch() const noexcept { return epoch_; }  // fixed for the publisher lifetime
+  SymbolId symbol() const noexcept { return symbol_; }
+
+  // Full book snapshot as AddOrder messages (in-process convenience form of
+  // snapshotAtomic; same body, without the (epoch, lastSeq) framing).
+  std::vector<MdMessage> snapshot() const { return snapshotAtomic().orders; }
+
+  // Atomic (snapshot, lastSeq) pair, consistent with the emitted stream: no
+  // increment with seq <= lastSeq is missing from the snapshot and none with
+  // seq > lastSeq is included. A late joiner applies `orders`, then resumes
+  // the incremental feed at lastSeq+1.
+  MdSnapshot snapshotAtomic() const
+  {
+    std::lock_guard<std::mutex> lk(m_);
+    MdSnapshot s;
+    s.epoch = epoch_;
+    s.lastSeq = seq_;
+    s.orders.reserve(orders_.size());
     for (const auto& [id, r] : orders_)
     {
-      out.push_back(MdMessage{MdType::AddOrder, 0, r.symbol, id, r.side, r.price, r.leaves, 0});
+      s.orders.push_back(
+          MdMessage{MdType::AddOrder, 0, r.symbol, id, r.side, r.price, r.leaves, 0, epoch_});
+    }
+    return s;
+  }
+
+  // Replay increments with seq >= fromSeq from the bounded ring. nullopt means
+  // fromSeq is older than the retained tail (or 0): the caller must serve a
+  // snapshot instead. fromSeq past the head returns an empty replay.
+  std::optional<std::vector<MdMessage>> resendFrom(uint64_t fromSeq) const
+  {
+    std::lock_guard<std::mutex> lk(m_);
+    if (fromSeq > seq_)
+    {
+      return std::vector<MdMessage>{};
+    }
+    if (ring_.empty() || fromSeq < ring_.front().seq)
+    {
+      return std::nullopt;
+    }
+    std::vector<MdMessage> out;
+    for (const auto& m : ring_)
+    {
+      if (m.seq >= fromSeq)
+      {
+        out.push_back(m);
+      }
     }
     return out;
   }
 
  private:
+  static uint64_t makeEpoch()
+  {
+    std::random_device rd;
+    const uint64_t now = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
+    const uint64_t e = ((static_cast<uint64_t>(rd()) << 32) | rd()) ^ now;
+    return e != 0 ? e : 1;
+  }
   struct Resting
   {
     SymbolId symbol{};
@@ -137,6 +233,12 @@ class MarketDataPublisher
   void emit(MdMessage m)
   {
     m.seq = ++seq_;
+    m.epoch = epoch_;
+    ring_.push_back(m);
+    if (ring_.size() > resendCapacity_)
+    {
+      ring_.pop_front();
+    }
     sink_(m);
   }
 
@@ -221,6 +323,29 @@ class MarketDataPublisher
     emit(MdMessage{MdType::Triggered, 0, t.symbol, t.id, Side::BUY, t.refPrice, Quantity{}, 0});
   }
 
+  // Last-look hold: the held qty is reserved OUT of the matching book, so the
+  // public level must shrink now -- otherwise the feed advertises size that is
+  // not there (a phantom that would live forever after a reject). The entry is
+  // kept even at zero displayed size: the id is still live (a reject restores
+  // via OrderModified, an accept completes via OrderExecuted).
+  void onFillHeld(const FillHeld& f)
+  {
+    auto it = orders_.find(f.makerId);
+    if (it == orders_.end())
+    {
+      return;
+    }
+    Resting& r = it->second;
+    const Quantity shownAfter = f.makerDisplayAfter;
+    const int64_t levelDelta = shownAfter.raw() - r.leaves.raw();
+    if (levelDelta != 0)
+    {
+      applyLevel(r.side, r.price, Quantity::fromRaw(atPrice(r.side, r.price).raw() + levelDelta));
+    }
+    r.leaves = shownAfter;
+    emit(MdMessage{MdType::Executed, 0, r.symbol, f.makerId, r.side, r.price, shownAfter, 0});
+  }
+
   MdSink sink_;
   SymbolId symbol_{};
   flox::NLevelOrderBook<Levels> book_;
@@ -228,6 +353,10 @@ class MarketDataPublisher
   flox::BookUpdateEvent ev_{res_};
   std::unordered_map<OrderId, Resting> orders_;
   uint64_t seq_{0};
+  uint64_t epoch_{};
+  size_t resendCapacity_{};
+  std::deque<MdMessage> ring_;  // recent increments (seq embedded) for resendFrom
+  mutable std::mutex m_;        // matching thread vs recovery-server threads
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/matcher.h
+++ b/venue/include/flox-venue/matcher.h
@@ -62,13 +62,35 @@ class Matcher
  public:
   explicit Matcher(MatchPolicy policy = MatchPolicy::PriceTimeFifo) noexcept : policy_(policy) {}
 
+  MatchPolicy policy() const noexcept { return policy_; }
+
   using LastLookHook = std::function<void(const RestingOrder& maker, Quantity fill,
                                           const NewOrder& taker)>;
   void setLastLookHook(LastLookHook hook) { onLastLook_ = std::move(hook); }
 
   // Firm-group STP: map an account to a firm/group id so self-trade prevention
   // fires across all accounts of the same firm, not just the same account.
-  void setStpGroup(uint64_t account, uint64_t group) { stpGroup_[account] = group; }
+  // group 0 removes the membership (back to account-level STP), keeping the
+  // table canonical for the checkpoint state hash.
+  void setStpGroup(uint64_t account, uint64_t group)
+  {
+    if (group == 0)
+    {
+      stpGroup_.erase(account);
+    }
+    else
+    {
+      stpGroup_[account] = group;
+    }
+  }
+
+  // Live STP-group table (checkpoint serialization / state hash / clone).
+  const std::unordered_map<uint64_t, uint64_t>& stpGroups() const noexcept { return stpGroup_; }
+
+  // Defensive-path counter: pro-rata allocation met a resting lastLook maker
+  // (possible only when admission was bypassed) and skipped it instead of
+  // filling it as firm. See crossProRata.
+  uint64_t skippedLastLookProRata() const noexcept { return skippedLastLookProRata_; }
 
   MatchOutcome cross(const NewOrder& order, Book& book,
                      const std::function<uint64_t()>& nextTradeId, const EventSink& sink) const
@@ -97,17 +119,36 @@ class Matcher
     // With STP on, exclude same-scope liquidity: it will be canceled/decremented
     // rather than traded, so it cannot fill the FOK -- counting it would let the
     // FOK pass the precheck and then rest with 0 fills after STP removes it.
+    // With last look active, last-look makers are NON-FIRM liquidity: they can
+    // only be held, never guaranteed, so (a) they do not count toward the FOK
+    // precheck and (b) a FOK whose crossing range contains ANY last-look maker
+    // is rejected outright -- the sweep is strict price-time, so a last-look
+    // maker inside the range could be hit before the FOK completes, and a
+    // partial execution followed by a hold would violate all-or-none.
     if (order.tif == TimeInForce::FOK)
     {
-      const Quantity avail =
-          (order.stp == STPMode::None)
-              ? book.availableWithin(order.side, order.price, isMarket)
-              : book.availableWithinExcl(order.side, order.price, isMarket, [&](uint64_t maker)
-                                         { return stpScope(maker) == stpScope(order.accountId); });
-      if (avail < order.quantity)
+      const bool lastLookActive = static_cast<bool>(onLastLook_);
+      const bool stpActive = (order.stp != STPMode::None);
+      auto skipStp = [&](const RestingOrder& m)
+      { return stpActive && stpScope(m.accountId) == stpScope(order.accountId); };
+      auto skipStpOrLastLook = [&](const RestingOrder& m)
+      { return (lastLookActive && m.lastLook) || skipStp(m); };
+      const Quantity firm =
+          book.availableWithinExcl(order.side, order.price, isMarket, skipStpOrLastLook);
+      if (firm < order.quantity)
       {
         out.reject = RejectReason::FillOrKillUnfulfillable;
         return out;
+      }
+      if (lastLookActive)
+      {
+        const Quantity withLastLook =
+            book.availableWithinExcl(order.side, order.price, isMarket, skipStp);
+        if (firm < withLastLook)  // a last-look maker sits inside the crossing range
+        {
+          out.reject = RejectReason::FillOrKillUnfulfillable;
+          return out;
+        }
       }
     }
 
@@ -127,14 +168,16 @@ class Matcher
         switch (order.stp)
         {
           case STPMode::CancelOldest:
-            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention});
+            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention,
+                               m->accountId});
             book.cancel(m->id);
             continue;
           case STPMode::CancelNewest:
             takerCanceledBySTP = true;
             break;
           case STPMode::CancelBoth:
-            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention});
+            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention,
+                               m->accountId});
             book.cancel(m->id);
             takerCanceledBySTP = true;
             break;
@@ -146,7 +189,8 @@ class Matcher
             const Quantity dec = qmin(leaves, restTotal);
             if (!(dec < restTotal))  // resting <= incoming: resting fully removed
             {
-              sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention});
+              sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention,
+                                 m->accountId});
               book.cancel(m->id);
             }
             else  // incoming smaller: reduce resting, incoming fully decremented
@@ -204,9 +248,9 @@ class Matcher
       out.filled += fill;
 
       sink(OrderExecuted{makerId, order.symbol, fill, makerTotalAfter, false,
-                         makerTotalAfter.isZero(), makerPrice, makerDisplayAfter});
+                         makerTotalAfter.isZero(), makerPrice, makerDisplayAfter, makerAccount});
       sink(OrderExecuted{order.id, order.symbol, fill, leaves, true, leaves.isZero(), makerPrice,
-                         leaves});
+                         leaves, order.accountId});
     }
 
     out.leaves = leaves;
@@ -264,8 +308,14 @@ class Matcher
   // resting orders proportionally to size (deterministic floor + FIFO remainder),
   // for instruments with thick display levels. Icebergs ARE refilled here (via
   // consumeById). Scope limitations: STP is treated as None, and last-look is
-  // NOT honoured -- a resting lastLook maker on a pro-rata instrument is filled
-  // immediately rather than held (onLastLook_ fires only on the FIFO path).
+  // NOT honoured. The engine refuses lastLook orders on pro-rata instruments
+  // at admission (RejectReason::LastLookUnsupported), so a lastLook maker can
+  // only appear here if the caller bypassed validate(). DEFENSIVE PATH: such
+  // a maker is NOT filled as firm (pro-rata cannot hold a slice, so filling
+  // would fake firmness the maker never granted) -- it is skipped, the
+  // skippedLastLookProRata counter is bumped, and the allocation runs over
+  // the remaining (firm) participants of the level unchanged. A level whose
+  // firm size is zero stops the sweep.
   MatchOutcome crossProRata(const NewOrder& order, Book& book,
                             const std::function<uint64_t()>& nextTradeId,
                             const EventSink& sink) const
@@ -314,10 +364,22 @@ class Matcher
       {
         break;
       }
+      // Defensive: a resting lastLook maker here means validate() was bypassed
+      // (admission rejects the combination). It is non-firm liquidity and is
+      // excluded from the allocation entirely -- see the method comment.
       int64_t tot = 0;
       for (const auto& o : level)
       {
+        if (o.lastLook)
+        {
+          ++skippedLastLookProRata_;
+          continue;
+        }
         tot += o.leaves.raw();
+      }
+      if (tot == 0)
+      {
+        break;  // the whole level is non-firm: nothing to allocate against
       }
       const int64_t want = std::min<int64_t>(leaves.raw(), tot);
 
@@ -325,12 +387,20 @@ class Matcher
       int64_t assigned = 0;
       for (size_t i = 0; i < level.size(); ++i)
       {
+        if (level[i].lastLook)
+        {
+          continue;  // excluded participant keeps alloc 0
+        }
         alloc[i] = static_cast<int64_t>(static_cast<__int128>(want) * level[i].leaves.raw() / tot);
         assigned += alloc[i];
       }
       int64_t leftover = want - assigned;  // deterministic FIFO remainder
       for (size_t i = 0; i < level.size() && leftover > 0; ++i)
       {
+        if (level[i].lastLook)
+        {
+          continue;
+        }
         const int64_t room = level[i].leaves.raw() - alloc[i];
         if (room > 0)
         {
@@ -360,9 +430,10 @@ class Matcher
         leaves = Quantity::fromRaw(leaves.raw() - alloc[i]);
         out.filled += fill;
         sink(OrderExecuted{makerId, order.symbol, fill, makerTotalAfter, false,
-                           makerTotalAfter.isZero(), levelPrice, makerDisplayAfter});
+                           makerTotalAfter.isZero(), levelPrice, makerDisplayAfter,
+                           level[i].accountId});
         sink(OrderExecuted{order.id, order.symbol, fill, leaves, true, leaves.isZero(), levelPrice,
-                           leaves});
+                           leaves, order.accountId});
       }
       if (want < tot)
       {
@@ -395,6 +466,8 @@ class Matcher
   MatchPolicy policy_;
   LastLookHook onLastLook_;
   std::unordered_map<uint64_t, uint64_t> stpGroup_;  // account -> firm group (empty = account-level STP)
+  // mutable: cross() is const; this is a diagnostic counter, not matching state.
+  mutable uint64_t skippedLastLookProRata_{0};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/matching_book.h
+++ b/venue/include/flox-venue/matching_book.h
@@ -145,6 +145,31 @@ class MatchingBook
     return copy;
   }
 
+  // Enumerate every resting order in canonical book order: bids best-first,
+  // then asks best-first, FIFO within each level. Used by the venue checkpoint
+  // serializer and state hash (not a hot path); the canonical order is what
+  // makes a snapshot file deterministic and tail-appending restores exact.
+  template <class Fn>
+  void forEachOrder(Fn&& fn) const
+  {
+    for (const auto& [p, lst] : bids_)
+    {
+      (void)p;
+      for (const auto& o : lst)
+      {
+        fn(o);
+      }
+    }
+    for (const auto& [p, lst] : asks_)
+    {
+      (void)p;
+      for (const auto& o : lst)
+      {
+        fn(o);
+      }
+    }
+  }
+
   // Aggregated (price, total qty) per level, best-first (bids descending, asks
   // ascending). Used by the auction uncross.
   void levels(Side side, std::vector<std::pair<Price, Quantity>>& out) const
@@ -259,14 +284,16 @@ class MatchingBook
   // FOK all-or-none precheck.
   Quantity availableWithin(Side takerSide, Price limit, bool isMarket) const
   {
-    return availableWithinExcl(takerSide, limit, isMarket, [](uint64_t)
+    return availableWithinExcl(takerSide, limit, isMarket, [](const RestingOrder&)
                                { return false; });
   }
 
-  // availableWithin, skipping makers for which skip(acct) is true. An STP-aware
+  // availableWithin, skipping makers for which skip(order) is true. An STP-aware
   // FOK precheck uses this: same-STP-scope liquidity can never fill the taker (it
   // is canceled/decremented, not traded), so it must not count toward "can this
-  // order fully fill" -- otherwise a FOK+STP rests instead of being killed.
+  // order fully fill" -- otherwise a FOK+STP rests instead of being killed. The
+  // predicate sees the whole resting order so non-firm (last-look) liquidity can
+  // be excluded the same way.
   template <class Skip>
   Quantity availableWithinExcl(Side takerSide, Price limit, bool isMarket, Skip skip) const
   {
@@ -281,7 +308,7 @@ class MatchingBook
         }
         for (const auto& o : lst)
         {
-          if (!skip(o.accountId))
+          if (!skip(o))
           {
             total += o.leaves + o.hidden;  // hidden reserve is real liquidity
           }
@@ -298,7 +325,7 @@ class MatchingBook
         }
         for (const auto& o : lst)
         {
-          if (!skip(o.accountId))
+          if (!skip(o))
           {
             total += o.leaves + o.hidden;
           }

--- a/venue/include/flox-venue/matching_engine.h
+++ b/venue/include/flox-venue/matching_engine.h
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
 #include "flox-venue/ledger.h"
 #include "flox-venue/matcher.h"
 #include "flox-venue/matching_book.h"
@@ -18,9 +20,12 @@
 #include "flox/backtest/fee_schedule.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <deque>
+#include <memory>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
@@ -30,13 +35,8 @@
 namespace flox::venue
 {
 
-// Reference price a conditional order (stop / take-profit / trailing) triggers
-// against. Spot: last trade price. Derivatives: usually the mark price.
-enum class TriggerRef : uint8_t
-{
-  Last = 0,
-  Mark = 1,
-};
+// TriggerRef (the conditional-order reference price selector) lives in
+// messages.h next to the SetTriggerRef command that carries it.
 
 struct SymbolConfig
 {
@@ -97,7 +97,11 @@ class MatchingEngine
       }
       else if (const auto* x = std::get_if<OrderExecuted>(&e))
       {
-        if (x->complete)
+        // Hold-aware: an order can report complete while a last-look hold on it
+        // is still pending (its held slice already left `leaves`); releasing the
+        // whole reservation here would strand the eventual accept with nothing
+        // to settle from. Cleanup is deferred to resolveHeld in that case.
+        if (x->complete && !hasHoldsFor(x->id))
         {
           releaseReservation(x->id);  // free any over-reserved remainder
           forgetOrder(x->id);
@@ -115,9 +119,15 @@ class MatchingEngine
       }
     };
 
-    // Last look: the matcher hands each held fill here.
-    matcher_.setLastLookHook([this](const RestingOrder& maker, Quantity fill, const NewOrder& taker)
-                             { createHeld(maker, fill, taker); });
+    // Last look: the matcher hands each held fill here. lastLookWindowNs == 0
+    // means last look is disabled venue-wide (as the config promises): the hook
+    // is never installed, so a lastLook-flagged maker fills like any other.
+    if (cfg_.lastLookWindowNs > 0)
+    {
+      matcher_.setLastLookHook(
+          [this](const RestingOrder& maker, Quantity fill, const NewOrder& taker)
+          { createHeld(maker, fill, taker); });
+    }
   }
 
   void submit(const InboundCommand& cmd) { submit(cmd, ++timeCounter_); }
@@ -126,6 +136,18 @@ class MatchingEngine
   // windows deterministically.
   void submit(const InboundCommand& cmd, int64_t tsNs)
   {
+    // Snapshot-only records are forbidden in live traffic: a client that could
+    // sneak a Restore* through submit would "restore" itself an order or a
+    // balance. They apply exclusively through applySnapshotRecord (recovery).
+    // Dropping (not rejecting per-order) is deterministic on replay too: a
+    // journaled stray record is dropped identically.
+    if (isSnapshotRecord(cmd))
+    {
+      ++droppedSnapshotRecords_;
+      std::fprintf(stderr, "flox-venue: dropped snapshot-only record (tag %zu) from live traffic\n",
+                   cmd.index());
+      return;
+    }
     now_ = tsNs;
     if (cfg_.halted && haltUntil_ > 0 && now_ >= haltUntil_)
     {
@@ -170,10 +192,65 @@ class MatchingEngine
     {
       onAdmin(ad->action);  // sequenced -> journaled -> replayed (auction/halt reproduce)
     }
+    else if (const auto* d = std::get_if<Deposit>(&cmd))
+    {
+      onDeposit(*d);  // journaled genesis: replay from an empty ledger reproduces balances
+    }
+    else if (const auto* w = std::get_if<Withdraw>(&cmd))
+    {
+      onWithdraw(*w);
+    }
+    else if (const auto* sb = std::get_if<SetBands>(&cmd))
+    {
+      if (sb->symbol == cfg_.id)
+      {
+        setPriceBand(sb->minPrice, sb->maxPrice);  // sequenced -> journaled -> replayed
+      }
+    }
+    else if (const auto* st = std::get_if<SetTriggerRef>(&cmd))
+    {
+      if (st->symbol == cfg_.id)
+      {
+        setTriggerRef(st->ref);  // sequenced -> journaled -> replayed
+      }
+    }
+    else if (const auto* sg = std::get_if<SetStpGroup>(&cmd))
+    {
+      if (sg->symbol == cfg_.id)
+      {
+        setStpGroup(sg->account, sg->group);  // sequenced -> journaled -> replayed
+      }
+    }
+    else if (std::get_if<TimeTick>(&cmd) != nullptr)
+    {
+      // Pure time sweep: expireHolds/expireOrders already ran above. Sequenced
+      // and journaled so a replay reproduces the same timeouts (see tick()).
+    }
+    // ListInstrument is consumed above the engine (InstrumentRegistry / router);
+    // an existing engine has nothing to do with its own listing record.
     processOco();
     repeg();
     mmpEnforce();
   }
+
+  // Idempotent time sweep: advance engine time and resolve overdue last-look
+  // holds and GTD expiries without any order-flow traffic (a quiet symbol must
+  // not hold liquidity forever). NOT journaled here -- when the engine runs
+  // under a SequencedShard, route the sweep through the command stream as a
+  // TimeTick so a replay reproduces the timeouts (the shard's idle sweeper does
+  // exactly that). Direct callers (tests, embedded use) may call this freely.
+  void tick(int64_t nowNs)
+  {
+    if (nowNs > now_)
+    {
+      now_ = nowNs;
+    }
+    expireHolds();
+    expireOrders();
+  }
+
+  // Open last-look holds (approximate cross-thread gauge for the idle sweeper).
+  uint64_t openHolds() const noexcept { return heldOpen_.load(std::memory_order_relaxed); }
 
   void setFeeSchedule(flox::FeeSchedule fees)
   {
@@ -344,6 +421,12 @@ class MatchingEngine
   // fields (symbol id, tick size, assets, linearPerp) stay fixed. Applies to
   // subsequent orders; existing resting orders are unaffected.
   void setLuldBps(int32_t bps) noexcept { cfg_.luldBps = bps; }
+  void setTriggerRef(TriggerRef ref) noexcept { cfg_.triggerRef = ref; }
+  void setPriceBand(Price minPrice, Price maxPrice) noexcept
+  {
+    cfg_.minPrice = minPrice;
+    cfg_.maxPrice = maxPrice;
+  }
   void setFatFinger(Quantity maxOrderQty, Volume maxOrderNotional) noexcept
   {
     cfg_.maxOrderQty = maxOrderQty;
@@ -358,8 +441,15 @@ class MatchingEngine
   }
 
   // Firm-group STP: register an account under a firm/group id so self-trade
-  // prevention fires across all of a firm's accounts, not just the same account.
+  // prevention fires across all of a firm's accounts, not just the same account
+  // (group 0 removes the membership). Runtime mutations MUST arrive as the
+  // sequenced SetStpGroup command (journaled, snapshot-carried, hashed) --
+  // this direct setter is for pre-start() wiring and the recovery path.
   void setStpGroup(uint64_t account, uint64_t group) { matcher_.setStpGroup(account, group); }
+
+  // Pro-rata defensive-path counter (see Matcher::crossProRata): a resting
+  // lastLook maker met by a pro-rata allocation was skipped, not filled firm.
+  uint64_t skippedLastLookProRata() const noexcept { return matcher_.skippedLastLookProRata(); }
 
   // Operator emergency stop: halt the symbol (reject new orders) AND pull the
   // entire resting book -- every live limit order and pending conditional --
@@ -367,6 +457,9 @@ class MatchingEngine
   void haltAndCancelAll()
   {
     cfg_.halted = true;
+    // Resolve every open hold first: restored quantity lands back on the book
+    // and is then swept by the cancel loop below, so nothing survives the halt.
+    rejectAllHolds();
     std::vector<OrderId> resting;
     for (const auto& [acct, ids] : byAccount_)
     {
@@ -378,17 +471,19 @@ class MatchingEngine
     {
       if (book_.cancel(id).has_value())
       {
+        const uint64_t acct = ownerOf(id);
         releaseReservation(id);
         forgetOrder(id);
-        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt});
+        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt, acct});
       }
     }
     for (OrderId id : stops_.ids())
     {
+      const uint64_t acct = stops_.accountOf(id);
       if (stops_.cancel(id))
       {
         releaseReservation(id);
-        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt});
+        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt, acct});
       }
     }
   }
@@ -543,10 +638,627 @@ class MatchingEngine
       // Post-consume displayed peak (b2/a2 already refilled) for the public feed.
       const Quantity bDisp = b2 ? b2->leaves : Quantity{};
       const Quantity aDisp = a2 ? a2->leaves : Quantity{};
-      emit_(OrderExecuted{bidId, cfg_.id, fill, bl, false, bl.isZero(), P, bDisp});
-      emit_(OrderExecuted{askId, cfg_.id, fill, al, false, al.isZero(), P, aDisp});
+      emit_(OrderExecuted{bidId, cfg_.id, fill, bl, false, bl.isZero(), P, bDisp, bAcct});
+      emit_(OrderExecuted{askId, cfg_.id, fill, al, false, al.isZero(), P, aDisp, aAcct});
     }
   }
+
+  // ---- checkpoint (journal-format snapshot) ----
+
+  // Deterministic digest of the full engine state over a canonical traversal
+  // (event_hash-style FNV fold): instrument config and market state, sequence
+  // counters, book (price levels best-first, FIFO within each level), stops,
+  // pegs, open holds, positions, MMP config, clientOrderId dedup sets and
+  // ledger balances (available AND reserved per account x asset). Written into
+  // SnapshotBegin/SnapshotEnd and re-verified on load: a mismatch marks the
+  // snapshot corrupt and recovery falls back a generation.
+  uint64_t stateHash() const
+  {
+    uint64_t h = 0xcbf29ce484222325ULL;
+    h = mix(h, cfg_.id);
+    h = mix(h, cfg_.halted ? 1U : 0U);
+    h = mix(h, static_cast<uint64_t>(cfg_.minPrice.raw()));
+    h = mix(h, static_cast<uint64_t>(cfg_.maxPrice.raw()));
+    h = mix(h, static_cast<uint64_t>(cfg_.triggerRef));
+    h = mix(h, auctionMode_ ? 1U : 0U);
+    h = mix(h, static_cast<uint64_t>(haltUntil_));
+    h = mix(h, hasLast_ ? 1U : 0U);
+    h = mix(h, static_cast<uint64_t>(lastPrice_.raw()));
+    h = mix(h, hasMark_ ? 1U : 0U);
+    h = mix(h, static_cast<uint64_t>(markPrice_.raw()));
+    h = mix(h, tradeSeq_);
+    h = mix(h, heldSeq_);
+    h = mix(h, static_cast<uint64_t>(timeCounter_));
+    h = mix(h, static_cast<uint64_t>(now_));
+
+    book_.forEachOrder(
+        [&](const RestingOrder& o)
+        {
+          h = mix(h, 0xB001U);
+          h = mix(h, o.id);
+          h = mix(h, o.accountId);
+          h = mix(h, static_cast<uint64_t>(o.price.raw()));
+          h = mix(h, static_cast<uint64_t>(o.leaves.raw()));
+          h = mix(h, static_cast<uint64_t>(o.hidden.raw()));
+          h = mix(h, static_cast<uint64_t>(o.peak.raw()));
+          h = mix(h, static_cast<uint64_t>(o.side));
+          h = mix(h, o.lastLook ? 1U : 0U);
+          h = mix(h, o.reduceOnly ? 1U : 0U);
+          h = mix(h, static_cast<uint64_t>(expiryOf(o.id)));
+          h = mix(h, ocoOf(o.id));
+        });
+
+    for (const auto& [o, trig] : sortedStops())
+    {
+      h = mix(h, 0xB002U);
+      h = mix(h, o.id);
+      h = mix(h, o.accountId);
+      h = mix(h, static_cast<uint64_t>(o.side));
+      h = mix(h, static_cast<uint64_t>(o.type));
+      h = mix(h, static_cast<uint64_t>(o.price.raw()));
+      h = mix(h, static_cast<uint64_t>(o.quantity.raw()));
+      h = mix(h, static_cast<uint64_t>(o.tif));
+      h = mix(h, static_cast<uint64_t>(o.visibleQuantity.raw()));
+      h = mix(h, static_cast<uint64_t>(o.triggerPrice.raw()));
+      h = mix(h, static_cast<uint64_t>(o.trailingOffset.raw()));
+      h = mix(h, o.lastLook ? 1U : 0U);
+      h = mix(h, o.reduceOnly ? 1U : 0U);
+      h = mix(h, static_cast<uint64_t>(o.expiryNs));
+      h = mix(h, o.ocoGroup);
+      h = mix(h, static_cast<uint64_t>(trig.raw()));
+    }
+
+    for (OrderId id : sortedKeys(pegged_))
+    {
+      const Peg& p = pegged_.at(id);
+      h = mix(h, 0xB003U);
+      h = mix(h, id);
+      h = mix(h, static_cast<uint64_t>(p.side));
+      h = mix(h, static_cast<uint64_t>(p.ref));
+      h = mix(h, static_cast<uint64_t>(p.offsetRaw));
+    }
+
+    for (uint64_t hid : sortedKeys(held_))
+    {
+      const Held& x = held_.at(hid);
+      h = mix(h, 0xB004U);
+      h = mix(h, x.id);
+      h = mix(h, x.taker);
+      h = mix(h, x.takerAccount);
+      h = mix(h, static_cast<uint64_t>(x.takerSide));
+      h = mix(h, x.maker);
+      h = mix(h, x.makerAccount);
+      h = mix(h, static_cast<uint64_t>(x.price.raw()));
+      h = mix(h, static_cast<uint64_t>(x.qty.raw()));
+      h = mix(h, static_cast<uint64_t>(x.deadline));
+      h = mix(h, static_cast<uint64_t>(x.takerTif));
+      h = mix(h, static_cast<uint64_t>(x.takerType));
+      h = mix(h, static_cast<uint64_t>(x.takerPrice.raw()));
+      h = mix(h, static_cast<uint64_t>(x.takerExpiryNs));
+      h = mix(h, x.makerReduceOnly ? 1U : 0U);
+      h = mix(h, x.takerReduceOnly ? 1U : 0U);
+      // Live-tracking truth of the maker (see RestoreHeld::makerTracked).
+      h = mix(h, orderAccount_.count(x.maker) != 0 ? 1U : 0U);
+    }
+
+    for (OrderId id : sortedKeys(reserve_))
+    {
+      const Reservation& r = reserve_.at(id);
+      h = mix(h, 0xB009U);
+      h = mix(h, id);
+      h = mix(h, r.account);
+      h = mix(h, r.asset);
+      h = mix(h, static_cast<uint64_t>(r.side));
+      h = mix(h, static_cast<uint64_t>(r.limitPriceRaw));
+      h = mixAmount(h, r.reservedRaw);
+    }
+
+    for (uint64_t acct : sortedKeys(positions_))
+    {
+      const Position& p = positions_.at(acct);
+      h = mix(h, 0xB005U);
+      h = mix(h, acct);
+      h = mix(h, static_cast<uint64_t>(p.qtyRaw));
+      h = mix(h, static_cast<uint64_t>(p.entryRaw));
+      h = mixAmount(h, p.margin);
+    }
+
+    for (uint64_t acct : sortedKeys(mmpCfg_))
+    {
+      const MmpCfg& c = mmpCfg_.at(acct);
+      h = mix(h, 0xB006U);
+      h = mix(h, acct);
+      h = mix(h, static_cast<uint64_t>(c.qtyLimit.raw()));
+      h = mix(h, static_cast<uint64_t>(c.windowNs));
+    }
+
+    // MMP sliding-window fills, deque (time) order. An EMPTY window contributes
+    // nothing, so it is indistinguishable from absence -- which also keeps
+    // pre-window-serialization snapshots (that restored windows empty) hashing
+    // identically when the windows really were empty.
+    for (uint64_t acct : sortedKeys(mmpFills_))
+    {
+      const MmpWindow& w = mmpFills_.at(acct);
+      if (w.fills.empty())
+      {
+        continue;
+      }
+      h = mix(h, 0xB00AU);
+      h = mix(h, acct);
+      for (const auto& [ts, q] : w.fills)
+      {
+        h = mix(h, static_cast<uint64_t>(ts));
+        h = mix(h, static_cast<uint64_t>(q.raw()));
+      }
+    }
+
+    // Firm-group STP table (feeds matching decisions, journaled as SetStpGroup).
+    if (const auto& groups = matcher_.stpGroups(); !groups.empty())
+    {
+      for (uint64_t acct : sortedKeys(groups))
+      {
+        h = mix(h, 0xB00BU);
+        h = mix(h, acct);
+        h = mix(h, groups.at(acct));
+      }
+    }
+
+    for (uint64_t acct : sortedKeys(clientOrderIds_))
+    {
+      h = mix(h, 0xB007U);
+      h = mix(h, acct);
+      const auto& seen = clientOrderIds_.at(acct);
+      std::vector<uint64_t> ids(seen.begin(), seen.end());
+      std::sort(ids.begin(), ids.end());
+      for (uint64_t id : ids)
+      {
+        h = mix(h, id);
+      }
+    }
+
+    if (ledger_ != nullptr)
+    {
+      std::vector<std::tuple<uint64_t, AssetId, Amount, Amount>> bals;
+      ledger_->forEachBalanceSplit(
+          [&](uint64_t acct, AssetId asset, Amount avail, Amount rsvd)
+          {
+            if (avail != 0 || rsvd != 0)  // a zeroed entry is indistinguishable from absence
+            {
+              bals.emplace_back(acct, asset, avail, rsvd);
+            }
+          });
+      std::sort(bals.begin(), bals.end(),
+                [](const auto& a, const auto& b)
+                {
+                  return std::get<0>(a) != std::get<0>(b) ? std::get<0>(a) < std::get<0>(b)
+                                                          : std::get<1>(a) < std::get<1>(b);
+                });
+      for (const auto& [acct, asset, avail, rsvd] : bals)
+      {
+        h = mix(h, 0xB008U);
+        h = mix(h, acct);
+        h = mix(h, asset);
+        h = mixAmount(h, avail);
+        h = mixAmount(h, rsvd);
+      }
+    }
+    return h;
+  }
+
+  // Digest of the CONSTRUCTOR configuration -- the structural parameters a
+  // snapshot cannot restore and recovery cannot verify through stateHash
+  // alone: fixed-point scales, assets, tick/lot/minQty, last-look window,
+  // perp mode and the match policy. Written into SnapshotBegin and compared
+  // on load: restoring raw fixed-point state into an engine constructed with
+  // different scales (or a different policy) would silently reinterpret every
+  // number, so a mismatch rejects the snapshot. Mutable knobs (bands, halted,
+  // triggerRef, LULD, fat-finger, margins, position/order caps) are excluded:
+  // they are carried by the snapshot itself or owned by the control plane.
+  uint64_t configHash() const
+  {
+    uint64_t h = 0xcbf29ce484222325ULL;
+    h = mix(h, 0xC0F1U);
+    h = mix(h, cfg_.id);
+    h = mix(h, static_cast<uint64_t>(cfg_.tickSize.raw()));
+    h = mix(h, static_cast<uint64_t>(cfg_.lotSize.raw()));
+    h = mix(h, static_cast<uint64_t>(cfg_.minQty.raw()));
+    h = mix(h, cfg_.baseAsset);
+    h = mix(h, cfg_.quoteAsset);
+    h = mix(h, static_cast<uint64_t>(cfg_.lastLookWindowNs));
+    h = mix(h, cfg_.lastLookAcceptOnTimeout ? 1U : 0U);
+    h = mix(h, cfg_.linearPerp ? 1U : 0U);
+    h = mix(h, cfg_.autoDeleverage ? 1U : 0U);
+    h = mix(h, static_cast<uint64_t>(cfg_.priceScale));
+    h = mix(h, static_cast<uint64_t>(cfg_.qtyScale));
+    h = mix(h, static_cast<uint64_t>(matcher_.policy()));
+    return h;
+  }
+
+  // Serialize the engine into `out` as a journal-format snapshot: SnapshotBegin
+  // (with the constructor-config hash), existing config records
+  // (ListInstrument/SetBands/SetTriggerRef/SetStpGroup/AdminCmd), one
+  // RestoreBalance per (account, asset) carrying the EXACT signed
+  // available/reserved split, then the Restore* records in canonical order,
+  // closed by SnapshotEnd. The canonical traversal (levels by price
+  // best-first, FIFO within; everything else sorted by key) makes the file
+  // byte-for-byte deterministic, and tail-appending RestoreOrder application
+  // reproduces the exact book layout. Because balances restore exactly,
+  // RestoreReservation / RestorePosition rebuild only the engine-side tables
+  // on apply (no ledger re-reservation); the records still carry the exact
+  // live amounts (history-dependent -- partial fills, held slices, STP; a
+  // formula re-derivation is NOT faithful).
+  void writeSnapshot(Journal& out) const
+  {
+    const int64_t ts = now_;
+    const uint64_t h = stateHash();
+    out.append(InboundCommand{SnapshotBegin{kSnapshotFormatVersion, ts, h, configHash()}}, ts);
+
+    out.append(InboundCommand{ListInstrument{cfg_.id, cfg_.tickSize, cfg_.lotSize, cfg_.minPrice,
+                                             cfg_.maxPrice}},
+               ts);
+    out.append(InboundCommand{SetBands{cfg_.id, cfg_.minPrice, cfg_.maxPrice}}, ts);
+    out.append(InboundCommand{SetTriggerRef{cfg_.id, cfg_.triggerRef}}, ts);
+    // STP groups are engine state journaled as SetStpGroup commands; the
+    // snapshot re-emits the live table as the same records (config section,
+    // applied through the ordinary submit path on load).
+    if (const auto& groups = matcher_.stpGroups(); !groups.empty())
+    {
+      for (uint64_t acct : sortedKeys(groups))
+      {
+        out.append(InboundCommand{SetStpGroup{cfg_.id, acct, groups.at(acct)}}, ts);
+      }
+    }
+    out.append(InboundCommand{AdminCmd{cfg_.id, cfg_.halted ? AdminAction::Halt
+                                                            : AdminAction::Resume}},
+               ts);
+    if (auctionMode_)
+    {
+      out.append(InboundCommand{AdminCmd{cfg_.id, AdminAction::BeginPreOpen}}, ts);
+    }
+
+    if (ledger_ != nullptr)
+    {
+      // Exact signed split per (account, asset): every live moment is
+      // representable, including a negative wallet mid-liquidation and
+      // non-positive totals (states the v1 Deposit-total encoding could not
+      // express, forcing recovery a generation back). A fully zero entry is
+      // skipped -- indistinguishable from absence, matching stateHash.
+      std::vector<std::tuple<uint64_t, AssetId, Amount, Amount>> bals;
+      ledger_->forEachBalanceSplit(
+          [&](uint64_t acct, AssetId asset, Amount avail, Amount rsvd)
+          {
+            if (avail != 0 || rsvd != 0)
+            {
+              bals.emplace_back(acct, asset, avail, rsvd);
+            }
+          });
+      std::sort(bals.begin(), bals.end(),
+                [](const auto& a, const auto& b)
+                {
+                  return std::get<0>(a) != std::get<0>(b) ? std::get<0>(a) < std::get<0>(b)
+                                                          : std::get<1>(a) < std::get<1>(b);
+                });
+      for (const auto& [acct, asset, avail, rsvd] : bals)
+      {
+        out.append(InboundCommand{RestoreBalance{acct, asset, avail, rsvd}}, ts);
+      }
+    }
+
+    for (uint64_t acct : sortedKeys(mmpCfg_))
+    {
+      const MmpCfg& c = mmpCfg_.at(acct);
+      out.append(InboundCommand{RestoreMmpCfg{acct, c.qtyLimit, c.windowNs}}, ts);
+    }
+
+    // MMP sliding-window fills, exact, in deque (time) order -- a maker one
+    // fill from its limit stays one fill from it across recovery.
+    for (uint64_t acct : sortedKeys(mmpFills_))
+    {
+      const MmpWindow& w = mmpFills_.at(acct);
+      if (w.fills.empty())
+      {
+        continue;
+      }
+      RestoreMmpFills batch{};
+      batch.account = acct;
+      for (const auto& [fts, q] : w.fills)
+      {
+        batch.tsNs[batch.count] = fts;
+        batch.qtyRaw[batch.count] = q.raw();
+        if (++batch.count == kMmpFillBatch)
+        {
+          out.append(InboundCommand{batch}, ts);
+          batch = RestoreMmpFills{};
+          batch.account = acct;
+        }
+      }
+      if (batch.count > 0)
+      {
+        out.append(InboundCommand{batch}, ts);
+      }
+    }
+
+    for (uint64_t acct : sortedKeys(clientOrderIds_))
+    {
+      const auto& seen = clientOrderIds_.at(acct);
+      std::vector<uint64_t> ids(seen.begin(), seen.end());
+      std::sort(ids.begin(), ids.end());
+      RestoreClOrdIds batch{};
+      batch.account = acct;
+      for (uint64_t id : ids)
+      {
+        batch.ids[batch.count++] = id;
+        if (batch.count == kClOrdIdBatch)
+        {
+          out.append(InboundCommand{batch}, ts);
+          batch = RestoreClOrdIds{};
+          batch.account = acct;
+        }
+      }
+      if (batch.count > 0)
+      {
+        out.append(InboundCommand{batch}, ts);
+      }
+    }
+
+    book_.forEachOrder(
+        [&](const RestingOrder& o)
+        {
+          RestoreOrder r{o.id, o.accountId, o.price, o.leaves, o.side, o.hidden,
+                         o.peak, o.lastLook, o.reduceOnly};
+          r.expiryNs = expiryOf(o.id);
+          r.ocoGroup = ocoOf(o.id);
+          out.append(InboundCommand{r}, ts);
+        });
+
+    for (const auto& [o, trig] : sortedStops())
+    {
+      out.append(InboundCommand{RestoreStop{o, trig}}, ts);
+    }
+
+    for (OrderId id : sortedKeys(pegged_))
+    {
+      const Peg& p = pegged_.at(id);
+      out.append(InboundCommand{RestorePeg{id, p.side, p.ref, p.offsetRaw}}, ts);
+    }
+
+    for (uint64_t acct : sortedKeys(positions_))
+    {
+      const Position& p = positions_.at(acct);
+      out.append(InboundCommand{RestorePosition{acct, p.qtyRaw, p.entryRaw, p.margin}}, ts);
+    }
+
+    for (uint64_t hid : sortedKeys(held_))
+    {
+      const Held& x = held_.at(hid);
+      RestoreHeld r{x.id, x.taker, x.takerAccount, x.takerSide, x.maker,
+                    x.makerAccount, x.price, x.qty, x.deadline, x.takerTif,
+                    x.takerType, x.takerPrice, x.takerExpiryNs, x.makerReduceOnly,
+                    x.takerReduceOnly};
+      r.makerTracked = orderAccount_.count(x.maker) != 0;
+      out.append(InboundCommand{r}, ts);
+    }
+
+    for (OrderId id : sortedKeys(reserve_))
+    {
+      const Reservation& r = reserve_.at(id);
+      out.append(
+          InboundCommand{RestoreReservation{id, r.account, r.asset, r.side, r.limitPriceRaw,
+                                            r.reservedRaw}},
+          ts);
+    }
+
+    SnapshotEnd end{};
+    end.stateHash = h;
+    end.tradeSeq = tradeSeq_;
+    end.heldSeq = heldSeq_;
+    end.timeCounter = timeCounter_;
+    end.nowNs = now_;
+    end.mdEpoch = 0;  // the engine carries no MD epoch today
+    end.lastPriceRaw = lastPrice_.raw();
+    end.hasLast = hasLast_;
+    end.markPriceRaw = markPrice_.raw();
+    end.hasMark = hasMark_;
+    end.haltUntilNs = haltUntil_;
+    out.append(InboundCommand{end}, ts);
+  }
+
+  // Recovery-only application of one snapshot record. Existing journaled
+  // record types (config, deposits) route through the normal submit path;
+  // Restore* records rebuild state directly, WITHOUT a matching pass -- the
+  // snapshot book is uncrossed by invariant, and a crossing RestoreOrder
+  // marks the snapshot corrupt. Returns false when the record proves the
+  // snapshot corrupt (version mismatch, crossed book, un-backable
+  // reservation, hash mismatch at SnapshotEnd); the caller then discards the
+  // generation. NEVER wire this to live traffic: submit() drops snapshot tags
+  // for exactly that reason.
+  bool applySnapshotRecord(const InboundCommand& cmd, int64_t tsNs)
+  {
+    if (const auto* b = std::get_if<SnapshotBegin>(&cmd))
+    {
+      if (b->formatVersion != kSnapshotFormatVersion)
+      {
+        return false;
+      }
+      // Constructor-config guard: a snapshot written by an engine with other
+      // structural parameters (scales, assets, policy, ...) must not restore
+      // -- the raw fixed-point state would be silently reinterpreted.
+      if (b->configHash != 0 && b->configHash != configHash())
+      {
+        std::fprintf(stderr,
+                     "flox-venue: snapshot rejected for symbol %llu: constructor-config hash "
+                     "mismatch (snapshot %016llx, engine %016llx) -- scales/assets/policy differ "
+                     "from the writer's\n",
+                     static_cast<unsigned long long>(cfg_.id),
+                     static_cast<unsigned long long>(b->configHash),
+                     static_cast<unsigned long long>(configHash()));
+        return false;
+      }
+      return true;
+    }
+    if (const auto* r = std::get_if<RestoreOrder>(&cmd))
+    {
+      return applyRestoreOrder(*r);
+    }
+    if (const auto* r = std::get_if<RestoreStop>(&cmd))
+    {
+      return applyRestoreStop(*r);
+    }
+    if (const auto* r = std::get_if<RestorePeg>(&cmd))
+    {
+      if (!book_.contains(r->id))
+      {
+        return false;  // a peg spec must reference a restored resting order
+      }
+      pegged_[r->id] = Peg{r->side, r->ref, r->offsetRaw};
+      return true;
+    }
+    if (const auto* r = std::get_if<RestoreHeld>(&cmd))
+    {
+      return applyRestoreHeld(*r);
+    }
+    if (const auto* r = std::get_if<RestorePosition>(&cmd))
+    {
+      return applyRestorePosition(*r);
+    }
+    if (const auto* r = std::get_if<RestoreMmpCfg>(&cmd))
+    {
+      // Fill windows arrive separately as RestoreMmpFills records (exact
+      // restore); a snapshot without them restores the windows empty.
+      mmpCfg_[r->account] = MmpCfg{r->qtyLimit, r->windowNs};
+      return true;
+    }
+    if (const auto* r = std::get_if<RestoreMmpFills>(&cmd))
+    {
+      if (r->count > kMmpFillBatch)
+      {
+        return false;
+      }
+      auto& w = mmpFills_[r->account];
+      for (uint32_t i = 0; i < r->count; ++i)
+      {
+        w.fills.emplace_back(r->tsNs[i], Quantity::fromRaw(r->qtyRaw[i]));
+        w.sumRaw += r->qtyRaw[i];
+      }
+      return true;
+    }
+    if (const auto* r = std::get_if<RestoreBalance>(&cmd))
+    {
+      if (ledger_ != nullptr)
+      {
+        ledger_->restore(r->account, r->asset, r->availableRaw, r->reservedRaw);
+        // Balances are now exact: the RestoreReservation / RestorePosition
+        // records that follow must NOT re-reserve (the reserved side is
+        // already in place); they only rebuild the engine-side tables.
+        exactBalanceRestore_ = true;
+      }
+      return true;
+    }
+    if (const auto* r = std::get_if<RestoreClOrdIds>(&cmd))
+    {
+      if (r->count > kClOrdIdBatch)
+      {
+        return false;
+      }
+      auto& seen = clientOrderIds_[r->account];
+      for (uint32_t i = 0; i < r->count; ++i)
+      {
+        seen.insert(r->ids[i]);
+      }
+      return true;
+    }
+    if (const auto* r = std::get_if<RestoreReservation>(&cmd))
+    {
+      return applyRestoreReservation(*r);
+    }
+    if (const auto* e = std::get_if<SnapshotEnd>(&cmd))
+    {
+      return applySnapshotEnd(*e);
+    }
+    submit(cmd, tsNs);  // existing record types apply through the live path
+    return true;
+  }
+
+  // Live-traffic snapshot-tag drops (observability; see the guard in submit).
+  uint64_t droppedSnapshotRecords() const noexcept { return droppedSnapshotRecords_; }
+
+  // ---- asynchronous checkpoint support ----
+  // A full engine clone taken under the consumer pause; serialization (fsync,
+  // rename, rotation bookkeeping) then runs on a background thread against the
+  // clone while matching continues. fork()-based copy-on-write snapshotting
+  // was considered and REJECTED deliberately: the venue process is
+  // multi-threaded (journal writer semantics aside -- gateway/ingress threads,
+  // the idle sweeper, metrics/monitor threads), and fork() in a multi-threaded
+  // process clones only the calling thread while every lock keeps the state
+  // its holder left it in; a malloc arena lock held by another thread at fork
+  // time deadlocks the child on its first allocation inside writeSnapshot.
+  // An explicit deep copy is O(state) but safe, and the measured pause is the
+  // clone alone, not serialize+fsync.
+  struct SnapshotClone
+  {
+    std::unique_ptr<Ledger> ledger;  // owned deep copy (null: live engine had no ledger)
+    std::unique_ptr<MatchingEngine> engine;
+  };
+
+  // `emptyBook` must be a PRISTINE book instance carrying only construction
+  // config (ladder geometry); the resting orders are re-added canonically
+  // (levels best-first, FIFO within -- forEachOrder order), which reproduces
+  // the exact live layout the same way snapshot restore does. A default
+  // MatchingBook needs no config, so the default argument suffices for it.
+  SnapshotClone cloneForSnapshot(Book emptyBook = Book{}) const
+  {
+    SnapshotClone c;
+    c.engine = std::make_unique<MatchingEngine>(cfg_, EventSink{[](const OutboundEvent&) {}},
+                                                std::move(emptyBook), matcher_.policy());
+    MatchingEngine& e = *c.engine;
+    book_.forEachOrder([&](const RestingOrder& o)
+                       { e.book_.addResting(o.side, o); });
+    e.stops_ = stops_;
+    e.lastPrice_ = lastPrice_;
+    e.hasLast_ = hasLast_;
+    e.markPrice_ = markPrice_;
+    e.hasMark_ = hasMark_;
+    e.tradeSeq_ = tradeSeq_;
+    e.now_ = now_;
+    e.timeCounter_ = timeCounter_;
+    e.orderAccount_ = orderAccount_;
+    e.byAccount_ = byAccount_;
+    e.expiry_ = expiry_;
+    e.orderOco_ = orderOco_;
+    e.ocoMembers_ = ocoMembers_;
+    e.ocoPending_ = ocoPending_;  // empty at a command boundary; copied for completeness
+    e.pegged_ = pegged_;
+    e.fees_ = fees_;
+    e.feesEnabled_ = feesEnabled_;
+    e.mmpCfg_ = mmpCfg_;
+    e.mmpFills_ = mmpFills_;
+    e.mmpBreached_ = mmpBreached_;
+    e.held_ = held_;
+    e.heldSeq_ = heldSeq_;
+    e.heldOpen_.store(e.held_.size(), std::memory_order_relaxed);
+    e.clientOrderIds_ = clientOrderIds_;
+    e.reserve_ = reserve_;
+    e.positions_ = positions_;
+    e.auctionMode_ = auctionMode_;
+    e.haltUntil_ = haltUntil_;
+    for (const auto& [acct, grp] : matcher_.stpGroups())
+    {
+      e.matcher_.setStpGroup(acct, grp);
+    }
+    if (ledger_ != nullptr)
+    {
+      c.ledger = std::make_unique<Ledger>(*ledger_);
+      e.setLedger(c.ledger.get(), venueAccount_);
+    }
+    else
+    {
+      e.venueAccount_ = venueAccount_;
+    }
+    return c;
+  }
+
+  Ledger* ledger() const noexcept { return ledger_; }
+  uint64_t venueAccount() const noexcept { return venueAccount_; }
 
  private:
   RejectReason validate(const NewOrder& o) const
@@ -562,6 +1274,13 @@ class MatchingEngine
     if (o.quantity.raw() <= 0)
     {
       return RejectReason::InvalidQuantity;
+    }
+    // Pro-rata allocation does not honour last look (a held slice cannot be
+    // carved out of a proportional round), so the combination is refused at
+    // admission instead of silently filling the maker as firm.
+    if (o.lastLook && matcher_.policy() == MatchPolicy::ProRata)
+    {
+      return RejectReason::LastLookUnsupported;
     }
     if (!cfg_.minQty.isZero() && o.quantity < cfg_.minQty)
     {
@@ -602,6 +1321,20 @@ class MatchingEngine
     if (book_.contains(o.id) || stops_.contains(o.id))
     {
       return RejectReason::DuplicateOrderId;
+    }
+    // An id referenced by an active last-look hold is still live even when its
+    // order is (fully held) out of the book: a reject will restore quantity
+    // under that id, so a reused id would merge two unrelated orders.
+    if (!held_.empty())
+    {
+      for (const auto& [hid, h] : held_)
+      {
+        (void)hid;
+        if (h.maker == o.id || h.taker == o.id)
+        {
+          return RejectReason::DuplicateOrderId;
+        }
+      }
     }
     return RejectReason::None;
   }
@@ -649,6 +1382,22 @@ class MatchingEngine
 
   void onNew(NewOrder o)
   {
+    // clientOrderId dedup (per account, window = engine session/uptime; see
+    // docs/venue/matching.md). Registered on receipt, BEFORE any other gate:
+    // a resend of an already-seen clOrdId must reject deterministically even
+    // when the first instance has long filled or canceled -- that is the whole
+    // point (double execution after an ambiguous disconnect). clientOrderId 0
+    // means "not set" and is never deduplicated. Replay-safe: the index is
+    // rebuilt by the same submits during journal replay.
+    if (o.clientOrderId != 0)
+    {
+      auto& seen = clientOrderIds_[o.accountId];
+      if (!seen.insert(o.clientOrderId).second)
+      {
+        sink_(OrderRejected{o.id, o.symbol, RejectReason::DuplicateClientOrderId, o.accountId});
+        return;
+      }
+    }
     if (o.ocoGroup > 0)
     {
       orderOco_[o.id] = o.ocoGroup;  // link before matching so a taker fill triggers OCO too
@@ -690,7 +1439,7 @@ class MatchingEngine
       auto it = byAccount_.find(o.accountId);
       if (it != byAccount_.end() && it->second.size() >= cfg_.maxOpenOrders)
       {
-        sink_(OrderRejected{o.id, o.symbol, RejectReason::TooManyOpenOrders});
+        sink_(OrderRejected{o.id, o.symbol, RejectReason::TooManyOpenOrders, o.accountId});
         return;
       }
     }
@@ -701,17 +1450,17 @@ class MatchingEngine
     // a no-op.
     if (const RejectReason r = perpRiskGate(o); r != RejectReason::None)
     {
-      sink_(OrderRejected{o.id, o.symbol, r});
+      sink_(OrderRejected{o.id, o.symbol, r, o.accountId});
       return;
     }
     if (const RejectReason r = validate(o); r != RejectReason::None)
     {
-      sink_(OrderRejected{o.id, o.symbol, r});
+      sink_(OrderRejected{o.id, o.symbol, r, o.accountId});
       return;
     }
     if (!reserveFunds(o))
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::InsufficientFunds});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InsufficientFunds, o.accountId});
       return;  // pre-trade buying-power (ledger reservation or credit hook)
     }
     committed = true;  // past all reject gates: the order will match/rest, and any
@@ -731,7 +1480,7 @@ class MatchingEngine
       ro.reduceOnly = o.reduceOnly;
       book_.addResting(o.side, ro);
       trackResting(o.id, o.accountId);
-      sink_(OrderAccepted{o.id, o.symbol, o.side, restPx, o.quantity, true});
+      sink_(OrderAccepted{o.id, o.symbol, o.side, restPx, o.quantity, true, Quantity{}, o.accountId});
       return;
     }
 
@@ -749,7 +1498,7 @@ class MatchingEngine
           (o.side == Side::SELL && o.price.raw() < luldLo))
       {
         releaseReservation(o.id);
-        sink_(OrderRejected{o.id, o.symbol, RejectReason::LuldBreach});
+        sink_(OrderRejected{o.id, o.symbol, RejectReason::LuldBreach, o.accountId});
         tripLuldHalt();
         return;
       }
@@ -762,14 +1511,14 @@ class MatchingEngine
     if (out.reject != RejectReason::None)
     {
       releaseReservation(o.id);  // post-only-would-cross / FOK-unfulfillable: free the reserve
-      sink_(OrderRejected{o.id, o.symbol, out.reject});
+      sink_(OrderRejected{o.id, o.symbol, out.reject, o.accountId});
       return;
     }
     if (out.residualRests)
     {
       RestingOrder ro{o.id, o.accountId, o.price, out.leaves, o.side};
-      ro.lastLook = o.lastLook;
-      ro.reduceOnly = o.reduceOnly;  // carried so a later modify preserves it
+      ro.lastLook = o.lastLook && cfg_.lastLookWindowNs > 0;  // window 0 = feature off
+      ro.reduceOnly = o.reduceOnly;                           // carried so a later modify preserves it
       if (o.visibleQuantity.raw() > 0 && o.visibleQuantity < out.leaves)
       {
         ro.peak = o.visibleQuantity;    // iceberg: show a peak, hide the rest
@@ -788,15 +1537,16 @@ class MatchingEngine
       }
       // Public feed shows only the displayed peak (ro.leaves); the hidden iceberg
       // reserve (out.leaves - ro.leaves) is not leaked. Non-iceberg: they match.
-      sink_(OrderAccepted{o.id, o.symbol, o.side, o.price, out.leaves, true, ro.leaves});
+      sink_(OrderAccepted{o.id, o.symbol, o.side, o.price, out.leaves, true, ro.leaves, o.accountId});
     }
     else if (out.residualCanceled)
     {
       // The unfilled residual (IOC/FOK/MARKET/STP-newest) never rests, so its
       // buying-power reservation must be released here -- this raw-sink path does
-      // not run the emit_ wrapper's release-on-cancel.
-      releaseReservation(o.id);
-      sink_(OrderCanceled{o.id, o.symbol, out.residualCancelReason});
+      // not run the emit_ wrapper's release-on-cancel. Held slices stay
+      // reserved: their accept still has to settle (reject releases later).
+      releaseReservationExceptHeld(o.id);
+      sink_(OrderCanceled{o.id, o.symbol, out.residualCancelReason, o.accountId});
     }
 
     processTriggers();  // this order's trades may have crossed resting stops
@@ -847,38 +1597,38 @@ class MatchingEngine
   {
     if (o.symbol != cfg_.id)
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::UnknownSymbol});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::UnknownSymbol, o.accountId});
       return false;
     }
     if (cfg_.halted)
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::Halted});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::Halted, o.accountId});
       return false;
     }
     if (o.quantity.raw() <= 0)
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidQuantity});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidQuantity, o.accountId});
       return false;
     }
     const bool trailing = (o.type == OrderType::TRAILING_STOP);
     if (!trailing && o.triggerPrice.raw() <= 0)
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice, o.accountId});
       return false;
     }
     if (trailing && o.trailingOffset.raw() <= 0)
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice, o.accountId});
       return false;
     }
     if (isLimitStop(o.type) && o.price.raw() <= 0)
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InvalidPrice, o.accountId});
       return false;
     }
     if (book_.contains(o.id) || stops_.contains(o.id))
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::DuplicateOrderId});
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::DuplicateOrderId, o.accountId});
       return false;
     }
 
@@ -897,8 +1647,9 @@ class MatchingEngine
       initTrig = o.triggerPrice;
     }
     stops_.add(o, initTrig, trailing);
-    sink_(OrderAccepted{o.id, o.symbol, o.side, o.triggerPrice, o.quantity, false});  // pending, not on book
-    processTriggers();                                                                // may already be in-the-money
+    sink_(OrderAccepted{o.id, o.symbol, o.side, o.triggerPrice, o.quantity, false, Quantity{},
+                        o.accountId});  // pending, not on book
+    processTriggers();                  // may already be in-the-money
     return true;
   }
 
@@ -923,7 +1674,7 @@ class MatchingEngine
     stops_.updateTrailing(*ref);
     while (auto agg = stops_.popTriggered(*ref))
     {
-      sink_(OrderTriggered{agg->id, cfg_.id, *ref});
+      sink_(OrderTriggered{agg->id, cfg_.id, *ref, agg->accountId});
       // Perp risk gates: a triggered stop re-enters matching HERE, not through
       // onNew, so it must run the same reduce-only cap + position-limit checks --
       // else a reduce-only stop opens an uncollateralized (im=0) position and a
@@ -931,7 +1682,7 @@ class MatchingEngine
       // reserved) if the reduce-only cap leaves nothing or the cap is breached.
       if (const RejectReason r = perpRiskGate(*agg); r != RejectReason::None)
       {
-        sink_(OrderRejected{agg->id, cfg_.id, r});
+        sink_(OrderRejected{agg->id, cfg_.id, r, agg->accountId});
         ref = triggerReference();
         if (!ref)
         {
@@ -945,7 +1696,7 @@ class MatchingEngine
       // value (buyer receives base it can't pay for).
       if (!reserveFunds(*agg))
       {
-        sink_(OrderRejected{agg->id, cfg_.id, RejectReason::InsufficientFunds});
+        sink_(OrderRejected{agg->id, cfg_.id, RejectReason::InsufficientFunds, agg->accountId});
         ref = triggerReference();
         if (!ref)
         {
@@ -960,7 +1711,7 @@ class MatchingEngine
       if (out.reject != RejectReason::None)
       {
         releaseReservation(agg->id);
-        sink_(OrderRejected{agg->id, cfg_.id, out.reject});
+        sink_(OrderRejected{agg->id, cfg_.id, out.reject, agg->accountId});
       }
       else if (out.residualRests)
       {
@@ -968,12 +1719,13 @@ class MatchingEngine
         rro.reduceOnly = agg->reduceOnly;
         book_.addResting(agg->side, rro);
         trackResting(agg->id, agg->accountId);
-        sink_(OrderAccepted{agg->id, cfg_.id, agg->side, agg->price, out.leaves, true});
+        sink_(OrderAccepted{agg->id, cfg_.id, agg->side, agg->price, out.leaves, true, Quantity{},
+                            agg->accountId});
       }
       else if (out.residualCanceled)
       {
-        releaseReservation(agg->id);
-        sink_(OrderCanceled{agg->id, cfg_.id, out.residualCancelReason});
+        releaseReservationExceptHeld(agg->id);  // held slices stay reserved
+        sink_(OrderCanceled{agg->id, cfg_.id, out.residualCancelReason, agg->accountId});
       }
       ref = triggerReference();  // trades may have moved the last-price reference
       if (!ref)
@@ -988,18 +1740,22 @@ class MatchingEngine
   {
     if (m.symbol != cfg_.id)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownSymbol});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownSymbol, m.accountId});
       return;
     }
+    // Resolve (reject) any last-look holds referencing this order FIRST: both
+    // modify paths re-shape the order and its reservation, and a hold left
+    // behind would later settle against a reservation that no longer covers it.
+    rejectHoldsFor(m.id);
     const RestingOrder* cur = book_.find(m.id);
     if (cur == nullptr)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownOrder});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownOrder, m.accountId});
       return;
     }
     if (m.newQty.raw() <= 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidQuantity});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidQuantity, m.accountId});
       return;
     }
 
@@ -1015,27 +1771,27 @@ class MatchingEngine
     // original order untouched.
     if (newPrice.raw() <= 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct});
       return;
     }
     if (!cfg_.tickSize.isZero() && (newPrice.raw() % cfg_.tickSize.raw()) != 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::TickSizeViolation});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::TickSizeViolation, acct});
       return;
     }
     if (!cfg_.minPrice.isZero() && newPrice < cfg_.minPrice)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct});
       return;
     }
     if (!cfg_.maxPrice.isZero() && cfg_.maxPrice < newPrice)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct});
       return;
     }
     if (!cfg_.lotSize.isZero() && (m.newQty.raw() % cfg_.lotSize.raw()) != 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::LotSizeViolation});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::LotSizeViolation, acct});
       return;
     }
 
@@ -1061,7 +1817,7 @@ class MatchingEngine
           it->second.reservedRaw -= freed;
         }
       }
-      sink_(OrderModified{m.id, m.symbol, newPrice, m.newQty, true});
+      sink_(OrderModified{m.id, m.symbol, newPrice, m.newQty, true, acct});
       return;
     }
 
@@ -1089,13 +1845,13 @@ class MatchingEngine
     if (const RejectReason r = perpRiskGate(re); r != RejectReason::None)
     {
       forgetOrder(m.id);  // order was already canceled above -> stays gone
-      sink_(OrderRejected{m.id, m.symbol, r});
+      sink_(OrderRejected{m.id, m.symbol, r, acct});
       return;
     }
     if (!reserveFunds(re))  // cannot fund the modified order -> reject; order is gone
     {
       forgetOrder(m.id);
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InsufficientFunds});
+      sink_(OrderRejected{m.id, m.symbol, RejectReason::InsufficientFunds, acct});
       return;
     }
     const MatchOutcome out =
@@ -1108,7 +1864,7 @@ class MatchingEngine
       book_.addResting(side, mro);
       trackResting(m.id, acct);
     }
-    sink_(OrderModified{m.id, m.symbol, newPrice, out.leaves, false});
+    sink_(OrderModified{m.id, m.symbol, newPrice, out.leaves, false, acct});
     processTriggers();  // a reprice-into-cross may have moved the last price
   }
 
@@ -1116,26 +1872,42 @@ class MatchingEngine
   {
     if (c.symbol != cfg_.id)
     {
-      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownSymbol});
+      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownSymbol, c.accountId});
       return;
     }
+    // Cancel-while-held: deterministically resolve (reject) the order's holds
+    // BEFORE removing it. The reject restores held quantity to the book (so the
+    // cancel below removes ALL of it and releases the full reservation), and a
+    // later accept of the same heldId is impossible (UnknownOrder) -- without
+    // this, releaseReservation would strip the held slice and the accept would
+    // settle through the unchecked-debit path, breaking conservation.
+    rejectHoldsFor(c.id);
+    const uint64_t restingAcct = ownerOf(c.id);
+    const uint64_t stopAcct = stops_.accountOf(c.id);
     if (book_.cancel(c.id).has_value())
     {
       releaseReservation(c.id);
       forgetOrder(c.id);
-      sink_(OrderCanceled{c.id, c.symbol, CancelReason::UserRequested});
+      sink_(OrderCanceled{c.id, c.symbol, CancelReason::UserRequested, restingAcct});
     }
     else if (stops_.cancel(c.id))
     {
-      sink_(OrderCanceled{c.id, c.symbol, CancelReason::UserRequested});
+      sink_(OrderCanceled{c.id, c.symbol, CancelReason::UserRequested, stopAcct});
     }
     else
     {
-      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownOrder});
+      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownOrder, c.accountId});
     }
   }
 
   // ---- per-account resting-order tracking (mass-cancel / MMP) ----
+  // Owner of a live tracked order (0 if unknown) -- read BEFORE forgetOrder so
+  // async cancel events can be routed to the owner's session.
+  uint64_t ownerOf(OrderId id) const noexcept
+  {
+    auto it = orderAccount_.find(id);
+    return it == orderAccount_.end() ? 0 : it->second;
+  }
   void trackResting(OrderId id, uint64_t account)
   {
     orderAccount_[id] = account;
@@ -1184,6 +1956,12 @@ class MatchingEngine
   }
   void cancelAllForAccount(uint64_t account, CancelReason reason = CancelReason::UserRequested)
   {
+    // Resolve every hold touching this account FIRST (mass-cancel / MMP /
+    // liquidation must not leave held fills behind): the account's own held
+    // slices are restored and then canceled below; counterparty slices return
+    // to the book. Resolving before the id snapshot also catches an order of
+    // this account that a restore would re-create.
+    rejectHoldsForAccount(account);
     auto it = byAccount_.find(account);
     if (it == byAccount_.end())
     {
@@ -1197,7 +1975,7 @@ class MatchingEngine
       {
         releaseReservation(id);
         forgetOrder(id);
-        sink_(OrderCanceled{id, cfg_.id, reason});
+        sink_(OrderCanceled{id, cfg_.id, reason, account});
       }
     }
   }
@@ -1217,17 +1995,21 @@ class MatchingEngine
     {
       return;
     }
+    rejectHoldsFor(q.bidId);  // a replaced quote may carry open holds
+    rejectHoldsFor(q.askId);
     if (book_.cancel(q.bidId).has_value())
     {
+      const uint64_t acct = ownerOf(q.bidId);
       releaseReservation(q.bidId);
       forgetOrder(q.bidId);
-      sink_(OrderCanceled{q.bidId, cfg_.id, CancelReason::UserRequested});
+      sink_(OrderCanceled{q.bidId, cfg_.id, CancelReason::UserRequested, acct});
     }
     if (book_.cancel(q.askId).has_value())
     {
+      const uint64_t acct = ownerOf(q.askId);
       releaseReservation(q.askId);
       forgetOrder(q.askId);
-      sink_(OrderCanceled{q.askId, cfg_.id, CancelReason::UserRequested});
+      sink_(OrderCanceled{q.askId, cfg_.id, CancelReason::UserRequested, acct});
     }
     if (q.bidQty.raw() > 0)
     {
@@ -1331,8 +2113,10 @@ class MatchingEngine
         static_cast<double>(
             notionalRaw(t.price.raw(), t.quantity.raw(), cfg_.priceScale, cfg_.qtyScale)) /
         kMoneyScale;
-    sink_(FeeCharged{t.makerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, true)), true});
-    sink_(FeeCharged{t.takerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, false)), false});
+    sink_(FeeCharged{t.makerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, true)),
+                     true, t.makerAccount});
+    sink_(FeeCharged{t.takerId, cfg_.id, Volume::fromDouble(fees_.feeFor(now_, notional, false)),
+                     false, t.takerAccount});
   }
 
   // ---- settlement ledger ----
@@ -1415,6 +2199,43 @@ class MatchingEngine
     return true;
   }
 
+  // ---- journaled balance genesis ----
+  // Deposits/withdrawals are sequenced commands, not direct Ledger calls, so
+  // the WAL is the single source of truth for balances: a replay from an empty
+  // ledger reproduces them. Without a ledger bound they are no-ops.
+  void onDeposit(const Deposit& d)
+  {
+    if (ledger_ == nullptr || d.amountRaw <= 0)
+    {
+      return;
+    }
+    ledger_->deposit(d.accountId, d.asset, static_cast<Amount>(d.amountRaw));
+    // The owner sees the credit land. Deterministic (post-event ledger state),
+    // so it is part of the event hash; journal replay re-emits it and the
+    // shard's recovery suppression keeps replayed/snapshot-restored copies off
+    // the wire.
+    emitBalance(d.accountId, d.asset, BalanceReason::Deposit);
+  }
+
+  void onWithdraw(const Withdraw& w)
+  {
+    if (ledger_ == nullptr || w.amountRaw <= 0)
+    {
+      return;
+    }
+    // debit is all-or-nothing (checks available >= amount): an uncovered
+    // withdraw changes nothing, so conservation and replay stay intact.
+    const bool ok = ledger_->debit(w.accountId, w.asset, static_cast<Amount>(w.amountRaw));
+    emitBalance(w.accountId, w.asset,
+                ok ? BalanceReason::Withdraw : BalanceReason::WithdrawRejected);
+  }
+
+  void emitBalance(uint64_t account, AssetId asset, BalanceReason reason)
+  {
+    sink_(BalanceUpdate{account, asset, static_cast<int64_t>(ledger_->available(account, asset)),
+                        static_cast<int64_t>(ledger_->reserved(account, asset)), reason});
+  }
+
   void releaseReservation(OrderId id)
   {
     if (ledger_ == nullptr)
@@ -1431,6 +2252,92 @@ class MatchingEngine
       ledger_->release(it->second.account, it->second.asset, it->second.reservedRaw);
     }
     reserve_.erase(it);
+  }
+
+  // Any open last-look hold referencing this order (as maker or taker)?
+  bool hasHoldsFor(OrderId id) const
+  {
+    if (held_.empty())
+    {
+      return false;
+    }
+    for (const auto& [hid, h] : held_)
+    {
+      (void)hid;
+      if (h.maker == id || h.taker == id)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // releaseReservation, but keep the slice backing this order's open held
+  // fills reserved: a canceled residual must not strip the collateral an
+  // accept still needs to settle from (the unchecked-debit fallback would
+  // credit the counterparty against a possibly failing debit).
+  void releaseReservationExceptHeld(OrderId id)
+  {
+    if (ledger_ == nullptr)
+    {
+      return;
+    }
+    Quantity heldQty{};
+    for (const auto& [hid, h] : held_)
+    {
+      (void)hid;
+      if (h.taker == id || h.maker == id)
+      {
+        heldQty += h.qty;
+      }
+    }
+    if (heldQty.isZero())
+    {
+      releaseReservation(id);
+      return;
+    }
+    auto it = reserve_.find(id);
+    if (it == reserve_.end())
+    {
+      return;
+    }
+    Amount keep;
+    if (cfg_.linearPerp)
+    {
+      keep = imForRaw(heldQty.raw(), it->second.limitPriceRaw);
+    }
+    else if (it->second.side == Side::BUY)
+    {
+      keep = notionalRaw(it->second.limitPriceRaw, heldQty.raw(), cfg_.priceScale, cfg_.qtyScale);
+    }
+    else
+    {
+      keep = amountOf(heldQty);
+    }
+    if (keep > it->second.reservedRaw)
+    {
+      keep = it->second.reservedRaw;
+    }
+    const Amount rel = it->second.reservedRaw - keep;
+    if (rel > 0)
+    {
+      ledger_->release(it->second.account, it->second.asset, rel);
+      it->second.reservedRaw = keep;
+    }
+  }
+
+  // After the last hold on an order resolves: if the order is gone from the
+  // book (and the stop book), free any leftover reservation and drop tracking.
+  // Complements the emit_ wrapper, which defers this cleanup while holds are
+  // open (see the complete-with-holds note there).
+  void cleanupOrderIfDone(OrderId id)
+  {
+    if (book_.contains(id) || stops_.contains(id) || hasHoldsFor(id))
+    {
+      return;
+    }
+    releaseReservation(id);
+    forgetOrder(id);
   }
 
   void settleTrade(const Trade& t)
@@ -1501,7 +2408,7 @@ class MatchingEngine
     // Signed move: participant -fee, venue +fee (conserves value; fee<0 = rebate).
     ledger_->credit(acct, cfg_.quoteAsset, -fee);
     ledger_->credit(venueAccount_, cfg_.quoteAsset, fee);
-    sink_(FeeCharged{id, cfg_.id, Volume::fromDouble(feeD), maker});
+    sink_(FeeCharged{id, cfg_.id, Volume::fromDouble(feeD), maker, acct});
   }
 
   // ---- linear-perp clearing ----
@@ -1784,6 +2691,218 @@ class MatchingEngine
     }
   }
 
+  // ---- checkpoint helpers ----
+  static uint64_t mixAmount(uint64_t h, Amount a) noexcept
+  {
+    h = mix(h, static_cast<uint64_t>(static_cast<unsigned __int128>(a)));
+    h = mix(h, static_cast<uint64_t>(static_cast<unsigned __int128>(a) >> 64));
+    return h;
+  }
+
+  template <class Map>
+  static std::vector<typename Map::key_type> sortedKeys(const Map& m)
+  {
+    std::vector<typename Map::key_type> keys;
+    keys.reserve(m.size());
+    for (const auto& [k, v] : m)
+    {
+      (void)v;
+      keys.push_back(k);
+    }
+    std::sort(keys.begin(), keys.end());
+    return keys;
+  }
+
+  int64_t expiryOf(OrderId id) const
+  {
+    auto it = expiry_.find(id);
+    return it == expiry_.end() ? 0 : it->second;
+  }
+  uint64_t ocoOf(OrderId id) const
+  {
+    auto it = orderOco_.find(id);
+    return it == orderOco_.end() ? 0 : it->second;
+  }
+
+  // Pending conditional orders with their current triggers, sorted by order id
+  // (the stop book's internal container order is not state: firing and cancel
+  // are id-deterministic, so the canonical order for hash/serialization is id).
+  std::vector<std::pair<NewOrder, Price>> sortedStops() const
+  {
+    std::vector<std::pair<NewOrder, Price>> v;
+    stops_.forEachPending([&](const NewOrder& o, Price trigger)
+                          { v.emplace_back(o, trigger); });
+    std::sort(v.begin(), v.end(),
+              [](const auto& a, const auto& b)
+              { return a.first.id < b.first.id; });
+    return v;
+  }
+
+  void linkOco(OrderId id, uint64_t group)
+  {
+    orderOco_[id] = group;
+    ocoMembers_[group].push_back(id);
+  }
+
+  bool applyRestoreOrder(const RestoreOrder& r)
+  {
+    if (book_.contains(r.id) || stops_.contains(r.id))
+    {
+      return false;
+    }
+    // Corruption tripwire: a continuous-trading book without last look is
+    // uncrossed by invariant, so a crossing restore marks the file corrupt.
+    // Two legal exceptions: a pre-open (auction) book accumulates crossed
+    // (the AdminCmd{BeginPreOpen} record earlier in the file has set
+    // auctionMode_ by the time orders restore), and a last-look venue can
+    // legitimately hold a crossed book -- a rejected hold restores the maker
+    // at its original price on top of a residual that rested through it (see
+    // restoreMakerHeld). There the SnapshotEnd stateHash remains the
+    // corruption check.
+    if (!auctionMode_ && cfg_.lastLookWindowNs == 0)
+    {
+      if (r.side == Side::BUY)
+      {
+        if (auto ba = book_.bestAsk(); ba && !(r.price < *ba))
+        {
+          return false;
+        }
+      }
+      else
+      {
+        if (auto bb = book_.bestBid(); bb && !(*bb < r.price))
+        {
+          return false;
+        }
+      }
+    }
+    RestingOrder ro{r.id, r.accountId, r.price, r.leaves, r.side};
+    ro.hidden = r.hidden;
+    ro.peak = r.peak;
+    ro.lastLook = r.lastLook;
+    ro.reduceOnly = r.reduceOnly;
+    // Straight to the tail of its level, NO matching pass: the canonical write
+    // order (levels best-first, FIFO within) makes tail-appends reproduce the
+    // exact live book layout.
+    book_.addResting(r.side, ro);
+    trackResting(r.id, r.accountId);
+    if (r.expiryNs > 0)
+    {
+      expiry_[r.id] = r.expiryNs;
+    }
+    if (r.ocoGroup > 0)
+    {
+      linkOco(r.id, r.ocoGroup);
+    }
+    // Buying power is NOT re-derived here: the order's exact reservation
+    // arrives as its own RestoreReservation record (live amounts are
+    // history-dependent -- partial fills, held slices, STP interactions).
+    return true;
+  }
+
+  bool applyRestoreStop(const RestoreStop& r)
+  {
+    if (!isConditional(r.order.type) || stops_.contains(r.order.id) ||
+        book_.contains(r.order.id))
+    {
+      return false;
+    }
+    if (r.order.ocoGroup > 0)
+    {
+      linkOco(r.order.id, r.order.ocoGroup);  // a parked stop keeps its OCO link
+    }
+    // No processTriggers: a restore is not a market event; an in-the-money
+    // stop at write time would already have fired live.
+    stops_.add(r.order, r.trigger, r.order.type == OrderType::TRAILING_STOP);
+    return true;
+  }
+
+  bool applyRestoreHeld(const RestoreHeld& r)
+  {
+    if (held_.count(r.heldId) != 0 || r.qty.raw() <= 0)
+    {
+      return false;
+    }
+    Held h{r.heldId, r.taker, r.takerAccount, r.takerSide, r.maker,
+           r.makerAccount, r.price, r.qty, r.deadline};
+    h.takerTif = r.takerTif;
+    h.takerType = r.takerType;
+    h.takerPrice = r.takerPrice;
+    h.takerExpiryNs = r.takerExpiryNs;
+    h.makerReduceOnly = r.makerReduceOnly;
+    h.takerReduceOnly = r.takerReduceOnly;
+    held_[r.heldId] = h;
+    heldOpen_.store(held_.size(), std::memory_order_relaxed);
+    // Tracking follows the recorded live truth: a held maker normally stays
+    // tracked even fully off the book (see createHeld), but an STP-cancel can
+    // have removed it while the hold stayed open. Idempotent when the maker
+    // also rests (RestoreOrder tracked it). The taker is tracked only while
+    // resting. Reservations backing the legs arrive as RestoreReservation
+    // records -- nothing is re-derived here.
+    if (r.makerTracked)
+    {
+      trackResting(h.maker, h.makerAccount);
+    }
+    return true;
+  }
+
+  // Restore one buying-power reservation entry EXACTLY as recorded. With
+  // exact RestoreBalance splits in the snapshot the ledger's reserved side is
+  // already in place, so only the engine-side table is rebuilt; a v1
+  // (Deposit-total) snapshot instead moves the amount available -> reserved
+  // through the ledger, and a total that cannot back its recorded reservation
+  // marks the snapshot corrupt.
+  bool applyRestoreReservation(const RestoreReservation& r)
+  {
+    if (reserve_.count(r.id) != 0)
+    {
+      return false;
+    }
+    if (ledger_ == nullptr)
+    {
+      return true;  // no ledger bound: reservations do not exist
+    }
+    if (!exactBalanceRestore_ && r.reservedRaw > 0 &&
+        !ledger_->reserve(r.account, r.asset, r.reservedRaw))
+    {
+      return false;
+    }
+    reserve_[r.id] = Reservation{r.account, r.asset, r.reservedRaw, r.limitPriceRaw, r.side};
+    return true;
+  }
+
+  bool applyRestorePosition(const RestorePosition& r)
+  {
+    if (r.qtyRaw == 0 || positions_.count(r.account) != 0)
+    {
+      return false;
+    }
+    if (ledger_ != nullptr && !exactBalanceRestore_ && r.marginRaw > 0 &&
+        !ledger_->reserve(r.account, cfg_.quoteAsset, r.marginRaw))
+    {
+      return false;  // deposited total cannot back the posted margin -> corrupt
+    }
+    positions_[r.account] = Position{r.qtyRaw, r.entryRaw, r.marginRaw};
+    return true;
+  }
+
+  bool applySnapshotEnd(const SnapshotEnd& e)
+  {
+    tradeSeq_ = e.tradeSeq;
+    heldSeq_ = e.heldSeq;
+    timeCounter_ = e.timeCounter;
+    now_ = e.nowNs;
+    lastPrice_ = Price::fromRaw(e.lastPriceRaw);
+    hasLast_ = e.hasLast;
+    markPrice_ = Price::fromRaw(e.markPriceRaw);
+    hasMark_ = e.hasMark;
+    haltUntil_ = e.haltUntilNs;
+    // Full verification: the reconstructed state must hash to what the writer
+    // measured. A mismatch (torn/corrupted/semantically-drifted snapshot)
+    // rejects the generation.
+    return stateHash() == e.stateHash;
+  }
+
   // ---- last look ----
   struct Held
   {
@@ -1796,17 +2915,42 @@ class MatchingEngine
     Price price{};
     Quantity qty{};
     int64_t deadline{};
+    // Captured at hold time so a reject can route the taker residual by its
+    // TIF and rebuild either leg if it was fully held out of the book.
+    TimeInForce takerTif{TimeInForce::GTC};
+    OrderType takerType{OrderType::LIMIT};
+    Price takerPrice{};
+    int64_t takerExpiryNs{0};
+    bool makerReduceOnly{false};
+    // Captured so a checkpoint can re-reserve the taker leg's held backing
+    // exactly (a perp reduce-only taker reserves nothing).
+    bool takerReduceOnly{false};
   };
   void createHeld(const RestingOrder& maker, Quantity fill, const NewOrder& taker)
   {
     const uint64_t id = ++heldSeq_;
-    held_[id] = Held{id, taker.id, taker.accountId, taker.side, maker.id,
-                     maker.accountId, maker.price, fill, now_ + cfg_.lastLookWindowNs};
-    sink_(FillHeld{id, cfg_.id, maker.id, taker.id, maker.price, fill});
-    if (!book_.contains(maker.id))
-    {
-      forgetOrder(maker.id);
-    }
+    Held h{id, taker.id, taker.accountId, taker.side, maker.id,
+           maker.accountId, maker.price, fill, now_ + cfg_.lastLookWindowNs};
+    h.takerTif = taker.tif;
+    h.takerType = taker.type;
+    h.takerPrice = taker.price;
+    h.takerExpiryNs = taker.expiryNs;
+    h.makerReduceOnly = maker.reduceOnly;
+    h.takerReduceOnly = taker.reduceOnly;
+    held_[id] = h;
+    heldOpen_.store(held_.size(), std::memory_order_relaxed);
+    // Called BEFORE the matcher reserves the qty out of the book, so the
+    // maker's post-hold displayed size is computed here the same way a normal
+    // fill would (partial peak -> remainder shown; full peak -> iceberg refill).
+    const Quantity displayAfter =
+        (fill < maker.leaves) ? (maker.leaves - fill)
+                              : ((maker.peak < maker.hidden) ? maker.peak : maker.hidden);
+    sink_(FillHeld{id, cfg_.id, maker.id, taker.id, maker.price, fill, displayAfter,
+                   maker.accountId, taker.accountId});
+    // NOTE: the maker stays tracked (orderAccount_/byAccount_) even when the
+    // hold empties its displayed size and fillBest removes it from the book --
+    // the id is still live (a reject restores it) and mass-cancel paths must
+    // still find it.
   }
   // Release one leg's buying-power reservation for a held quantity that will NOT
   // trade (last-look reject / timeout). Mirrors the per-fill decrement settleTrade
@@ -1857,6 +3001,7 @@ class MatchingEngine
   {
     const Held h = it->second;
     held_.erase(it);
+    heldOpen_.store(held_.size(), std::memory_order_relaxed);
     if (accept)
     {
       emit_(Trade{++tradeSeq_, cfg_.id, h.price, h.qty, h.maker, h.taker, h.takerSide,
@@ -1865,25 +3010,183 @@ class MatchingEngine
       const Quantity makerLeaves = mk ? Quantity::fromRaw(mk->leaves.raw() + mk->hidden.raw()) : Quantity{};
       const Quantity makerDisp = mk ? mk->leaves : Quantity{};  // displayed peak for public feed
       emit_(OrderExecuted{h.maker, cfg_.id, h.qty, makerLeaves, false, makerLeaves.isZero(), h.price,
-                          makerDisp});
-      emit_(OrderExecuted{h.taker, cfg_.id, h.qty, Quantity{}, true, false, h.price, Quantity{}});
+                          makerDisp, h.makerAccount});
+      emit_(OrderExecuted{h.taker, cfg_.id, h.qty, Quantity{}, true, false, h.price, Quantity{},
+                          h.takerAccount});
     }
     else
     {
-      // Reject / timeout: the held qty does not trade. Return both parties' held
-      // buying power to available (else it is stranded in `reserved` forever and
-      // the taker is never made whole for the fill that did not happen).
-      releaseHeldLeg(h.taker, h.qty);
-      releaseHeldLeg(h.maker, h.qty);
-      sink_(FillRejected{h.id, cfg_.id, h.taker});
+      // Reject / timeout: the held qty does not trade, and liquidity must not
+      // be destroyed. The maker's displayed qty returns to its price level (at
+      // the TAIL, as-if re-entered -- see docs/venue/matching.md); its
+      // reservation was never touched and keeps backing it. The taker residual
+      // follows its TIF: GTC/GTD rests, IOC/FOK/MARKET is canceled with the
+      // matching residual reason (that leg's buying power is released). The
+      // cancel paths resolve holds BEFORE removing an order, so a leg that is
+      // absent from the book here was fully held out of it -- never "gone".
+      restoreMakerHeld(h);
+      restoreTakerHeld(h);
+      sink_(FillRejected{h.id, cfg_.id, h.taker, h.maker, h.price, h.qty, h.takerAccount,
+                         h.makerAccount});
+    }
+    // Whichever way the hold resolved: if this was the last hold on a leg and
+    // that leg no longer rests, free its leftover reservation and tracking
+    // (deferred from the emit_ wrapper while holds were open).
+    cleanupOrderIfDone(h.taker);
+    cleanupOrderIfDone(h.maker);
+  }
+
+  // Return a rejected hold's qty to the maker: back onto its price level at the
+  // tail (as-if re-entered). If the hold consumed the whole displayed size the
+  // order left the book -- rebuild it from the hold record.
+  void restoreMakerHeld(const Held& h)
+  {
+    if (auto ro = book_.cancel(h.maker); ro.has_value())
+    {
+      ro->leaves += h.qty;  // the returned slice was displayed when it was held
+      book_.addResting(ro->side, *ro);
+      sink_(OrderModified{h.maker, cfg_.id, ro->price, ro->leaves, false, h.makerAccount});
+    }
+    else
+    {
+      const Side makerSide = (h.takerSide == Side::BUY) ? Side::SELL : Side::BUY;
+      RestingOrder rebuilt{h.maker, h.makerAccount, h.price, h.qty, makerSide};
+      rebuilt.lastLook = true;
+      rebuilt.reduceOnly = h.makerReduceOnly;
+      book_.addResting(makerSide, rebuilt);
+      // Still tracked in orderAccount_/byAccount_: a fully-held maker is never
+      // forgotten while its hold is open (see createHeld).
+      sink_(OrderModified{h.maker, cfg_.id, h.price, h.qty, false, h.makerAccount});
     }
   }
+
+  // Return a rejected hold's qty to the taker per its TIF.
+  void restoreTakerHeld(const Held& h)
+  {
+    const bool rests = h.takerType == OrderType::LIMIT &&
+                       (h.takerTif == TimeInForce::GTC || h.takerTif == TimeInForce::GTD);
+    if (rests)
+    {
+      // Reservation keeps backing the restored resting quantity.
+      if (auto ro = book_.cancel(h.taker); ro.has_value())
+      {
+        ro->leaves += h.qty;  // combine with the already-resting remainder, tail requeue
+        book_.addResting(ro->side, *ro);
+        sink_(OrderModified{h.taker, cfg_.id, ro->price, ro->leaves, false, h.takerAccount});
+      }
+      else
+      {
+        RestingOrder rebuilt{h.taker, h.takerAccount, h.takerPrice, h.qty, h.takerSide};
+        book_.addResting(h.takerSide, rebuilt);
+        trackResting(h.taker, h.takerAccount);
+        if (h.takerTif == TimeInForce::GTD && h.takerExpiryNs > 0)
+        {
+          expiry_[h.taker] = h.takerExpiryNs;
+        }
+        sink_(OrderAccepted{h.taker, cfg_.id, h.takerSide, h.takerPrice, h.qty, true, h.qty,
+                            h.takerAccount});
+      }
+      return;
+    }
+    // IOC / FOK / MARKET: the residual never rests -- release the taker's held
+    // buying power and cancel it with the reason its TIF would have produced.
+    releaseHeldLeg(h.taker, h.qty);
+    const CancelReason reason = (h.takerType == OrderType::MARKET) ? CancelReason::MarketResidual
+                                : (h.takerTif == TimeInForce::FOK)
+                                    ? CancelReason::FillOrKillResidual
+                                    : CancelReason::ImmediateOrCancelResidual;
+    sink_(OrderCanceled{h.taker, cfg_.id, reason, h.takerAccount});
+  }
+
+  // Deterministically resolve (reject) every open hold that references `id` as
+  // maker or taker. MUST run before any path that permanently removes the order
+  // or reshapes its reservation (cancel/modify/quote-replace/expiry/OCO/peg):
+  // a hold left behind would let a later accept settle with no backing
+  // reservation (unchecked debit -> conservation breach).
+  void rejectHoldsFor(OrderId id)
+  {
+    if (held_.empty())
+    {
+      return;
+    }
+    std::vector<uint64_t> due;
+    for (const auto& [hid, h] : held_)
+    {
+      if (h.maker == id || h.taker == id)
+      {
+        due.push_back(hid);
+      }
+    }
+    std::sort(due.begin(), due.end());  // deterministic resolution/event order
+    for (uint64_t hid : due)
+    {
+      if (auto it = held_.find(hid); it != held_.end())
+      {
+        resolveHeld(it, false);
+      }
+    }
+  }
+
+  // Account-scope variant for mass-cancel / MMP / liquidation.
+  void rejectHoldsForAccount(uint64_t account)
+  {
+    if (held_.empty())
+    {
+      return;
+    }
+    std::vector<uint64_t> due;
+    for (const auto& [hid, h] : held_)
+    {
+      if (h.makerAccount == account || h.takerAccount == account)
+      {
+        due.push_back(hid);
+      }
+    }
+    std::sort(due.begin(), due.end());
+    for (uint64_t hid : due)
+    {
+      if (auto it = held_.find(hid); it != held_.end())
+      {
+        resolveHeld(it, false);
+      }
+    }
+  }
+
+  void rejectAllHolds()
+  {
+    if (held_.empty())
+    {
+      return;
+    }
+    std::vector<uint64_t> due;
+    due.reserve(held_.size());
+    for (const auto& [hid, h] : held_)
+    {
+      (void)h;
+      due.push_back(hid);
+    }
+    std::sort(due.begin(), due.end());
+    for (uint64_t hid : due)
+    {
+      if (auto it = held_.find(hid); it != held_.end())
+      {
+        resolveHeld(it, false);
+      }
+    }
+  }
+
   void onLastLookDecision(const LastLookDecision& d)
   {
     auto it = held_.find(d.heldId);
     if (it == held_.end())
     {
-      sink_(OrderRejected{d.heldId, cfg_.id, RejectReason::UnknownOrder});
+      sink_(OrderRejected{d.heldId, cfg_.id, RejectReason::UnknownOrder, d.accountId});
+      return;
+    }
+    // Ownership: only the maker whose quote is held may decide its fate.
+    if (d.accountId != it->second.makerAccount)
+    {
+      sink_(OrderRejected{d.heldId, cfg_.id, RejectReason::NotOrderOwner, d.accountId});
       return;
     }
     resolveHeld(it, d.accept);
@@ -1908,11 +3211,13 @@ class MatchingEngine
     for (OrderId id : due)
     {
       expiry_.erase(id);
+      rejectHoldsFor(id);                // expiry removes the order: resolve holds first
       if (book_.cancel(id).has_value())  // still resting -> expire it
       {
+        const uint64_t acct = ownerOf(id);
         releaseReservation(id);
         forgetOrder(id);
-        sink_(OrderCanceled{id, cfg_.id, CancelReason::Expired});
+        sink_(OrderCanceled{id, cfg_.id, CancelReason::Expired, acct});
       }
     }
   }
@@ -1993,6 +3298,10 @@ class MatchingEngine
         continue;
       }
       const Peg pg = pit->second;
+      // A peg reprice releases and re-reserves buying power at the new price;
+      // an open hold against the old price/reservation would settle against a
+      // reservation that no longer covers it -- resolve holds first.
+      rejectHoldsFor(id);
       // Remove the order from the book BEFORE computing its peg target: otherwise
       // pegTargetRaw reads best-bid/ask/mid INCLUDING this order's own resting
       // quantity, so a peg that is the touch references itself and ratchets one
@@ -2026,14 +3335,14 @@ class MatchingEngine
         {
           forgetOrder(id);
           pegged_.erase(id);
-          sink_(OrderCanceled{id, cfg_.id, CancelReason::UserRequested});
+          sink_(OrderCanceled{id, cfg_.id, CancelReason::UserRequested, ro->accountId});
           continue;
         }
       }
       RestingOrder nr = *ro;
       nr.price = Price::fromRaw(target);
       book_.addResting(nr.side, nr);
-      sink_(OrderModified{id, cfg_.id, Price::fromRaw(target), nr.leaves, false});
+      sink_(OrderModified{id, cfg_.id, Price::fromRaw(target), nr.leaves, false, nr.accountId});
     }
   }
 
@@ -2052,7 +3361,11 @@ class MatchingEngine
       {
         continue;  // already resolved this submit
       }
-      const std::vector<OrderId> members = git->second;  // copy: cancel mutates maps
+      std::vector<OrderId> members = git->second;  // copy: cancel mutates maps
+      // Deterministic sibling order by id: group membership is a SET (the
+      // insertion order is not state -- a checkpoint restore rebuilds it in
+      // canonical book order), so the cancel/event order must not depend on it.
+      std::sort(members.begin(), members.end());
       ocoMembers_.erase(git);
       for (OrderId id : members)
       {
@@ -2067,15 +3380,18 @@ class MatchingEngine
   }
   void cancelOcoSibling(OrderId id)
   {
+    rejectHoldsFor(id);  // the sibling leaves for good: resolve its holds first
+    const uint64_t restingAcct = ownerOf(id);
+    const uint64_t stopAcct = stops_.accountOf(id);
     if (book_.cancel(id).has_value())
     {
       releaseReservation(id);
       forgetOrder(id);
-      sink_(OrderCanceled{id, cfg_.id, CancelReason::OcoTriggered});
+      sink_(OrderCanceled{id, cfg_.id, CancelReason::OcoTriggered, restingAcct});
     }
     else if (stops_.cancel(id))
     {
-      sink_(OrderCanceled{id, cfg_.id, CancelReason::OcoTriggered});
+      sink_(OrderCanceled{id, cfg_.id, CancelReason::OcoTriggered, stopAcct});
     }
   }
 
@@ -2157,6 +3473,22 @@ class MatchingEngine
 
   std::unordered_map<uint64_t, Held> held_;
   uint64_t heldSeq_{0};
+  // Mirror of held_.size() readable from other threads (the shard's idle
+  // sweeper); the engine itself never reads it for logic.
+  std::atomic<uint64_t> heldOpen_{0};
+
+  // clientOrderId dedup index, per account. Window = the engine session
+  // (uptime); rotation/compaction is a future checkpoint concern -- see
+  // docs/venue/matching.md. Rebuilt naturally by journal replay.
+  std::unordered_map<uint64_t, std::unordered_set<uint64_t>> clientOrderIds_;
+
+  // Snapshot-only records seen (and dropped) on the live submit path.
+  uint64_t droppedSnapshotRecords_{0};
+
+  // Recovery mode flag: this snapshot carried exact RestoreBalance splits, so
+  // RestoreReservation / RestorePosition must not move ledger money (v1
+  // Deposit-total snapshots leave it false and keep the re-reservation path).
+  bool exactBalanceRestore_{false};
 
   Ledger* ledger_{nullptr};
   uint64_t venueAccount_{0};

--- a/venue/include/flox-venue/md_recovery.h
+++ b/venue/include/flox-venue/md_recovery.h
@@ -1,0 +1,560 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * TCP recovery channel for the market-data feed.
+ *
+ * The multicast feed is fire-and-forget; this server is where a consumer goes
+ * when the feed is not enough: a late joiner (no book at all), a detected gap
+ * (missed datagrams), or a publisher restart (epoch change). Protocol, one
+ * request per connection, length-prefixed frames (flox::net::writeFrame):
+ *
+ *   client:  ResendRequest{symbol, fromSeq}       (fromSeq=0 -> snapshot)
+ *   server:  EITHER the increments with seq >= fromSeq replayed from the
+ *            publisher's bounded ring, terminated by EOF,
+ *            OR SnapshotRequired + SnapshotBegin + AddOrder body (seq=0,
+ *            epoch set) + SnapshotEnd, when fromSeq is older than the ring's
+ *            tail. The consumer applies the body and resumes the incremental
+ *            feed at lastSeq+1.
+ *
+ * The snapshot/replay is taken under the publisher's lock (snapshotAtomic /
+ * resendFrom), so it is consistent with the live stream. An unknown symbol is
+ * answered by EOF with no frames. Stop the server before destroying the
+ * publishers registered with it.
+ *
+ * MdRecoveryClient (below) is the consumer-side counterpart: one call runs the
+ * whole round-trip and returns the classified result.
+ */
+#pragma once
+
+#include "flox-venue/market_data.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/resend_buffer.h"
+#include "flox-venue/sbe_md_codec.h"
+#include "flox-venue/socket_acceptor.h"
+#include "flox-venue/udp_multicast.h"
+#include "flox/util/transport.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+class MdRecoveryServer
+{
+ public:
+  explicit MdRecoveryServer(MdCounters* counters = nullptr) : counters_(counters) {}
+  ~MdRecoveryServer() { stop(); }
+
+  // Register the recovery source for the publisher's symbol (one per symbol;
+  // re-adding replaces, e.g. after a publisher restart). The publisher must
+  // outlive the server (or be replaced before it is destroyed).
+  template <size_t Levels>
+  void addPublisher(MarketDataPublisher<Levels>& pub)
+  {
+    std::lock_guard<std::mutex> lk(m_);
+    sources_[pub.symbol()] =
+        Source{[&pub]
+               { return pub.snapshotAtomic(); },
+               [&pub](uint64_t fromSeq)
+               { return pub.resendFrom(fromSeq); }};
+  }
+
+  // Listen on bindIp:port (0 = ephemeral). Returns the bound port, or -1.
+  // bindIp nullptr/"" keeps the loopback-only default. Passing an explicit
+  // address ("0.0.0.0" / a NIC address) exposes the recovery channel beyond
+  // the host; the hardening contract is the same as for the order-entry
+  // gateways -- put TLS termination and/or a firewall in front before binding
+  // externally, the protocol itself carries no authentication or encryption
+  // (see docs/venue/market-data.md).
+  int start(uint16_t port, const char* bindIp = nullptr)
+  {
+    return acceptor_.start(port, [this](int fd)
+                           { serve(fd); }, bindIp);
+  }
+
+  void stop() { acceptor_.stop(); }
+  int port() const noexcept { return acceptor_.port(); }
+
+ private:
+  struct Source
+  {
+    std::function<MdSnapshot()> snapshot;
+    std::function<std::optional<std::vector<MdMessage>>(uint64_t)> resend;
+  };
+
+  void serve(int fd)
+  {
+    std::vector<uint8_t> frame;
+    if (!net::readFrame(fd, frame))
+    {
+      return;
+    }
+    MdResendRequest req{};
+    if (!SbeMdCodec::decode(frame.data(), frame.size(), req))
+    {
+      return;
+    }
+    Source src;
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      const auto it = sources_.find(req.symbol);
+      if (it == sources_.end())
+      {
+        return;  // unknown symbol: EOF, no frames
+      }
+      src = it->second;
+    }
+
+    std::vector<uint8_t> buf;
+    if (const auto tail = src.resend(req.fromSeq))
+    {
+      for (const MdMessage& m : *tail)
+      {
+        SbeMdCodec::encode(m, buf);
+        if (!net::writeFrame(fd, buf.data(), buf.size()))
+        {
+          return;
+        }
+      }
+      if (counters_ != nullptr)
+      {
+        counters_->resendServed.fetch_add(1, std::memory_order_relaxed);
+      }
+      return;  // EOF terminates the replay
+    }
+
+    // fromSeq is older than the ring's tail (or 0): the increments are gone,
+    // serve the whole book instead.
+    const MdSnapshot snap = src.snapshot();
+    SbeMdCodec::encode(MdSnapshotRequired{req.symbol, snap.epoch, snap.lastSeq}, buf);
+    if (!net::writeFrame(fd, buf.data(), buf.size()))
+    {
+      return;
+    }
+    SbeMdCodec::encode(
+        MdSnapshotBegin{req.symbol, snap.epoch, snap.lastSeq,
+                        static_cast<uint32_t>(snap.orders.size())},
+        buf);
+    if (!net::writeFrame(fd, buf.data(), buf.size()))
+    {
+      return;
+    }
+    for (const MdMessage& m : snap.orders)
+    {
+      SbeMdCodec::encode(m, buf);
+      if (!net::writeFrame(fd, buf.data(), buf.size()))
+      {
+        return;
+      }
+    }
+    SbeMdCodec::encode(MdSnapshotEnd{req.symbol, snap.epoch, snap.lastSeq}, buf);
+    if (!net::writeFrame(fd, buf.data(), buf.size()))
+    {
+      return;
+    }
+    if (counters_ != nullptr)
+    {
+      counters_->snapshotsServed.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+
+  MdCounters* counters_;
+  SocketAcceptor acceptor_;
+  std::mutex m_;
+  std::unordered_map<SymbolId, Source> sources_;
+};
+
+// Consumer-side client for the recovery channel above. One recover() call is
+// one TCP connection (the protocol is one request per connection), so the
+// class holds no socket state and its destructor has nothing to fail. The
+// consumer protocol it packages: on a detected gap or an epoch change, ask for
+// `fromSeq` (0 = late joiner / re-snapshot), apply either the replayed
+// increments or the snapshot body, reset the GapDetector to `lastSeq + 1`
+// (`resetSequencer`) and resume the incremental feed.
+class MdRecoveryClient
+{
+ public:
+  enum class Status : uint8_t
+  {
+    Ok,             // result populated (possibly zero increments: nothing past fromSeq)
+    ConnectError,   // could not reach the server (or the request failed to send)
+    Timeout,        // server reachable but the reply stalled past the socket timeout
+    ProtocolError,  // malformed / truncated reply (e.g. a snapshot without SnapshotEnd)
+  };
+
+  struct Result
+  {
+    bool snapshot{false};             // true = SnapshotRequired path (`messages` is the book body)
+    std::vector<MdMessage> messages;  // replayed increments, or AddOrder body records (seq=0)
+    MdSnapshotBegin begin{};          // valid when `snapshot`
+    MdSnapshotEnd end{};              // valid when `snapshot`
+    // Resume point: the incremental feed continues at lastSeq + 1. On the
+    // snapshot path these come from SnapshotEnd; on a replay, from the last
+    // increment. An EMPTY replay (fromSeq ahead of the stream) keeps the
+    // consumer's own position: lastSeq = fromSeq - 1, epoch = 0 (unchanged).
+    uint64_t lastSeq{0};
+    uint64_t epoch{0};
+  };
+
+  MdRecoveryClient(std::string host, uint16_t port,
+                   std::chrono::milliseconds timeout = std::chrono::seconds(2))
+      : host_(std::move(host)), port_(port), timeout_(timeout)
+  {
+  }
+
+  Status recover(SymbolId symbol, uint64_t fromSeq, Result& out) const
+  {
+    out = Result{};
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
+    {
+      return Status::ConnectError;
+    }
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_port = htons(port_);
+    if (::inet_pton(AF_INET, host_.c_str(), &a.sin_addr) != 1 ||
+        ::connect(fd, reinterpret_cast<const sockaddr*>(&a), sizeof a) != 0)
+    {
+      ::close(fd);
+      return Status::ConnectError;
+    }
+    timeval tv{};
+    tv.tv_sec = static_cast<time_t>(timeout_.count() / 1000);
+    tv.tv_usec = static_cast<suseconds_t>((timeout_.count() % 1000) * 1000);
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof tv);
+
+    std::vector<uint8_t> b;
+    SbeMdCodec::encode(MdResendRequest{symbol, fromSeq}, b);
+    if (!net::writeFrame(fd, b.data(), b.size()))
+    {
+      ::close(fd);
+      return Status::ConnectError;
+    }
+
+    const Status st = collect(fd, fromSeq, out);
+    ::close(fd);
+    return st;
+  }
+
+ private:
+  Status collect(int fd, uint64_t fromSeq, Result& out) const
+  {
+    bool sawBegin = false;
+    bool sawEnd = false;
+    std::vector<uint8_t> f;
+    while (true)
+    {
+      errno = 0;
+      if (!net::readFrame(fd, f))
+      {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+          return Status::Timeout;  // reply stalled mid-stream, not a clean EOF
+        }
+        break;  // EOF terminates a replay (and follows SnapshotEnd)
+      }
+      switch (static_cast<SbeMdCodec::Tmpl>(SbeMdCodec::templateId(f.data(), f.size())))
+      {
+        case SbeMdCodec::Tmpl::SnapshotRequired:
+        {
+          MdSnapshotRequired sr{};
+          if (!SbeMdCodec::decode(f.data(), f.size(), sr))
+          {
+            return Status::ProtocolError;
+          }
+          out.snapshot = true;
+          break;
+        }
+        case SbeMdCodec::Tmpl::SnapshotBegin:
+          sawBegin = SbeMdCodec::decode(f.data(), f.size(), out.begin);
+          break;
+        case SbeMdCodec::Tmpl::SnapshotEnd:
+          sawEnd = SbeMdCodec::decode(f.data(), f.size(), out.end);
+          break;
+        default:
+        {
+          MdMessage m;
+          if (!SbeMdCodec::decode(f.data(), f.size(), m))
+          {
+            return Status::ProtocolError;
+          }
+          out.messages.push_back(m);
+          break;
+        }
+      }
+      if (sawEnd)
+      {
+        break;  // snapshot fully served; the server closes after this anyway
+      }
+    }
+    if (out.snapshot)
+    {
+      if (!sawBegin || !sawEnd)
+      {
+        return Status::ProtocolError;  // truncated snapshot must never look complete
+      }
+      out.lastSeq = out.end.lastSeq;
+      out.epoch = out.end.epoch;
+      return Status::Ok;
+    }
+    if (sawBegin || sawEnd)
+    {
+      return Status::ProtocolError;  // snapshot frames without SnapshotRequired
+    }
+    if (!out.messages.empty())
+    {
+      out.lastSeq = out.messages.back().seq;
+      out.epoch = out.messages.back().epoch;
+    }
+    else
+    {
+      out.lastSeq = fromSeq > 0 ? fromSeq - 1 : 0;  // nothing new: keep the position
+    }
+    return Status::Ok;
+  }
+
+  std::string host_;
+  uint16_t port_;
+  std::chrono::milliseconds timeout_;
+};
+
+// Self-recovering market-data consumer: UdpMdSubscriber (raw datagrams) +
+// GapDetector (owned here) + MdRecoveryClient composed into the full consumer
+// protocol, so a subscriber neither implements gap accounting nor the TCP
+// round-trips itself. recv()-style API, mirroring UdpMdSubscriber::recv with a
+// detector attached: only in-order messages surface, recovery is invisible
+// except through the onSnapshot callback and the counters.
+//
+// - Gap: ResendRequest{fromSeq} on the recovery channel; the replayed
+//   increments are woven through the detector into the in-order stream.
+// - Epoch change (publisher restart) or a gap deeper than
+//   maxGapBeforeSnapshot: snapshot recovery (fromSeq=0) -- the snapshot body
+//   is handed to the onSnapshot callback (apply it to your book), the
+//   sequencer fast-forwards to lastSeq+1 and the incremental feed continues.
+// - A failed round-trip retries with doubling backoff, bounded by
+//   maxAttempts -- never an eternal loop; exhaustion counts in
+//   recoveriesFailed() and the stream falls back to plain gap semantics
+//   (the detector re-raises or abandons per its own config).
+//
+// The wrapped subscriber must NOT have its own GapDetector attached
+// (setGapDetector): this class owns sequencing. Single-threaded like the
+// subscriber itself: all recovery work happens inside recv() on the calling
+// thread (backoff sleeps block the caller, as any synchronous recover would).
+class RecoveringMdSubscriber
+{
+ public:
+  struct Config
+  {
+    std::string host{"127.0.0.1"};  // recovery server (MdRecoveryServer)
+    uint16_t port{0};
+    uint64_t maxGapBeforeSnapshot{256};                                       // deeper holes take the snapshot path
+    int maxAttempts{3};                                                       // recovery round-trips per incident
+    std::chrono::milliseconds initialBackoff{std::chrono::milliseconds(20)};  // doubles per retry
+  };
+
+  // Snapshot application hook: `orders` is the AddOrder book body (seq=0).
+  // Clear the symbol's book and apply the records; the wrapper resumes the
+  // incremental stream at begin.lastSeq + 1 afterwards.
+  using SnapshotFn = std::function<void(SymbolId symbol, const MdSnapshotBegin& begin,
+                                        const std::vector<MdMessage>& orders)>;
+
+  RecoveringMdSubscriber(UdpMdSubscriber& sub, Config cfg, GapDetector::Config gdCfg = {})
+      : sub_(sub), cfg_(std::move(cfg)), gd_(gdCfg)
+  {
+  }
+
+  void onSnapshot(SnapshotFn fn) { onSnapshot_ = std::move(fn); }
+
+  // Receive the next IN-ORDER message; false on socket timeout / error with
+  // no recovery pending (a pending recovery is serviced before giving up).
+  bool recv(MdMessage& out)
+  {
+    while (true)
+    {
+      if (recoveryPending())
+      {
+        serviceRecovery();
+      }
+      if (!ready_.empty())
+      {
+        out = ready_.front();
+        ready_.pop_front();
+        return true;
+      }
+      MdMessage m;
+      if (!sub_.recv(m))
+      {
+        if (!recoveryPending())
+        {
+          return false;  // plain timeout, nothing to recover
+        }
+        continue;  // service the pending recovery (bounded), then re-check
+      }
+      observe(m);
+    }
+  }
+
+  // Next seq the symbol's stream will deliver (GapDetector::expected).
+  uint64_t expected(SymbolId symbol) const { return gd_.expected(symbol); }
+
+  uint64_t gapsDetected() const noexcept { return gaps_; }
+  uint64_t epochChanges() const noexcept { return epochs_; }
+  uint64_t resendsRecovered() const noexcept { return resends_; }
+  uint64_t snapshotsRecovered() const noexcept { return snapshots_; }
+  uint64_t recoveriesFailed() const noexcept { return failures_; }
+
+ private:
+  struct Pending
+  {
+    bool active{false};
+    bool snapshot{false};  // snapshot path (epoch change / too-deep gap) vs resend
+    uint64_t fromSeq{0};
+    uint64_t epoch{0};
+    int attempts{0};
+  };
+
+  bool recoveryPending() const
+  {
+    for (const auto& [sym, p] : pending_)
+    {
+      (void)sym;
+      if (p.active)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void deliver(const MdMessage& m) { ready_.push_back(m); }
+
+  void observe(const MdMessage& m)
+  {
+    gd_.observe(m, [this](const MdMessage& d)
+                { deliver(d); }, [this](SymbolId s, uint64_t ep, uint64_t from)
+                {
+                  ++gaps_;
+                  Pending& p = pending_[s];
+                  if (!p.active)
+                  {
+                    p = Pending{};
+                    p.active = true;
+                  }
+                  p.fromSeq = from;
+                  p.epoch = ep; }, [this](SymbolId s, uint64_t, uint64_t newEpoch)
+                {
+                  ++epochs_;
+                  Pending& p = pending_[s];
+                  p = Pending{};
+                  p.active = true;
+                  p.snapshot = true;  // prior book is void, not merely gapped
+                  p.epoch = newEpoch; });
+    // Depth check outside the callbacks: this message's seq bounds the hole.
+    // A gap deeper than the resend budget flips to the snapshot path -- the
+    // server would route it there anyway once the ring has trimmed.
+    auto it = pending_.find(m.symbol);
+    if (it != pending_.end() && it->second.active && !it->second.snapshot &&
+        m.seq > it->second.fromSeq && m.seq - it->second.fromSeq > cfg_.maxGapBeforeSnapshot)
+    {
+      it->second.snapshot = true;
+    }
+  }
+
+  void serviceRecovery()
+  {
+    for (auto& [sym, p] : pending_)
+    {
+      if (p.active)
+      {
+        attemptRecovery(sym, p);
+      }
+    }
+  }
+
+  void attemptRecovery(SymbolId sym, Pending& p)
+  {
+    MdRecoveryClient::Result res;
+    const uint64_t fromSeq = p.snapshot ? 0 : p.fromSeq;
+    const MdRecoveryClient::Status st =
+        MdRecoveryClient(cfg_.host, cfg_.port).recover(sym, fromSeq, res);
+    if (st != MdRecoveryClient::Status::Ok)
+    {
+      ++p.attempts;
+      if (p.attempts >= cfg_.maxAttempts)
+      {
+        ++failures_;
+        p = Pending{};  // give up on this incident; the detector re-raises or abandons
+        return;
+      }
+      // Bounded, doubling backoff between attempts; the next recv() pass
+      // retries. Never an unbounded spin: attempts are capped above.
+      std::this_thread::sleep_for(cfg_.initialBackoff * (1 << (p.attempts - 1)));
+      return;
+    }
+    if (res.snapshot)
+    {
+      // Server chose (or we requested) the snapshot path. Hand the book body
+      // to the consumer, then fast-forward the sequencer: held datagrams past
+      // lastSeq drain into the in-order stream immediately.
+      if (onSnapshot_)
+      {
+        onSnapshot_(sym, res.begin, res.messages);
+      }
+      gd_.reset(sym, res.epoch, res.lastSeq + 1, [this](const MdMessage& d)
+                { deliver(d); });
+      ++snapshots_;
+    }
+    else
+    {
+      // Replayed increments weave through the detector: they fill the hole in
+      // seq order and drain whatever was held behind it. If the replay did
+      // not reach the hole's end, the still-open gap re-raises on subsequent
+      // live traffic and recovery re-arms.
+      for (const MdMessage& m : res.messages)
+      {
+        gd_.observe(m, [this](const MdMessage& d)
+                    { deliver(d); });
+      }
+      ++resends_;
+    }
+    p = Pending{};
+  }
+
+  UdpMdSubscriber& sub_;
+  Config cfg_;
+  GapDetector gd_;
+  SnapshotFn onSnapshot_;
+  std::deque<MdMessage> ready_;  // sequenced, deliverable messages
+  std::unordered_map<SymbolId, Pending> pending_;
+  uint64_t gaps_{0};
+  uint64_t epochs_{0};
+  uint64_t resends_{0};
+  uint64_t snapshots_{0};
+  uint64_t failures_{0};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/messages.h
+++ b/venue/include/flox-venue/messages.h
@@ -10,15 +10,26 @@
 
 #include "flox/common.h"  // Price, Quantity, Side, OrderId, OrderType, TimeInForce, STPMode, SymbolId
 
+#include "flox-venue/ledger.h"  // AssetId, kMoneyScale (Deposit/Withdraw amounts)
 #include "flox-venue/reject_reason.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <variant>
 
 namespace flox::venue
 {
 
 // ---- Inbound commands -----------------------------------------------------
+
+// Reference price a conditional order (stop / take-profit / trailing) triggers
+// against. Spot: last trade price. Derivatives: usually the mark price.
+enum class TriggerRef : uint8_t
+{
+  Last = 0,
+  Mark = 1,
+};
 
 // Peg reference: a resting order tracks the book, re-priced at each submit
 // boundary. Bid/Ask peg to the near or far touch; Mid to the midpoint.
@@ -135,11 +146,303 @@ struct AdminCmd
   AdminAction action{};
 };
 
-using InboundCommand = std::variant<NewOrder, CancelOrder, ModifyOrder, MassCancel, Quote,
-                                    LastLookDecision, SetMark, ApplyFunding, AdminCmd>;
+// Genesis flows through the SAME sequenced, journaled stream as orders, so a
+// replay from an EMPTY ledger/registry reproduces balances and instrument
+// state without out-of-band seeding. Amounts travel as int64 raw at
+// kMoneyScale (1e-8 units) -- the scale the ledger settles in -- matching the
+// raw fixed-point convention of every other wire number (SetMark, prices).
+struct Deposit  // credit external funds into an account
+{
+  uint64_t accountId{};
+  AssetId asset{};
+  int64_t amountRaw{};  // kMoneyScale units; <= 0 is ignored
+  SymbolId symbol{};    // routing key only: the shard owning this account's ledger
+};
+
+struct Withdraw  // debit available funds; a no-op unless available >= amount
+{
+  uint64_t accountId{};
+  AssetId asset{};
+  int64_t amountRaw{};  // kMoneyScale units; <= 0 is ignored
+  SymbolId symbol{};    // routing key only
+};
+
+// Instrument configuration mutations, sequenced so a restart replays them.
+// ListInstrument carries the control-plane listing surface (see ControlApi);
+// structural knobs beyond it (assets, scales, margin, fees) are startup
+// configuration supplied when the shard is constructed.
+struct ListInstrument
+{
+  SymbolId symbol{};
+  Price tickSize{};
+  Quantity lotSize{};
+  Price minPrice{};
+  Price maxPrice{};
+};
+
+struct SetBands  // adjust the static price band (collar) of a listed instrument
+{
+  SymbolId symbol{};
+  Price minPrice{};
+  Price maxPrice{};
+};
+
+struct SetTriggerRef  // switch the conditional-order reference (last trade vs mark)
+{
+  SymbolId symbol{};
+  TriggerRef ref{TriggerRef::Last};
+};
+
+// Firm-group STP membership: map an account to a firm/group id so self-trade
+// prevention fires across all of a firm's accounts. Sequenced and journaled
+// like every other engine-state mutation (the group table feeds matching
+// decisions), so replay and recovery reproduce the same STP outcomes; a
+// checkpoint re-emits the live table as SetStpGroup records in its config
+// section. group 0 removes the membership (back to account-level STP).
+struct SetStpGroup
+{
+  SymbolId symbol{};  // routing key
+  uint64_t account{};
+  uint64_t group{};
+};
+
+// Idle time sweep: carries no order flow, only advances engine time so
+// last-look holds (and GTD expiries) resolve on a quiet symbol instead of
+// waiting for the next order. Sequenced and journaled like any other command,
+// so a replay reproduces every timeout at the same point in the stream.
+struct TimeTick
+{
+  SymbolId symbol{};  // routing key
+};
+
+// ---- Snapshot-only records ------------------------------------------------
+// A checkpoint is NOT a parallel binary format: it is a journal-format file
+// (same [ts][tag][len][body][crc] framing, same CRC/torn-tail protection)
+// whose records rebuild engine state through the same apply machinery live
+// traffic uses. These records are SNAPSHOT-ONLY: MatchingEngine::submit drops
+// them from live traffic (a client must never be able to "restore" itself an
+// order or a balance); they apply exclusively through
+// MatchingEngine::applySnapshotRecord during shard recovery.
+//
+// Balances travel as snapshot-only RestoreBalance records carrying the EXACT
+// signed (available, reserved) split -- so any live moment is representable,
+// including a negative wallet mid-liquidation. RestoreReservation /
+// RestorePosition then only rebuild the engine-side reservation/position
+// tables; they do not move ledger money when the balances were restored
+// exactly. Snapshots written by format version 1 carried Deposit records
+// (TOTAL per account x asset) instead; those still apply through the same
+// journaled-deposit path and reconstitute `reserved` by re-reservation
+// (backward read compatibility). Instrument configuration travels as existing
+// ListInstrument / SetBands / SetTriggerRef / SetStpGroup / AdminCmd records.
+
+// v2: SnapshotBegin gained configHash; balances moved from Deposit totals to
+// exact RestoreBalance splits; MMP fill windows serialize (RestoreMmpFills).
+inline constexpr uint32_t kSnapshotFormatVersion = 2;
+
+struct SnapshotBegin
+{
+  uint32_t formatVersion{kSnapshotFormatVersion};
+  int64_t lastAppliedTs{0};  // sequencer-ts of the last command folded into this snapshot
+  uint64_t stateHash{0};     // MatchingEngine::stateHash() at write time (repeated in SnapshotEnd)
+  // Hash of the engine's CONSTRUCTOR configuration (scales, assets, tick/lot,
+  // last-look window, perp mode, match policy -- MatchingEngine::configHash).
+  // Recovery compares it against the loading engine and rejects the snapshot
+  // on mismatch: restoring raw fixed-point state into an engine with, say,
+  // different scales would silently reinterpret every price and quantity.
+  // 0 = unknown (crafted/legacy file): the check is skipped.
+  uint64_t configHash{0};
+};
+
+struct RestoreOrder  // one resting book order, applied straight to the TAIL of its level
+{
+  OrderId id{};
+  uint64_t accountId{};
+  Price price{};
+  Quantity leaves{};  // displayed peak
+  Side side{};
+  Quantity hidden{};  // iceberg reserve (0 = none)
+  Quantity peak{};    // iceberg display size (0 = non-iceberg)
+  bool lastLook{false};
+  bool reduceOnly{false};
+  // The engine keeps only the per-account dedup SET (restored via
+  // RestoreClOrdIds), not an order -> clientOrderId mapping, so writeSnapshot
+  // emits 0 here; the field exists so the record stays self-contained if a
+  // future engine retains the mapping.
+  uint64_t clientOrderId{0};
+  int64_t expiryNs{0};   // GTD expiry sequencer-ts (0 = none)
+  uint64_t ocoGroup{0};  // OCO group (0 = none)
+};
+
+struct RestoreStop  // one pending conditional order (stop book)
+{
+  NewOrder order{};
+  Price trigger{};  // current trigger; trailing: the ratcheted value (raw 0 = unarmed)
+};
+
+struct RestorePeg  // peg spec of a resting order (pegged_ entry)
+{
+  OrderId id{};
+  Side side{};
+  PegRef ref{PegRef::None};
+  int64_t offsetRaw{0};
+};
+
+struct RestoreHeld  // one open last-look hold (mirrors MatchingEngine::Held)
+{
+  uint64_t heldId{};
+  OrderId taker{};
+  uint64_t takerAccount{};
+  Side takerSide{};
+  OrderId maker{};
+  uint64_t makerAccount{};
+  Price price{};
+  Quantity qty{};
+  int64_t deadline{};
+  TimeInForce takerTif{TimeInForce::GTC};
+  OrderType takerType{OrderType::LIMIT};
+  Price takerPrice{};
+  int64_t takerExpiryNs{0};
+  bool makerReduceOnly{false};
+  bool takerReduceOnly{false};
+  // Whether the maker is in the engine's live-order tracking maps. Normally
+  // true (a held maker stays tracked even fully off the book), but an
+  // STP-cancel can legally remove a maker while its hold stays open -- the
+  // write side records the live truth instead of re-deriving it.
+  bool makerTracked{true};
+};
+
+struct RestorePosition  // one perp position (qty, average entry, posted margin)
+{
+  uint64_t account{};
+  int64_t qtyRaw{0};    // signed contracts (Quantity raw)
+  int64_t entryRaw{0};  // average entry price (Price raw)
+  Amount marginRaw{0};  // posted position margin (quote raw); re-reserved on apply
+};
+
+struct RestoreMmpCfg  // market-maker-protection config for one account.
+{
+  // The mmp FILL WINDOWS restore EMPTY by design: the sliding window is
+  // shorter than any realistic checkpoint interval, so the lost tail of the
+  // window cannot span a restart (see docs/venue/runtime.md).
+  uint64_t account{};
+  Quantity qtyLimit{};
+  int64_t windowNs{0};
+};
+
+inline constexpr uint32_t kClOrdIdBatch = 32;
+
+struct RestoreClOrdIds  // fixed-size batch of an account's clientOrderId dedup set
+{
+  // The set can be large; it serializes as repeated fixed-size batches so the
+  // journal's strictly-sized blittable body model is preserved.
+  uint64_t account{};
+  uint32_t count{0};  // ids[0..count) valid, count <= kClOrdIdBatch
+  uint64_t ids[kClOrdIdBatch]{};
+};
+
+// One buying-power reservation entry (MatchingEngine::reserve_), serialized
+// EXACTLY as held live. Reservations are deliberately not re-derived from
+// order formulas on load: partial fills, held slices and STP interactions
+// make the live amount history-dependent, so the record carries it. Applying
+// still moves the amount available -> reserved through Ledger::reserve, so
+// the deposited totals split back into the exact live available/reserved.
+struct RestoreReservation
+{
+  OrderId id{};
+  uint64_t account{};
+  AssetId asset{};
+  Side side{};
+  int64_t limitPriceRaw{0};
+  Amount reservedRaw{0};
+};
+
+// One (account, asset) ledger balance, EXACT signed available/reserved split.
+// Snapshot-only: a client that could submit this would set its own balance.
+// Applied via Ledger::restore (recovery-only direct write); RestoreReservation
+// and RestorePosition records that follow rebuild the engine-side tables
+// WITHOUT re-reserving, so the split is preserved bit-for-bit -- including
+// states Deposit records could not represent (negative available mid-
+// liquidation, non-positive totals).
+struct RestoreBalance
+{
+  uint64_t account{};
+  AssetId asset{};
+  Amount availableRaw{0};  // signed, kMoneyScale units
+  Amount reservedRaw{0};
+};
+
+inline constexpr uint32_t kMmpFillBatch = 16;
+
+// Fixed-size batch of one account's MMP sliding-window fills, in deque (time)
+// order; consecutive batches for the same account concatenate. Restores the
+// window EXACTLY, so a market maker sitting one fill from its qtyLimit is
+// still one fill from it after recovery -- the window no longer restores
+// empty.
+struct RestoreMmpFills
+{
+  uint64_t account{};
+  uint32_t count{0};  // entries [0..count) valid, count <= kMmpFillBatch
+  int64_t tsNs[kMmpFillBatch]{};
+  int64_t qtyRaw[kMmpFillBatch]{};
+};
+
+struct SnapshotEnd
+{
+  uint64_t stateHash{0};  // must equal the loader's recomputed hash, or the snapshot is corrupt
+  uint64_t tradeSeq{0};
+  uint64_t heldSeq{0};
+  int64_t timeCounter{0};
+  int64_t nowNs{0};
+  uint64_t mdEpoch{0};  // 0 = none (the engine carries no MD epoch today)
+  int64_t lastPriceRaw{0};
+  bool hasLast{false};
+  int64_t markPriceRaw{0};
+  bool hasMark{false};
+  int64_t haltUntilNs{0};  // pending timed (LULD) halt deadline (0 = none)
+};
+
+// Journal tags are the variant indices: append-only, never reorder.
+// (SetTriggerRef postdates TimeTick, hence its position at the tail; the
+// snapshot-only records postdate SetTriggerRef; RestoreBalance/RestoreMmpFills
+// and the live SetStpGroup command postdate the original snapshot block, so
+// live and snapshot-only tags interleave past tag 24.)
+using InboundCommand =
+    std::variant<NewOrder, CancelOrder, ModifyOrder, MassCancel, Quote, LastLookDecision, SetMark,
+                 ApplyFunding, AdminCmd, Deposit, Withdraw, ListInstrument, SetBands, TimeTick,
+                 SetTriggerRef, SnapshotBegin, RestoreOrder, RestoreStop, RestorePeg, RestoreHeld,
+                 RestorePosition, RestoreMmpCfg, RestoreClOrdIds, SnapshotEnd, RestoreReservation,
+                 RestoreBalance, RestoreMmpFills, SetStpGroup>;
+
+inline constexpr size_t kFirstSnapshotTag = 15;
+inline constexpr size_t kLastContiguousSnapshotTag = 24;
+static_assert(std::is_same_v<std::variant_alternative_t<kFirstSnapshotTag, InboundCommand>,
+                             SnapshotBegin>,
+              "kFirstSnapshotTag must index SnapshotBegin");
+static_assert(std::is_same_v<std::variant_alternative_t<kLastContiguousSnapshotTag, InboundCommand>,
+                             RestoreReservation>,
+              "kLastContiguousSnapshotTag must index RestoreReservation");
+
+// Snapshot-only records are forbidden in live traffic; the engine's submit
+// dispatcher drops them and recovery applies them through a dedicated path.
+// Tags [kFirstSnapshotTag, kLastContiguousSnapshotTag] are the original
+// contiguous snapshot block; appended alternatives past it interleave live
+// commands with snapshot-only records, so membership is explicit from there.
+inline bool isSnapshotRecord(const InboundCommand& c) noexcept
+{
+  const size_t i = c.index();
+  return (i >= kFirstSnapshotTag && i <= kLastContiguousSnapshotTag) ||
+         std::holds_alternative<RestoreBalance>(c) || std::holds_alternative<RestoreMmpFills>(c);
+}
 
 // ---- Outbound events ------------------------------------------------------
 
+// Owner account on per-order events (appended fields; wire codecs place them
+// last, and the order-entry wire does not carry them -- the session already IS
+// the account). They exist so the delivery layer (SessionRegistry) can route an
+// asynchronous exec report to the session that owns it: a maker fill from a
+// foreign aggressor, a stop trigger, a GTD expiry or a liquidation cancel has
+// no request/response context to answer on. account == 0 = unrouteable
+// (unbound/trusted-transport sessions).
 struct OrderAccepted  // order accepted / working
 {
   OrderId id{};
@@ -149,6 +452,7 @@ struct OrderAccepted  // order accepted / working
   Quantity leavesQty{};      // full working quantity (for the owner's ack)
   bool restingOnBook{true};  // false = working but not on the visible book (pending stop)
   Quantity displayQty{};     // publicly visible size (== leavesQty unless iceberg; 0 = use leavesQty)
+  uint64_t account{0};       // owner (appended: delivery routing)
 };
 
 struct OrderRejected
@@ -156,6 +460,7 @@ struct OrderRejected
   OrderId id{};
   SymbolId symbol{};
   RejectReason reason{};
+  uint64_t account{0};  // owner (appended: delivery routing)
 };
 
 struct Trade
@@ -185,6 +490,7 @@ struct OrderExecuted  // per-order execution report on a fill
   // (never the hidden reserve), so the public book cannot be probed for hidden
   // size. leavesQty stays the whole remaining for the owner's exec report.
   Quantity displayLeaves{};
+  uint64_t account{0};  // owner of this order leg (appended: delivery routing)
 };
 
 struct OrderCanceled
@@ -192,6 +498,7 @@ struct OrderCanceled
   OrderId id{};
   SymbolId symbol{};
   CancelReason reason{};
+  uint64_t account{0};  // owner (appended: delivery routing)
 };
 
 struct OrderModified
@@ -201,13 +508,15 @@ struct OrderModified
   Price price{};
   Quantity leavesQty{};
   bool priorityKept{false};  // false = re-entered at the tail (lost time priority)
+  uint64_t account{0};       // owner (appended: delivery routing)
 };
 
 struct OrderTriggered  // a stop / take-profit activated and was injected into matching
 {
   OrderId id{};
   SymbolId symbol{};
-  Price refPrice{};  // reference (last-trade) price that crossed the trigger
+  Price refPrice{};     // reference (last-trade) price that crossed the trigger
+  uint64_t account{0};  // owner (appended: delivery routing)
 };
 
 struct FillHeld  // last-look: a fill is held pending the maker's decision
@@ -218,6 +527,12 @@ struct FillHeld  // last-look: a fill is held pending the maker's decision
   OrderId takerId{};
   Price price{};
   Quantity qty{};
+  // Maker's DISPLAYED remaining after the held qty is reserved out of the book
+  // (iceberg: the refilled peak). Lets the public feed keep level == book while
+  // the qty is in limbo. Appended field -- wire codecs place it last.
+  Quantity makerDisplayAfter{};
+  uint64_t makerAccount{0};  // appended: delivery routing (both parties get the report)
+  uint64_t takerAccount{0};
 };
 
 struct FillRejected  // last-look: the held fill was rejected (or timed out)
@@ -225,6 +540,14 @@ struct FillRejected  // last-look: the held fill was rejected (or timed out)
   uint64_t heldId{};
   SymbolId symbol{};
   OrderId takerId{};
+  // Appended fields (wire codecs place them last): what was rejected, so the
+  // taker can show a usable report -- counterparty order, price and size of the
+  // fill that did not happen.
+  OrderId makerId{};
+  Price price{};
+  Quantity qty{};
+  uint64_t takerAccount{0};  // appended: delivery routing (both parties get the report)
+  uint64_t makerAccount{0};
 };
 
 struct MmpTriggered  // market-maker protection fired: the account was mass-canceled
@@ -239,6 +562,7 @@ struct FeeCharged  // per-leg maker/taker fee (negative = rebate)
   SymbolId symbol{};
   Volume fee{};
   bool maker{};
+  uint64_t account{0};  // charged account (appended: delivery routing)
 };
 
 struct Liquidation  // a perp position was force-closed below maintenance margin
@@ -251,8 +575,35 @@ struct Liquidation  // a perp position was force-closed below maintenance margin
   bool adl{};       // auto-deleveraged: closed to absorb a bankrupt counterparty
 };
 
+enum class BalanceReason : uint8_t
+{
+  Deposit = 0,
+  Withdraw = 1,
+  WithdrawRejected = 2,  // insufficient available: nothing moved
+};
+
+// Balance change report on a sequenced Deposit/Withdraw. Carries the POST-event
+// available/reserved of the touched (account, asset) so the owner needs no
+// arithmetic of its own; a rejected withdraw reports the unchanged balances
+// with reason WithdrawRejected -- the client is told, never left guessing.
+// Emitted from the engine's journaled money path only: snapshot restore
+// (Deposit records inside a checkpoint) replays through the same code but the
+// shard's recovery suppression keeps it off the wire, like every replayed
+// event.
+struct BalanceUpdate
+{
+  uint64_t account{};
+  AssetId asset{};
+  int64_t availableRaw{};  // kMoneyScale units after this event
+  int64_t reservedRaw{};
+  BalanceReason reason{};
+};
+
+// Appended alternatives go at the END (wire codecs and the event hash key off
+// the alternative order).
 using OutboundEvent =
     std::variant<OrderAccepted, OrderRejected, Trade, OrderExecuted, OrderCanceled, OrderModified,
-                 OrderTriggered, FillHeld, FillRejected, MmpTriggered, FeeCharged, Liquidation>;
+                 OrderTriggered, FillHeld, FillRejected, MmpTriggered, FeeCharged, Liquidation,
+                 BalanceUpdate>;
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/metrics.h
+++ b/venue/include/flox-venue/metrics.h
@@ -13,6 +13,7 @@
 #include "flox-venue/reject_reason.h"
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <unordered_map>
 
@@ -96,6 +97,26 @@ struct Metrics
 
  private:
   std::unordered_map<SymbolId, std::pair<int64_t, int64_t>> scales_;
+};
+
+// Perimeter (gateway/delivery) counters. Atomics: they are bumped from
+// connection reader threads, per-session writer threads and the matching
+// thread concurrently, unlike Metrics which lives on the engine thread.
+struct GatewayCounters
+{
+  std::atomic<uint64_t> slowConsumerDisconnects{0};  // outbound queue overflow -> session dropped
+  std::atomic<uint64_t> idleDisconnects{0};          // liveness timeout -> session dropped
+  std::atomic<uint64_t> resendServed{0};             // ResendRequest served from the session log
+};
+
+// Market-data feed counters. Atomics: sendDrops is bumped on the matching
+// thread (publish path), the recovery counters on MdRecoveryServer connection
+// threads.
+struct MdCounters
+{
+  std::atomic<uint64_t> sendDrops{0};        // sendto failed/partial: datagram never left the host
+  std::atomic<uint64_t> resendServed{0};     // recovery requests answered by ring replay
+  std::atomic<uint64_t> snapshotsServed{0};  // recovery requests answered by a full snapshot
 };
 
 // Point-in-time venue state that is NOT derivable from the outbound event

--- a/venue/include/flox-venue/reject_reason.h
+++ b/venue/include/flox-venue/reject_reason.h
@@ -26,11 +26,20 @@ enum class RejectReason : uint8_t
   UnknownOrder,
   PostOnlyWouldCross,
   FillOrKillUnfulfillable,
-  OrderTooLarge,          // fat-finger: exceeds max order qty / notional
-  InsufficientFunds,      // pre-trade credit / buying-power check failed
-  LuldBreach,             // price outside the limit-up/limit-down volatility band
-  PositionLimitExceeded,  // would grow the account's position past the symbol cap
-  TooManyOpenOrders,      // account already at its max live-order count (ingress DoS/risk gate)
+  OrderTooLarge,           // fat-finger: exceeds max order qty / notional
+  InsufficientFunds,       // pre-trade credit / buying-power check failed
+  LuldBreach,              // price outside the limit-up/limit-down volatility band
+  PositionLimitExceeded,   // would grow the account's position past the symbol cap
+  TooManyOpenOrders,       // account already at its max live-order count (ingress DoS/risk gate)
+  NotOrderOwner,           // last-look decision from an account that does not own the held maker order
+  DuplicateClientOrderId,  // clientOrderId already used by this account this session (resend dedup)
+  LastLookUnsupported,     // lastLook order on a pro-rata instrument (allocation would not honour the hold)
+  // Session-level admission rejects, surfaced to the client as an exec-report
+  // reject instead of silence (appended values -- wire enum is append-only).
+  RateLimited,       // per-session rate limit tripped; the command was not admitted
+  MalformedMessage,  // frame did not decode to a valid command
+  Unauthenticated,   // command before a successful logon
+  SessionSeqGap,     // FIX: inbound MsgSeqNum gap -- session must resync
 };
 
 enum class CancelReason : uint8_t

--- a/venue/include/flox-venue/resend_buffer.h
+++ b/venue/include/flox-venue/resend_buffer.h
@@ -5,115 +5,186 @@
  * Copyright (c) 2025 FLOX Foundation
  * Licensed under the MIT License. See LICENSE file in the project root for full
  * license information.
+ *
+ * The old ResendBuffer (a per-session OutboundEvent log) was removed: the
+ * per-account resend log now lives in SessionRegistry (session_registry.h),
+ * which stores the SERIALIZED frames with their embedded seq -- replay is a
+ * byte-for-byte repeat of the original reports, reachable from the wire via
+ * the SBE ResendRequest verb. Keeping an unreachable event-level duplicate
+ * here would just be dead forest.
+ *
+ * GapDetector is the CLIENT-side market-data sequencer. It consumes the raw
+ * (possibly reordered, duplicated, gapped) datagram stream and delivers
+ * messages strictly in seq order per (symbol, epoch):
+ *
+ * - Keyed by symbol: multiple per-symbol publishers may share one multicast
+ *   group; every root block carries the symbol, so the detector demultiplexes
+ *   before any gap accounting.
+ * - Reordering: a message ahead of the next expected seq is HELD, not
+ *   delivered; when the missing seq arrives (a late, reordered datagram --
+ *   NOT a duplicate) the contiguous run drains in order. Nothing held is ever
+ *   lost: if held messages exceed maxHeld the gap is abandoned and the held
+ *   run is delivered in seq order (the consumer was already told about the
+ *   gap and can re-snapshot).
+ * - Gap reporting: onGap fires once when a gap opens (fromSeq = first missing
+ *   seq) and RE-FIRES every reraiseAfter further received messages while the
+ *   gap stays unfilled -- a lost resend does not strand the consumer.
+ * - Epoch: a changed epoch means the publisher restarted; held state is
+ *   dropped, the stream resets to seq 1 and onEpoch fires so the consumer can
+ *   re-snapshot (its book is stale, not just gapped).
+ * - reset() fast-forwards a stream after a snapshot was applied (next =
+ *   snapshot lastSeq+1); held messages beyond the snapshot drain immediately.
  */
 #pragma once
 
-#include "flox-venue/messages.h"
+#include "flox-venue/market_data.h"
 
-#include <algorithm>
 #include <cstdint>
+#include <functional>
+#include <map>
 #include <unordered_map>
-#include <vector>
 
 namespace flox::venue
 {
 
-struct SeqMessage
-{
-  uint64_t seq{};
-  int64_t tsNs{};
-  OutboundEvent event{};
-};
-
-class ResendBuffer
-{
- public:
-  // Assign the next per-session sequence number, buffer the message, return seq.
-  uint64_t append(uint64_t session, const OutboundEvent& e, int64_t tsNs)
-  {
-    auto& s = sessions_[session];
-    const uint64_t seq = ++s.lastSeq;
-    s.log.push_back(SeqMessage{seq, tsNs, e});
-    return seq;
-  }
-
-  uint64_t lastSeq(uint64_t session) const
-  {
-    auto it = sessions_.find(session);
-    return it == sessions_.end() ? 0 : it->second.lastSeq;
-  }
-
-  // Replay buffered messages with seq >= fromSeq, in order (gap-fill on reconnect).
-  std::vector<SeqMessage> resend(uint64_t session, uint64_t fromSeq) const
-  {
-    std::vector<SeqMessage> out;
-    auto it = sessions_.find(session);
-    if (it == sessions_.end())
-    {
-      return out;
-    }
-    // The log is append-ordered by seq (append increments lastSeq; ackThrough
-    // only trims the front), so binary-search the first seq >= fromSeq instead
-    // of scanning the whole history.
-    const auto& log = it->second.log;
-    const auto lo = std::lower_bound(log.begin(), log.end(), fromSeq,
-                                     [](const SeqMessage& m, uint64_t s)
-                                     { return m.seq < s; });
-    out.assign(lo, log.end());
-    return out;
-  }
-
-  // Drop acknowledged history up to and including `throughSeq` (bounded memory).
-  void ackThrough(uint64_t session, uint64_t throughSeq)
-  {
-    auto it = sessions_.find(session);
-    if (it == sessions_.end())
-    {
-      return;
-    }
-    auto& log = it->second.log;
-    size_t keep = 0;
-    while (keep < log.size() && log[keep].seq <= throughSeq)
-    {
-      ++keep;
-    }
-    log.erase(log.begin(), log.begin() + static_cast<std::ptrdiff_t>(keep));
-  }
-
- private:
-  struct Session
-  {
-    uint64_t lastSeq{0};
-    std::vector<SeqMessage> log;
-  };
-  std::unordered_map<uint64_t, Session> sessions_;
-};
-
-// Client-side gap detector: tracks the next expected sequence and reports the
-// first missing seq when a message arrives out of order.
 class GapDetector
 {
  public:
-  // Returns {gap, fromSeq}: gap=true means a resend for [fromSeq, seq) is needed.
-  std::pair<bool, uint64_t> observe(uint64_t seq)
+  struct Config
   {
-    if (seq == expected_)
+    uint64_t reraiseAfter{16};  // re-report an unfilled gap after this many further messages
+    size_t maxHeld{1024};       // held messages per symbol before the gap is abandoned
+  };
+
+  using DeliverFn = std::function<void(const MdMessage&)>;
+  using GapFn = std::function<void(SymbolId, uint64_t epoch, uint64_t fromSeq)>;
+  using EpochFn = std::function<void(SymbolId, uint64_t oldEpoch, uint64_t newEpoch)>;
+
+  GapDetector() = default;
+  explicit GapDetector(Config cfg) : cfg_(cfg) {}
+
+  // Feed one received message. In-order messages (including a drained held
+  // run) go to `deliver`; a new or re-raised gap goes to `onGap`; a publisher
+  // restart goes to `onEpoch`. Duplicates are dropped silently.
+  void observe(const MdMessage& m, const DeliverFn& deliver, const GapFn& onGap = {},
+               const EpochFn& onEpoch = {})
+  {
+    Stream& s = streams_[m.symbol];
+    if (!s.epochSet)
     {
-      ++expected_;
-      return {false, 0};
+      s.epoch = m.epoch;
+      s.epochSet = true;
     }
-    if (seq > expected_)
+    else if (m.epoch != s.epoch)
     {
-      const uint64_t from = expected_;
-      expected_ = seq + 1;
-      return {true, from};
+      const uint64_t old = s.epoch;
+      s = Stream{};
+      s.epoch = m.epoch;
+      s.epochSet = true;
+      if (onEpoch)
+      {
+        onEpoch(m.symbol, old, m.epoch);
+      }
     }
-    return {false, 0};  // duplicate / already seen
+
+    bool freshGap = false;
+    if (m.seq == s.next)
+    {
+      deliver(m);
+      ++s.next;
+      drainHeld(s, deliver);
+    }
+    else if (m.seq > s.next)
+    {
+      const bool held = s.held.emplace(m.seq, m).second;  // false: duplicate of a held one
+      if (held && !s.gapOpen)
+      {
+        s.gapOpen = true;
+        s.sinceReport = 0;
+        freshGap = true;
+        if (onGap)
+        {
+          onGap(m.symbol, s.epoch, s.next);
+        }
+      }
+      if (s.held.size() > cfg_.maxHeld)
+      {
+        abandonGap(s, deliver);
+      }
+    }
+    // else m.seq < s.next: duplicate below the delivery watermark -- drop
+
+    s.gapOpen = !s.held.empty();
+    if (s.gapOpen && !freshGap && ++s.sinceReport >= cfg_.reraiseAfter)
+    {
+      s.sinceReport = 0;
+      if (onGap)
+      {
+        onGap(m.symbol, s.epoch, s.next);
+      }
+    }
   }
-  uint64_t expected() const noexcept { return expected_; }
+
+  // Fast-forward after a snapshot: the snapshot covered everything up to
+  // nextSeq-1, so held messages below it are stale (pruned) and the contiguous
+  // run at/after it drains through `deliver` now.
+  void reset(SymbolId symbol, uint64_t epoch, uint64_t nextSeq, const DeliverFn& deliver = {})
+  {
+    Stream& s = streams_[symbol];
+    s.epoch = epoch;
+    s.epochSet = true;
+    s.next = nextSeq;
+    s.held.erase(s.held.begin(), s.held.lower_bound(nextSeq));
+    if (deliver)
+    {
+      drainHeld(s, deliver);
+    }
+    s.gapOpen = !s.held.empty();
+    s.sinceReport = 0;
+  }
+
+  // Next seq the symbol's stream will deliver (1 for an unseen symbol).
+  uint64_t expected(SymbolId symbol) const
+  {
+    const auto it = streams_.find(symbol);
+    return it == streams_.end() ? 1 : it->second.next;
+  }
 
  private:
-  uint64_t expected_{1};
+  struct Stream
+  {
+    uint64_t epoch{0};
+    bool epochSet{false};
+    uint64_t next{1};                    // next seq to deliver
+    std::map<uint64_t, MdMessage> held;  // out-of-order messages awaiting the gap fill
+    bool gapOpen{false};
+    uint64_t sinceReport{0};
+  };
+
+  static void drainHeld(Stream& s, const DeliverFn& deliver)
+  {
+    while (!s.held.empty() && s.held.begin()->first == s.next)
+    {
+      deliver(s.held.begin()->second);
+      s.held.erase(s.held.begin());
+      ++s.next;
+    }
+  }
+
+  // Held overflow: give up waiting for the resend and deliver everything held
+  // in seq order (with the hole). The gap was already reported; a consumer
+  // that needs a hole-free book re-snapshots.
+  static void abandonGap(Stream& s, const DeliverFn& deliver)
+  {
+    while (!s.held.empty())
+    {
+      s.next = s.held.begin()->first;
+      drainHeld(s, deliver);
+    }
+  }
+
+  Config cfg_;
+  std::unordered_map<SymbolId, Stream> streams_;
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/rest_json.h
+++ b/venue/include/flox-venue/rest_json.h
@@ -161,6 +161,37 @@ class RestJson
       w.u64("id", g->id);
       w.fixed("refPrice", g->refPrice.raw());
     }
+    else if (const auto* fh = std::get_if<FillHeld>(&ev))
+    {
+      // Last look: heldId is the handle the maker answers with; the taker sees
+      // which fill is in limbo, at what price and size.
+      w.str("type", "fillHeld");
+      w.u64("heldId", fh->heldId);
+      w.u64("maker", fh->makerId);
+      w.u64("taker", fh->takerId);
+      w.fixed("price", fh->price.raw());
+      w.fixed("qty", fh->qty.raw());
+    }
+    else if (const auto* fr = std::get_if<FillRejected>(&ev))
+    {
+      w.str("type", "fillRejected");
+      w.u64("heldId", fr->heldId);
+      w.u64("maker", fr->makerId);
+      w.u64("taker", fr->takerId);
+      w.fixed("price", fr->price.raw());
+      w.fixed("qty", fr->qty.raw());
+    }
+    else if (const auto* bu = std::get_if<BalanceUpdate>(&ev))
+    {
+      w.str("type", "balance");
+      w.u64("account", bu->account);
+      w.u64("asset", bu->asset);
+      w.fixed("available", bu->availableRaw);
+      w.fixed("reserved", bu->reservedRaw);
+      w.str("reason", bu->reason == BalanceReason::Deposit    ? "deposit"
+                      : bu->reason == BalanceReason::Withdraw ? "withdraw"
+                                                              : "withdrawRejected");
+    }
     w.finish();
   }
 

--- a/venue/include/flox-venue/sbe_md_codec.h
+++ b/venue/include/flox-venue/sbe_md_codec.h
@@ -30,14 +30,44 @@
 namespace flox::venue
 {
 
+// Recovery-channel messages (TCP, length-prefixed frames; see md_recovery.h).
+struct MdResendRequest
+{
+  SymbolId symbol{};
+  uint64_t fromSeq{};  // 0 = late joiner: always answered with a snapshot
+};
+
+struct MdSnapshotBegin
+{
+  SymbolId symbol{};
+  uint64_t epoch{};
+  uint64_t lastSeq{};
+  uint32_t orderCount{};
+};
+
+struct MdSnapshotEnd
+{
+  SymbolId symbol{};
+  uint64_t epoch{};
+  uint64_t lastSeq{};
+};
+
+struct MdSnapshotRequired
+{
+  SymbolId symbol{};
+  uint64_t epoch{};
+  uint64_t lastSeq{};
+};
+
 class SbeMdCodec
 {
  public:
   static constexpr uint16_t kSchemaId = 91;
-  static constexpr uint16_t kVersion = 0;
+  static constexpr uint16_t kVersion = 1;
   static constexpr size_t kHeaderSize = sbe::kHeaderSize;
 
-  // Template ids mirror MdType (order-preserving bijection): templateId = MdType+1.
+  // Template ids 1..6 mirror MdType (order-preserving bijection):
+  // templateId = MdType+1. 7..10 are the recovery-channel messages.
   enum class Tmpl : uint16_t
   {
     AddOrder = 1,
@@ -46,13 +76,26 @@ class SbeMdCodec
     Cancel = 4,
     Replace = 5,
     Triggered = 6,
+    ResendRequest = 7,
+    SnapshotBegin = 8,
+    SnapshotEnd = 9,
+    SnapshotRequired = 10,
   };
 
   // Root-block lengths per template (bytes after the header). Must match the
-  // field lists in md-sbe.xml.
-  static constexpr uint16_t kBlockOrder = 8 + 4 + 8 + 1 + 8 + 8;  // 37: seq,sym,id,side,px,qty
-  static constexpr uint16_t kBlockTrade = kBlockOrder + 8;        // 45: + makerId
-  static constexpr uint16_t kBlockTriggered = 8 + 4 + 8 + 8;      // 28: seq,sym,id,px
+  // field lists in md-sbe.xml. Version 1 appended a trailing epoch (u64) to
+  // every incremental template; a v0 reader skips it via blockLength, and this
+  // decoder accepts v0 frames (epoch reads as 0).
+  static constexpr uint16_t kBlockOrderV0 = 8 + 4 + 8 + 1 + 8 + 8;    // 37: seq,sym,id,side,px,qty
+  static constexpr uint16_t kBlockOrder = kBlockOrderV0 + 8;          // 45: + epoch
+  static constexpr uint16_t kBlockTradeV0 = kBlockOrderV0 + 8;        // 45: + makerId
+  static constexpr uint16_t kBlockTrade = kBlockTradeV0 + 8;          // 53: + epoch
+  static constexpr uint16_t kBlockTriggeredV0 = 8 + 4 + 8 + 8;        // 28: seq,sym,id,px
+  static constexpr uint16_t kBlockTriggered = kBlockTriggeredV0 + 8;  // 36: + epoch
+  static constexpr uint16_t kBlockResendRequest = 4 + 8;              // 12: sym,fromSeq
+  static constexpr uint16_t kBlockSnapshotBegin = 4 + 8 + 8 + 4;      // 24: sym,epoch,lastSeq,count
+  static constexpr uint16_t kBlockSnapshotEnd = 4 + 8 + 8;            // 20: sym,epoch,lastSeq
+  static constexpr uint16_t kBlockSnapshotRequired = kBlockSnapshotEnd;
 
   static constexpr size_t kMaxSize = kHeaderSize + kBlockTrade;  // largest framed message
 
@@ -65,23 +108,28 @@ class SbeMdCodec
       case MdType::AddOrder:
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::AddOrder), kSchemaId, kVersion);
         putOrderBlock(out, m);
+        sbe::putU64(out, m.epoch);
         break;
       case MdType::Trade:
         sbe::putHeader(out, kBlockTrade, tmpl(Tmpl::Trade), kSchemaId, kVersion);
         putOrderBlock(out, m);
         sbe::putU64(out, m.makerId);
+        sbe::putU64(out, m.epoch);
         break;
       case MdType::Executed:
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::Executed), kSchemaId, kVersion);
         putOrderBlock(out, m);
+        sbe::putU64(out, m.epoch);
         break;
       case MdType::Cancel:
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::Cancel), kSchemaId, kVersion);
         putOrderBlock(out, m);
+        sbe::putU64(out, m.epoch);
         break;
       case MdType::Replace:
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::Replace), kSchemaId, kVersion);
         putOrderBlock(out, m);
+        sbe::putU64(out, m.epoch);
         break;
       case MdType::Triggered:
         sbe::putHeader(out, kBlockTriggered, tmpl(Tmpl::Triggered), kSchemaId, kVersion);
@@ -89,8 +137,110 @@ class SbeMdCodec
         sbe::putU32(out, m.symbol);
         sbe::putU64(out, m.id);
         sbe::putI64(out, m.price.raw());
+        sbe::putU64(out, m.epoch);
         break;
     }
+  }
+
+  // ---- recovery-channel messages ----
+
+  static void encode(const MdResendRequest& r, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockResendRequest, tmpl(Tmpl::ResendRequest), kSchemaId, kVersion);
+    sbe::putU32(out, r.symbol);
+    sbe::putU64(out, r.fromSeq);
+  }
+
+  static void encode(const MdSnapshotBegin& s, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSnapshotBegin, tmpl(Tmpl::SnapshotBegin), kSchemaId, kVersion);
+    sbe::putU32(out, s.symbol);
+    sbe::putU64(out, s.epoch);
+    sbe::putU64(out, s.lastSeq);
+    sbe::putU32(out, s.orderCount);
+  }
+
+  static void encode(const MdSnapshotEnd& s, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSnapshotEnd, tmpl(Tmpl::SnapshotEnd), kSchemaId, kVersion);
+    sbe::putU32(out, s.symbol);
+    sbe::putU64(out, s.epoch);
+    sbe::putU64(out, s.lastSeq);
+  }
+
+  static void encode(const MdSnapshotRequired& s, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSnapshotRequired, tmpl(Tmpl::SnapshotRequired), kSchemaId, kVersion);
+    sbe::putU32(out, s.symbol);
+    sbe::putU64(out, s.epoch);
+    sbe::putU64(out, s.lastSeq);
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdResendRequest& r)
+  {
+    const uint8_t* b = checkFrame(p, n, Tmpl::ResendRequest, kBlockResendRequest);
+    if (b == nullptr)
+    {
+      return false;
+    }
+    r.symbol = static_cast<SymbolId>(sbe::getU32(b + 0));
+    r.fromSeq = sbe::getU64(b + 4);
+    return true;
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdSnapshotBegin& s)
+  {
+    const uint8_t* b = checkFrame(p, n, Tmpl::SnapshotBegin, kBlockSnapshotBegin);
+    if (b == nullptr)
+    {
+      return false;
+    }
+    s.symbol = static_cast<SymbolId>(sbe::getU32(b + 0));
+    s.epoch = sbe::getU64(b + 4);
+    s.lastSeq = sbe::getU64(b + 12);
+    s.orderCount = sbe::getU32(b + 20);
+    return true;
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdSnapshotEnd& s)
+  {
+    const uint8_t* b = checkFrame(p, n, Tmpl::SnapshotEnd, kBlockSnapshotEnd);
+    if (b == nullptr)
+    {
+      return false;
+    }
+    s.symbol = static_cast<SymbolId>(sbe::getU32(b + 0));
+    s.epoch = sbe::getU64(b + 4);
+    s.lastSeq = sbe::getU64(b + 12);
+    return true;
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdSnapshotRequired& s)
+  {
+    const uint8_t* b = checkFrame(p, n, Tmpl::SnapshotRequired, kBlockSnapshotRequired);
+    if (b == nullptr)
+    {
+      return false;
+    }
+    s.symbol = static_cast<SymbolId>(sbe::getU32(b + 0));
+    s.epoch = sbe::getU64(b + 4);
+    s.lastSeq = sbe::getU64(b + 12);
+    return true;
+  }
+
+  // Template id of a framed message; 0 on a short buffer or foreign schema.
+  static uint16_t templateId(const uint8_t* p, size_t n)
+  {
+    if (n < sbe::kHeaderSize)
+    {
+      return 0;
+    }
+    const sbe::Header h = sbe::readHeader(p);
+    return h.schemaId == kSchemaId ? h.templateId : 0;
   }
 
   // Decode one framed message. Returns false on a short buffer, a foreign
@@ -118,26 +268,34 @@ class SbeMdCodec
       case Tmpl::Executed:
       case Tmpl::Cancel:
       case Tmpl::Replace:
-        if (h.blockLength < kBlockOrder)
+        if (h.blockLength < kBlockOrderV0)
         {
           return false;
         }
         m = MdMessage{};
         m.type = tmplToType(static_cast<Tmpl>(h.templateId));
         getOrderBlock(b, m);
+        if (h.blockLength >= kBlockOrder)
+        {
+          m.epoch = sbe::getU64(b + kBlockOrderV0);  // v1 trailing field; v0 frame -> 0
+        }
         return true;
       case Tmpl::Trade:
-        if (h.blockLength < kBlockTrade)
+        if (h.blockLength < kBlockTradeV0)
         {
           return false;
         }
         m = MdMessage{};
         m.type = MdType::Trade;
         getOrderBlock(b, m);
-        m.makerId = sbe::getU64(b + kBlockOrder);
+        m.makerId = sbe::getU64(b + kBlockOrderV0);
+        if (h.blockLength >= kBlockTrade)
+        {
+          m.epoch = sbe::getU64(b + kBlockTradeV0);
+        }
         return true;
       case Tmpl::Triggered:
-        if (h.blockLength < kBlockTriggered)
+        if (h.blockLength < kBlockTriggeredV0)
         {
           return false;
         }
@@ -147,7 +305,16 @@ class SbeMdCodec
         m.symbol = static_cast<SymbolId>(sbe::getU32(b + 8));
         m.id = sbe::getU64(b + 12);
         m.price = Price::fromRaw(sbe::getI64(b + 20));
+        if (h.blockLength >= kBlockTriggered)
+        {
+          m.epoch = sbe::getU64(b + kBlockTriggeredV0);
+        }
         return true;
+      case Tmpl::ResendRequest:
+      case Tmpl::SnapshotBegin:
+      case Tmpl::SnapshotEnd:
+      case Tmpl::SnapshotRequired:
+        return false;  // recovery-channel messages, not MdMessage frames
     }
     return false;  // unknown template
   }
@@ -155,6 +322,22 @@ class SbeMdCodec
  private:
   static uint16_t tmpl(Tmpl t) { return static_cast<uint16_t>(t); }
   static MdType tmplToType(Tmpl t) { return static_cast<MdType>(static_cast<uint16_t>(t) - 1); }
+
+  // Validate header + template + block bounds; return the root block, or null.
+  static const uint8_t* checkFrame(const uint8_t* p, size_t n, Tmpl expected, uint16_t minBlock)
+  {
+    if (n < sbe::kHeaderSize)
+    {
+      return nullptr;
+    }
+    const sbe::Header h = sbe::readHeader(p);
+    if (h.schemaId != kSchemaId || h.templateId != tmpl(expected) || h.blockLength < minBlock ||
+        n < sbe::kHeaderSize + h.blockLength)
+    {
+      return nullptr;
+    }
+    return p + sbe::kHeaderSize;
+  }
 
   // Shared seq,symbol,orderId,side,price,qty block (37 bytes).
   static void putOrderBlock(std::vector<uint8_t>& o, const MdMessage& m)

--- a/venue/include/flox-venue/sbe_order_entry_codec.h
+++ b/venue/include/flox-venue/sbe_order_entry_codec.h
@@ -16,7 +16,7 @@
  * One template per message type, carrying only that type's fields.
  *
  * Direction is by templateId: inbound (client -> venue) EnterOrder/Cancel/
- * Replace use ids 1..3; outbound execution reports use ids 10..16. decode()
+ * Replace use ids 1..3; outbound execution reports use ids 10..18. decode()
  * handles the inbound side; encode() serialises either an InboundCommand or an
  * OutboundEvent.
  *
@@ -40,13 +40,34 @@ class SbeOrderEntryCodec
 {
  public:
   static constexpr uint16_t kSchemaId = 92;
-  static constexpr uint16_t kVersion = 0;
+  // Schema version 1: every OUTBOUND template gained a trailing `seq` (u64,
+  // sinceVersion=1) -- the per-session monotonic exec-report sequence number.
+  // Appending to the end of the root block (and bumping blockLength) is the
+  // SBE-sanctioned extension path: a version-0 reader skips the trailing bytes
+  // via the header's blockLength, and this version-1 decoder accepts version-0
+  // frames (their shorter blockLength simply has no seq -> seqOf returns 0).
+  // Inbound templates are unchanged.
+  // Schema version 2:
+  //  - SnapshotEnd gained a trailing `lastSeq` (u64, sinceVersion=2): the
+  //    stream's last assigned outbound seq at snapshot time, so the client
+  //    resumes gap detection from the exact point (a version-1 frame's shorter
+  //    blockLength decodes with lastSeq 0).
+  //  - New inbound SetSessionConfig (6): wire negotiation of per-session
+  //    cancel-on-disconnect (fire-and-forget, handled at the gateway).
+  //  - New outbound BalanceUpdate (21): balance change on a sequenced
+  //    Deposit/Withdraw (including a rejected withdraw).
+  static constexpr uint16_t kVersion = 2;
 
   enum class InTmpl : uint16_t
   {
     EnterOrder = 1,
     CancelOrder = 2,
     ReplaceOrder = 3,
+    // Session-layer verbs (handled by the gateway delivery layer, never
+    // forwarded to matching):
+    ResendRequest = 4,           // {fromSeq}: replay exec reports with seq >= fromSeq
+    AccountSnapshotRequest = 5,  // {}: open orders + position for the session account
+    SetSessionConfig = 6,        // {codEnabled}: per-session cancel-on-disconnect
   };
   enum class OutTmpl : uint16_t
   {
@@ -57,19 +78,35 @@ class SbeOrderEntryCodec
     Rejected = 14,
     Replaced = 15,
     Triggered = 16,
+    FillHeld = 17,      // last-look: fill held pending the maker's decision
+    FillRejected = 18,  // last-look: held fill rejected / timed out
+    // Session-layer replies (not sequenced, not in the resend log):
+    SnapshotRequired = 19,  // resend fromSeq is older than the retained log -> re-sync via snapshot
+    SnapshotEnd = 20,       // terminates a snapshot reply (position + open-order count + lastSeq)
+    BalanceUpdate = 21,     // balance change on Deposit/Withdraw (sequenced exec-report stream)
   };
 
   // Root-block lengths (bytes after the header). Must match order-entry-sbe.xml.
+  // Outbound blocks are the version-1 lengths: version-0 length + 8 (seq).
   static constexpr uint16_t kBlockEnter = 100;
   static constexpr uint16_t kBlockCancel = 20;
   static constexpr uint16_t kBlockReplace = 36;
-  static constexpr uint16_t kBlockAccepted = 30;
-  static constexpr uint16_t kBlockExecuted = 38;
-  static constexpr uint16_t kBlockTrade = 45;
-  static constexpr uint16_t kBlockCanceled = 13;
-  static constexpr uint16_t kBlockRejected = 13;
-  static constexpr uint16_t kBlockReplaced = 29;
-  static constexpr uint16_t kBlockTriggered = 20;
+  static constexpr uint16_t kBlockResendRequest = 8;
+  static constexpr uint16_t kBlockSnapshotRequest = 0;
+  static constexpr uint16_t kBlockSetSessionConfig = 1;
+  static constexpr uint16_t kBlockAccepted = 38;
+  static constexpr uint16_t kBlockExecuted = 46;
+  static constexpr uint16_t kBlockTrade = 53;
+  static constexpr uint16_t kBlockCanceled = 21;
+  static constexpr uint16_t kBlockRejected = 21;
+  static constexpr uint16_t kBlockReplaced = 37;
+  static constexpr uint16_t kBlockTriggered = 28;
+  static constexpr uint16_t kBlockFillHeld = 60;
+  static constexpr uint16_t kBlockFillRejected = 52;
+  static constexpr uint16_t kBlockSnapshotRequired = 8;
+  static constexpr uint16_t kBlockSnapshotEndV1 = 28;  // pre-lastSeq layout (schema v1)
+  static constexpr uint16_t kBlockSnapshotEnd = 36;    // v2: + trailing lastSeq (u64)
+  static constexpr uint16_t kBlockBalanceUpdate = 35;
 
   static constexpr size_t kMaxSize = sbe::kHeaderSize + kBlockEnter;
 
@@ -207,12 +244,17 @@ class SbeOrderEntryCodec
         m.accountId = sbe::getU64(b + 28);
         return InboundCommand{m};
       }
+      default:
+        break;  // session verbs (ResendRequest / AccountSnapshotRequest) are
+                // handled by the gateway delivery layer, never decoded here
     }
     return std::nullopt;  // unknown / outbound template
   }
 
   // ---- outbound: execution report -> wire ----
-  static void encode(const OutboundEvent& ev, std::vector<uint8_t>& out)
+  // `seq` is the per-session exec-report sequence number (schema v1, trailing
+  // field of every outbound root block). 0 = unsequenced (embedded/test use).
+  static void encode(const OutboundEvent& ev, std::vector<uint8_t>& out, uint64_t seq = 0)
   {
     out.clear();
     out.reserve(kMaxSize);
@@ -225,6 +267,7 @@ class SbeOrderEntryCodec
       sbe::putI64(out, a->price.raw());
       sbe::putI64(out, a->leavesQty.raw());
       sbe::putU8(out, a->restingOnBook ? 1 : 0);
+      sbe::putU64(out, seq);
     }
     else if (const auto* x = std::get_if<OrderExecuted>(&ev))
     {
@@ -236,6 +279,7 @@ class SbeOrderEntryCodec
       sbe::putI64(out, x->leavesQty.raw());
       sbe::putU8(out, x->aggressor ? 1 : 0);
       sbe::putU8(out, x->complete ? 1 : 0);
+      sbe::putU64(out, seq);
     }
     else if (const auto* t = std::get_if<Trade>(&ev))
     {
@@ -247,6 +291,7 @@ class SbeOrderEntryCodec
       sbe::putU64(out, t->makerId);
       sbe::putU64(out, t->takerId);
       sbe::putU8(out, static_cast<uint8_t>(t->takerSide));
+      sbe::putU64(out, seq);
     }
     else if (const auto* c = std::get_if<OrderCanceled>(&ev))
     {
@@ -254,6 +299,7 @@ class SbeOrderEntryCodec
       sbe::putU64(out, c->id);
       sbe::putU32(out, c->symbol);
       sbe::putU8(out, static_cast<uint8_t>(c->reason));
+      sbe::putU64(out, seq);
     }
     else if (const auto* j = std::get_if<OrderRejected>(&ev))
     {
@@ -261,6 +307,7 @@ class SbeOrderEntryCodec
       sbe::putU64(out, j->id);
       sbe::putU32(out, j->symbol);
       sbe::putU8(out, static_cast<uint8_t>(j->reason));
+      sbe::putU64(out, seq);
     }
     else if (const auto* m = std::get_if<OrderModified>(&ev))
     {
@@ -270,6 +317,7 @@ class SbeOrderEntryCodec
       sbe::putI64(out, m->price.raw());
       sbe::putI64(out, m->leavesQty.raw());
       sbe::putU8(out, m->priorityKept ? 1 : 0);
+      sbe::putU64(out, seq);
     }
     else if (const auto* g = std::get_if<OrderTriggered>(&ev))
     {
@@ -277,9 +325,190 @@ class SbeOrderEntryCodec
       sbe::putU64(out, g->id);
       sbe::putU32(out, g->symbol);
       sbe::putI64(out, g->refPrice.raw());
+      sbe::putU64(out, seq);
     }
-    // Events without an order-entry exec-report mapping (FillHeld, FillRejected,
-    // MmpTriggered, FeeCharged, Liquidation) produce no frame.
+    else if (const auto* fh = std::get_if<FillHeld>(&ev))
+    {
+      sbe::putHeader(out, kBlockFillHeld, u16(OutTmpl::FillHeld), kSchemaId, kVersion);
+      sbe::putU64(out, fh->heldId);
+      sbe::putU32(out, fh->symbol);
+      sbe::putU64(out, fh->makerId);
+      sbe::putU64(out, fh->takerId);
+      sbe::putI64(out, fh->price.raw());
+      sbe::putI64(out, fh->qty.raw());
+      sbe::putI64(out, fh->makerDisplayAfter.raw());
+      sbe::putU64(out, seq);
+    }
+    else if (const auto* fr = std::get_if<FillRejected>(&ev))
+    {
+      sbe::putHeader(out, kBlockFillRejected, u16(OutTmpl::FillRejected), kSchemaId, kVersion);
+      sbe::putU64(out, fr->heldId);
+      sbe::putU32(out, fr->symbol);
+      sbe::putU64(out, fr->takerId);
+      sbe::putU64(out, fr->makerId);
+      sbe::putI64(out, fr->price.raw());
+      sbe::putI64(out, fr->qty.raw());
+      sbe::putU64(out, seq);
+    }
+    else if (const auto* bu = std::get_if<venue::BalanceUpdate>(&ev))
+    {
+      sbe::putHeader(out, kBlockBalanceUpdate, u16(OutTmpl::BalanceUpdate), kSchemaId, kVersion);
+      sbe::putU64(out, bu->account);
+      sbe::putU16(out, bu->asset);
+      sbe::putI64(out, bu->availableRaw);
+      sbe::putI64(out, bu->reservedRaw);
+      sbe::putU8(out, static_cast<uint8_t>(bu->reason));
+      sbe::putU64(out, seq);
+    }
+    // Events without an order-entry exec-report mapping (MmpTriggered,
+    // FeeCharged, Liquidation) produce no frame.
+  }
+
+  // Per-session seq of an outbound exec report (schema v1 trailing field).
+  // 0 for inbound templates, foreign schemas, or version-0 frames.
+  static uint64_t seqOf(const uint8_t* p, size_t n)
+  {
+    if (n < sbe::kHeaderSize)
+    {
+      return 0;
+    }
+    const sbe::Header h = sbe::readHeader(p);
+    if (h.schemaId != kSchemaId || h.version < 1 || h.templateId < 10 || h.blockLength < 8 ||
+        n < sbe::kHeaderSize + h.blockLength)
+    {
+      return 0;
+    }
+    return sbe::getU64(p + sbe::kHeaderSize + h.blockLength - 8);
+  }
+
+  // ---- session-layer verbs (gateway delivery layer, never matched) ----
+  static void encodeResendRequest(uint64_t fromSeq, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockResendRequest, u16(InTmpl::ResendRequest), kSchemaId, kVersion);
+    sbe::putU64(out, fromSeq);
+  }
+  static std::optional<uint64_t> decodeResendRequest(const uint8_t* p, size_t n)
+  {
+    if (n < sbe::kHeaderSize)
+    {
+      return std::nullopt;
+    }
+    const sbe::Header h = sbe::readHeader(p);
+    if (h.schemaId != kSchemaId || h.templateId != u16(InTmpl::ResendRequest) ||
+        h.blockLength < kBlockResendRequest || n < sbe::kHeaderSize + h.blockLength)
+    {
+      return std::nullopt;
+    }
+    return sbe::getU64(p + sbe::kHeaderSize);
+  }
+  // The snapshot request carries no fields: the session IS the account.
+  static void encodeSnapshotRequest(std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSnapshotRequest, u16(InTmpl::AccountSnapshotRequest), kSchemaId,
+                   kVersion);
+  }
+  static bool isSnapshotRequest(const uint8_t* p, size_t n)
+  {
+    return templateId(p, n) == u16(InTmpl::AccountSnapshotRequest);
+  }
+  // Session config (fire-and-forget): per-session cancel-on-disconnect.
+  static void encodeSetSessionConfig(bool codEnabled, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSetSessionConfig, u16(InTmpl::SetSessionConfig), kSchemaId,
+                   kVersion);
+    sbe::putU8(out, codEnabled ? 1 : 0);
+  }
+  static std::optional<bool> decodeSetSessionConfig(const uint8_t* p, size_t n)
+  {
+    if (n < sbe::kHeaderSize)
+    {
+      return std::nullopt;
+    }
+    const sbe::Header h = sbe::readHeader(p);
+    if (h.schemaId != kSchemaId || h.templateId != u16(InTmpl::SetSessionConfig) ||
+        h.blockLength < kBlockSetSessionConfig || n < sbe::kHeaderSize + h.blockLength)
+    {
+      return std::nullopt;
+    }
+    return p[sbe::kHeaderSize] != 0;
+  }
+  static void encodeSnapshotRequired(uint64_t lastSeq, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSnapshotRequired, u16(OutTmpl::SnapshotRequired), kSchemaId,
+                   kVersion);
+    sbe::putU64(out, lastSeq);
+  }
+  struct SnapshotEnd
+  {
+    uint64_t account{};
+    int64_t positionQtyRaw{};
+    int64_t positionEntryRaw{};
+    uint32_t openOrders{};
+    // Last assigned outbound seq of the account's exec-report stream at
+    // snapshot time (schema v2, trailing field; 0 on a v1 frame). Snapshot
+    // frames themselves are unsequenced and never in the resend log; this is
+    // the exact point the client resumes gap detection from.
+    uint64_t lastSeq{};
+  };
+  static void encodeSnapshotEnd(const SnapshotEnd& se, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSnapshotEnd, u16(OutTmpl::SnapshotEnd), kSchemaId, kVersion);
+    sbe::putU64(out, se.account);
+    sbe::putI64(out, se.positionQtyRaw);
+    sbe::putI64(out, se.positionEntryRaw);
+    sbe::putU32(out, se.openOrders);
+    sbe::putU64(out, se.lastSeq);
+  }
+  static std::optional<SnapshotEnd> decodeSnapshotEnd(const uint8_t* p, size_t n)
+  {
+    if (n < sbe::kHeaderSize)
+    {
+      return std::nullopt;
+    }
+    const sbe::Header h = sbe::readHeader(p);
+    if (h.schemaId != kSchemaId || h.templateId != u16(OutTmpl::SnapshotEnd) ||
+        h.blockLength < kBlockSnapshotEndV1 || n < sbe::kHeaderSize + h.blockLength)
+    {
+      return std::nullopt;
+    }
+    const uint8_t* b = p + sbe::kHeaderSize;
+    SnapshotEnd se;
+    se.account = sbe::getU64(b + 0);
+    se.positionQtyRaw = sbe::getI64(b + 8);
+    se.positionEntryRaw = sbe::getI64(b + 16);
+    se.openOrders = sbe::getU32(b + 24);
+    if (h.blockLength >= kBlockSnapshotEnd)
+    {
+      se.lastSeq = sbe::getU64(b + 28);
+    }
+    return se;
+  }
+  // Balance change on a sequenced Deposit/Withdraw (schema v2).
+  static std::optional<venue::BalanceUpdate> decodeBalanceUpdate(const uint8_t* p, size_t n)
+  {
+    if (n < sbe::kHeaderSize)
+    {
+      return std::nullopt;
+    }
+    const sbe::Header h = sbe::readHeader(p);
+    if (h.schemaId != kSchemaId || h.templateId != u16(OutTmpl::BalanceUpdate) ||
+        h.blockLength < kBlockBalanceUpdate || n < sbe::kHeaderSize + h.blockLength)
+    {
+      return std::nullopt;
+    }
+    const uint8_t* b = p + sbe::kHeaderSize;
+    venue::BalanceUpdate bu;
+    bu.account = sbe::getU64(b + 0);
+    bu.asset = static_cast<AssetId>(sbe::getU16(b + 8));
+    bu.availableRaw = sbe::getI64(b + 10);
+    bu.reservedRaw = sbe::getI64(b + 18);
+    bu.reason = static_cast<BalanceReason>(b[26]);
+    return bu;
   }
 
  private:

--- a/venue/include/flox-venue/sequenced_shard.h
+++ b/venue/include/flox-venue/sequenced_shard.h
@@ -15,9 +15,20 @@
 
 #include "flox/util/eventing/event_bus.h"
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <functional>
+#include <future>
+#include <mutex>
 #include <string>
+#include <system_error>
+#include <thread>
 #include <utility>
+#include <vector>
 
 namespace flox::venue
 {
@@ -75,23 +86,153 @@ struct EventDispatcher<flox::venue::EngineEventMsg>
 namespace flox::venue
 {
 
+// Checkpoint / journal-rotation policy of a SequencedShard.
+struct CheckpointConfig
+{
+  // Auto-trigger thresholds on the CURRENT journal segment, checked by the
+  // idle sweeper thread -- automatic checkpoints therefore require
+  // idleSweepIntervalNs > 0 (checkpointNow() works regardless). 0 disables
+  // the corresponding threshold.
+  uint64_t maxSegmentRecords{1'000'000};
+  uint64_t maxSegmentBytes{256ULL << 20};
+  // Snapshot+journal generations kept on disk after a checkpoint (>= 1). The
+  // pre-checkpoint single-file journal counts as the oldest generation and is
+  // deleted once `retainGenerations` snapshot generations exist.
+  int retainGenerations{2};
+};
+
 template <class Book = MatchingBook, size_t IngressCap = 1 << 16, size_t OutboundCap = 1 << 16>
 class SequencedShard
 {
  public:
+  // ---- on-disk layout ----
+  // Before the first checkpoint the shard journals into the single file the
+  // caller named (`<base>`, the historical layout). Every checkpoint at
+  // boundary ts atomically publishes `<base>.snapshot.<ts>` and rotates the
+  // journal onto `<base>.journal.<ts>`; a journal segment's numeric suffix
+  // names its base snapshot, so the naming convention IS the manifest (plus
+  // per-record CRC) -- no separate SegmentHeader record or manifest file to
+  // tear. Recovery replays the newest snapshot that validates end-to-end
+  // (structure + stateHash) plus every segment with ts >= that snapshot's;
+  // an invalid snapshot falls back a generation, and with no valid snapshot
+  // at all recovery replays the legacy file plus all segments from scratch.
+  static std::string snapshotPath(const std::string& base, int64_t ts)
+  {
+    return base + ".snapshot." + std::to_string(ts);
+  }
+  static std::string segmentPath(const std::string& base, int64_t ts)
+  {
+    return base + ".journal." + std::to_string(ts);
+  }
+
+  struct Generations
+  {
+    std::vector<int64_t> snapshots;  // ascending checkpoint ts
+    std::vector<int64_t> segments;   // ascending checkpoint ts
+  };
+
+  static Generations scanGenerations(const std::string& base)
+  {
+    namespace fs = std::filesystem;
+    Generations g;
+    const fs::path bp(base);
+    fs::path dir = bp.parent_path();
+    if (dir.empty())
+    {
+      dir = ".";
+    }
+    const std::string snapPrefix = bp.filename().string() + ".snapshot.";
+    const std::string segPrefix = bp.filename().string() + ".journal.";
+    const auto tsOf = [](const std::string& name, const std::string& prefix) -> int64_t
+    {
+      if (name.size() <= prefix.size() || name.compare(0, prefix.size(), prefix) != 0)
+      {
+        return -1;
+      }
+      int64_t v = 0;
+      for (size_t i = prefix.size(); i < name.size(); ++i)
+      {
+        if (name[i] < '0' || name[i] > '9')
+        {
+          return -1;  // excludes ".tmp" staging files and foreign names
+        }
+        v = v * 10 + (name[i] - '0');
+      }
+      return v;
+    };
+    std::error_code ec;
+    for (fs::directory_iterator it(dir, ec), end; ec == std::error_code{} && it != end;
+         it.increment(ec))
+    {
+      const std::string name = it->path().filename().string();
+      if (const int64_t ts = tsOf(name, snapPrefix); ts >= 0)
+      {
+        g.snapshots.push_back(ts);
+      }
+      else if (const int64_t ts = tsOf(name, segPrefix); ts >= 0)
+      {
+        g.segments.push_back(ts);
+      }
+    }
+    std::sort(g.snapshots.begin(), g.snapshots.end());
+    std::sort(g.segments.begin(), g.segments.end());
+    return g;
+  }
+
   using IngressBus = flox::EventBus<InboundCommandEvent, IngressCap, 4>;
   using OutboundBus = flox::EventBus<EngineEventMsg, OutboundCap, 8>;
+
+  // Sequencer clock: nanosecond timestamps stamped on every accepted command,
+  // journaled AND fed to the engine as the same value. Injectable so tests are
+  // deterministic; defaults to system wall time.
+  using TimeSource = std::function<int64_t()>;
+
+  static int64_t systemNowNs()
+  {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+  }
 
   // journalSync defaults to Full: the shard WAL is fsync-durable before a
   // command is applied (production posture). Pass Journal::Sync::Off for
   // throughput-oriented runs where power-loss durability is not required.
+  //
+  // The journal opens in Append mode: a restart never erases the log it must
+  // recover from. start() replays any existing records before serving.
+  //
+  // idleSweepIntervalNs > 0 arms the idle time sweeper: a background thread
+  // that, while last-look holds are open, injects a TimeTick command through
+  // the normal sequenced path at most once per interval. That is what expires
+  // a hold on a QUIET symbol -- expiry otherwise runs only when traffic
+  // arrives. Going through the command stream (journaled, timestamped by the
+  // same sequencer clock) keeps replay deterministic: the sweep is a record
+  // like any other. 0 = off (the historical behavior; tests drive time by
+  // submitting commands or calling engine().tick()).
   SequencedShard(SymbolConfig cfg, const std::string& journalPath, Book book = Book{},
-                 Journal::Sync journalSync = Journal::Sync::Full)
-      : journal_(journalPath, journalSync),
-        consumer_(cfg, journal_, outbound_, std::move(book))
+                 Journal::Sync journalSync = Journal::Sync::Full,
+                 TimeSource clock = &SequencedShard::systemNowNs,
+                 int64_t idleSweepIntervalNs = 0, CheckpointConfig checkpointCfg = {})
+      : journalPath_(journalPath),
+        cfg_(cfg),
+        bookProto_(book),  // pristine (empty) copy: scratch snapshot validation clones it
+        checkpointCfg_(checkpointCfg),
+        // Append to the newest journal segment when checkpoint generations
+        // exist, else to the legacy single file (historical layout).
+        journal_(initialJournalPath(journalPath), journalSync, Journal::OpenMode::Append),
+        consumer_(cfg, journal_, outbound_, std::move(book), clock, this),
+        symbol_(cfg.id),
+        sweepClock_(std::move(clock)),
+        idleSweepNs_(idleSweepIntervalNs)
   {
     ingress_.enableDrainOnStop();
     outbound_.enableDrainOnStop();
+  }
+
+  ~SequencedShard()
+  {
+    stopIdleSweeper();
+    waitCheckpointPublish();  // never destroy members under a live background writer
   }
 
   // Subscribe an outbound consumer (exec-report, market-data, ...). Must be
@@ -101,12 +242,45 @@ class SequencedShard
     return outbound_.subscribe(l, required);
   }
 
+  // Checkpoint hook: runs on the consumer thread after each checkpoint
+  // generation is published (snapshot renamed in, journal rotated), with the
+  // boundary ts of the new generation. The gateway harness uses it to persist
+  // session-layer sidecars at the same durability point -- e.g. the FIX
+  // session sidecar (FixSessionSidecar::write to
+  // FixSessionSidecar::pathFor(journal base), i.e. `<base>.fixsessions`).
+  // Keep it fast: matching is paused for its duration. Set before start().
+  void onCheckpoint(std::function<void(int64_t boundaryTs)> hook)
+  {
+    checkpointHook_ = std::move(hook);
+  }
+
   void start()
   {
+    // Recovery FIRST: newest valid snapshot + its tail segments (or, without
+    // one, the full journal history) replayed into the engine before any new
+    // command is served. Replayed events are not re-published outbound --
+    // reconnecting clients reconcile via snapshots, not a re-broadcast of
+    // history.
+    recovered_ = recoverAll();
     outbound_.start();  // must be live before the matching thread publishes
     ingress_.subscribe(&consumer_, true);
     ingress_.start();
+    if (idleSweepNs_ > 0)
+    {
+      startIdleSweeper();
+    }
+    ready_ = true;
   }
+
+  // Recovery gate: callers hold traffic until ready(); recoveredCommands()
+  // reports how much of the journal was replayed on start().
+  bool ready() const noexcept { return ready_; }
+  uint64_t recoveredCommands() const noexcept { return recovered_; }
+
+  // The shard's engine, for wiring (setLedger, fees, MMP) before start() and
+  // for off-hot-path queries (book, snapshots) after quiescence.
+  MatchingEngine<Book>& engine() noexcept { return consumer_.engine(); }
+  const MatchingEngine<Book>& engine() const noexcept { return consumer_.engine(); }
 
   // Producer side (gateway). Returns the ingress sequence number.
   int64_t submit(const InboundCommand& cmd) { return ingress_.publish(InboundCommandEvent{cmd}); }
@@ -119,43 +293,458 @@ class SequencedShard
 
   void stop()
   {
+    stopIdleSweeper();
     ingress_.flush();
     ingress_.stop();
     outbound_.flush();
     outbound_.stop();
+    waitCheckpointPublish();  // a checkpoint in flight publishes before shutdown
     journal_.flush();
   }
 
   uint64_t journaled() const noexcept { return journal_.count(); }
 
+  // Checkpoint on demand (the control-plane SnapshotNow verb): requests a
+  // snapshot at the next command boundary on the consumer thread -- the only
+  // point of natural quiescence -- and waits for it. The TimeTick nudge
+  // guarantees a boundary even on a quiet symbol. Deliberately NOT a
+  // journaled verb: a snapshot must never be replay-visible (the nudge itself
+  // is an ordinary, harmless time sweep record). The consumer pause covers
+  // only the state CLONE + journal rotation; this call additionally waits for
+  // the background publish, so it still returns true only once the new
+  // generation is on disk.
+  bool checkpointNow()
+  {
+    if (!ready_)
+    {
+      return false;
+    }
+    const uint64_t before = checkpoints_.load(std::memory_order_acquire);
+    // Drain FIRST: the request must be observed no earlier than the boundary
+    // of the last command submitted before this call -- otherwise a lagging
+    // consumer would snapshot an earlier boundary (correct but surprising).
+    ingress_.flush();
+    checkpointRequested_.store(true, std::memory_order_release);
+    submit(InboundCommand{TimeTick{symbol_}});
+    ingress_.flush();  // the boundary ran: clone taken, background publish spawned
+    waitCheckpointPublish();
+    return checkpoints_.load(std::memory_order_acquire) > before;
+  }
+
+  uint64_t checkpointsTaken() const noexcept
+  {
+    return checkpoints_.load(std::memory_order_acquire);
+  }
+
+  // Consumer-thread stall of the most recent checkpoint (state clone + journal
+  // rotation; serialization runs in the background). Observability gauge.
+  int64_t lastCheckpointPauseNs() const noexcept
+  {
+    return lastCheckpointPauseNs_.load(std::memory_order_acquire);
+  }
+
+  // Records recovery applied from a snapshot file (0 = no snapshot was
+  // consumed: fresh start or full-history replay). Lets callers -- and tests
+  // -- prove recovery really went through the snapshot path instead of
+  // silently replaying the whole journal history.
+  uint64_t recoveredFromSnapshotRecords() const noexcept { return recoveredSnapshot_; }
+
  private:
   class MatchingConsumer : public ICommandListener
   {
    public:
-    MatchingConsumer(SymbolConfig cfg, Journal& journal, OutboundBus& out, Book book)
+    MatchingConsumer(SymbolConfig cfg, Journal& journal, OutboundBus& out, Book book,
+                     TimeSource clock, SequencedShard* owner)
         : journal_(journal),
           out_(out),
+          clock_(std::move(clock)),
+          owner_(owner),
           engine_(cfg, [this](const OutboundEvent& ev)
-                  { out_.publish(EngineEventMsg{ev}); }, std::move(book))
+                  {
+                    if (!replaying_)
+                    {
+                      out_.publish(EngineEventMsg{ev});
+                    } }, std::move(book))
     {
+    }
+
+    // Replay the journal's intact prefix into the engine (suppressing outbound
+    // re-publication) and seed the timestamp floor, so records appended after
+    // recovery stay monotonic relative to the recovered stream.
+    uint64_t recover(const std::string& path)
+    {
+      const auto records = Journal::loadTimed(path);
+      replaying_ = true;
+      for (const auto& [ts, cmd] : records)
+      {
+        engine_.submit(cmd, ts);
+        if (ts > lastTs_)
+        {
+          lastTs_ = ts;
+        }
+      }
+      replaying_ = false;
+      return records.size();
+    }
+
+    // Apply a snapshot file the shard has ALREADY validated end-to-end into
+    // the real engine (recovery path: outbound suppressed like journal
+    // replay, timestamp floor seeded from the snapshot records).
+    uint64_t applySnapshot(const std::string& path)
+    {
+      const auto records = Journal::loadTimed(path);
+      replaying_ = true;
+      for (const auto& [ts, cmd] : records)
+      {
+        engine_.applySnapshotRecord(cmd, ts);
+        if (ts > lastTs_)
+        {
+          lastTs_ = ts;
+        }
+      }
+      replaying_ = false;
+      return records.size();
     }
 
     void onCommand(const InboundCommandEvent& ev) override
     {
-      journal_.append(ev.cmd);  // write-ahead, before applying
-      engine_.submit(ev.cmd);
+      const int64_t ts = nextTs();
+      journal_.append(ev.cmd, ts);  // write-ahead, before applying
+      engine_.submit(ev.cmd, ts);   // the SAME timestamp the journal holds
+      owner_->maybeCheckpoint(ts);  // command boundary: natural quiescence
     }
 
+    MatchingEngine<Book>& engine() noexcept { return engine_; }
+    const MatchingEngine<Book>& engine() const noexcept { return engine_; }
+
    private:
+    // Strictly monotonic, non-zero sequencer time: a stalled or backwards
+    // clock still yields lastTs_ + 1, so replay ordering is unambiguous.
+    int64_t nextTs()
+    {
+      int64_t t = clock_();
+      if (t <= lastTs_)
+      {
+        t = lastTs_ + 1;
+      }
+      lastTs_ = t;
+      return t;
+    }
+
     Journal& journal_;
     OutboundBus& out_;
+    TimeSource clock_;
+    SequencedShard* owner_;
+    bool replaying_{false};
+    int64_t lastTs_{0};
     MatchingEngine<Book> engine_;
   };
 
+  // ---- checkpoint machinery (consumer thread unless noted) ----
+
+  static std::string initialJournalPath(const std::string& base)
+  {
+    const Generations g = scanGenerations(base);
+    return g.segments.empty() ? base : segmentPath(base, g.segments.back());
+  }
+
+  // Recovery: newest snapshot that validates end-to-end, plus every journal
+  // segment at or after it; an invalid snapshot logs and falls back a
+  // generation; no valid snapshot at all -> full-history replay (legacy
+  // single file, then all segments in order).
+  uint64_t recoverAll()
+  {
+    const Generations g = scanGenerations(journalPath_);
+    int64_t chosen = -1;
+    for (auto it = g.snapshots.rbegin(); it != g.snapshots.rend(); ++it)
+    {
+      if (validateSnapshot(snapshotPath(journalPath_, *it)))
+      {
+        chosen = *it;
+        break;
+      }
+      std::fprintf(stderr, "flox-venue: WARN snapshot %s invalid, falling back a generation\n",
+                   snapshotPath(journalPath_, *it).c_str());
+    }
+    uint64_t n = 0;
+    if (chosen >= 0)
+    {
+      recoveredSnapshot_ = consumer_.applySnapshot(snapshotPath(journalPath_, chosen));
+      n += recoveredSnapshot_;
+      for (const int64_t ts : g.segments)
+      {
+        if (ts >= chosen)
+        {
+          n += consumer_.recover(segmentPath(journalPath_, ts));
+        }
+      }
+      // Continue appending to the newest segment of the recovered history. A
+      // crash between snapshot publish and segment rotation leaves a snapshot
+      // with no segment of its own -- open (create) that segment now, so new
+      // records never land in a segment older than the snapshot they follow.
+      const int64_t cur =
+          (!g.segments.empty() && g.segments.back() >= chosen) ? g.segments.back() : chosen;
+      journal_.reopen(segmentPath(journalPath_, cur), Journal::OpenMode::Append);
+      lastCheckpointTs_ = chosen;
+    }
+    else
+    {
+      if (!g.snapshots.empty())
+      {
+        std::fprintf(stderr, "flox-venue: WARN no valid snapshot for %s, full-history replay\n",
+                     journalPath_.c_str());
+      }
+      n += consumer_.recover(journalPath_);  // legacy single file (absent -> 0 records)
+      for (const int64_t ts : g.segments)
+      {
+        n += consumer_.recover(segmentPath(journalPath_, ts));
+      }
+    }
+    return n;
+  }
+
+  // Scratch-validate a snapshot file end-to-end -- framing/CRC via loadTimed,
+  // SnapshotBegin/SnapshotEnd structure (a torn tail always lacks the End
+  // record, which is written last), every Restore* invariant, and the state
+  // hash at SnapshotEnd -- against a throwaway engine + ledger. The real
+  // engine is touched only after the whole file verified, so a corrupt
+  // snapshot can never pollute it.
+  bool validateSnapshot(const std::string& path)
+  {
+    const auto records = Journal::loadTimed(path);
+    if (records.size() < 2 || !std::holds_alternative<SnapshotBegin>(records.front().second) ||
+        !std::holds_alternative<SnapshotEnd>(records.back().second))
+    {
+      return false;
+    }
+    Ledger scratch;
+    MatchingEngine<Book> probe(cfg_, [](const OutboundEvent&) {}, Book{bookProto_});
+    if (consumer_.engine().ledger() != nullptr)
+    {
+      probe.setLedger(&scratch, consumer_.engine().venueAccount());
+    }
+    for (const auto& [ts, cmd] : records)
+    {
+      if (!probe.applySnapshotRecord(cmd, ts))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Consumer-thread entry at every command boundary (see onCommand).
+  void maybeCheckpoint(int64_t boundaryTs)
+  {
+    if (!checkpointRequested_.load(std::memory_order_acquire))
+    {
+      return;
+    }
+    checkpointRequested_.store(false, std::memory_order_release);
+    doCheckpoint(boundaryTs);
+  }
+
+  // Consumer thread only. ASYNCHRONOUS checkpoint: under the pause only the
+  // engine state is CLONED (deep copy, ledger by value) and the journal is
+  // rotated onto the segment named by the boundary ts -- the segment boundary
+  // and the snapshot content are fixed at the same command boundary.
+  // Serialization + fsync + rename (atomic publish) + retention pruning run on
+  // a background thread against the clone, so matching resumes after an
+  // O(clone) pause instead of O(serialize+fsync). fork()-based copy-on-write
+  // was rejected: this process is multi-threaded (see the rationale at
+  // MatchingEngine::cloneForSnapshot).
+  //
+  // Crash window: between rotation and the background rename the disk holds
+  // "segment ts exists, snapshot ts absent (only a .tmp at most)". recoverAll
+  // tolerates exactly that: the .tmp never parses as a generation, recovery
+  // picks the PREVIOUS valid snapshot and replays BOTH tail segments (ts-1's
+  // and ts's) after it, reproducing the state; the snapshot only ever appears
+  // atomically via rename. A failed background publish logs a WARN and leaves
+  // the same recoverable layout.
+  void doCheckpoint(int64_t ts)
+  {
+    if (ts <= lastCheckpointTs_)
+    {
+      return;  // repeated request inside one boundary: state already on disk
+    }
+    // No snapshot queue: at most one background publish in flight -- a new
+    // checkpoint first waits for the previous one to finish.
+    waitCheckpointPublish();
+    const auto pause0 = std::chrono::steady_clock::now();
+    auto clone = consumer_.engine().cloneForSnapshot(Book{bookProto_});
+    journal_.flush();
+    journal_.reopen(segmentPath(journalPath_, ts), Journal::OpenMode::Truncate);
+    syncDir();
+    lastCheckpointTs_ = ts;
+    if (checkpointHook_)
+    {
+      checkpointHook_(ts);  // sidecar persistence rides the same boundary (consumer thread)
+    }
+    lastCheckpointPauseNs_.store(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                     std::chrono::steady_clock::now() - pause0)
+                                     .count(),
+                                 std::memory_order_release);
+    auto publish = [this, ts, cl = std::move(clone)]() mutable -> bool
+    {
+      const std::string snap = snapshotPath(journalPath_, ts);
+      const std::string tmp = snap + ".tmp";
+      {
+        Journal out(tmp, Journal::Sync::Off, Journal::OpenMode::Truncate);
+        cl.engine->writeSnapshot(out);
+        out.flush();  // durable BEFORE the rename publishes it
+      }
+      std::error_code ec;
+      std::filesystem::rename(tmp, snap, ec);
+      if (ec)
+      {
+        std::fprintf(stderr, "flox-venue: WARN checkpoint rename failed for %s: %s\n",
+                     snap.c_str(), ec.message().c_str());
+        return false;  // recovery falls back a generation (both segments replay)
+      }
+      syncDir();
+      pruneGenerations();
+      checkpoints_.fetch_add(1, std::memory_order_release);
+      return true;
+    };
+    std::lock_guard<std::mutex> lk(ckptMx_);
+    ckptPending_ = std::async(std::launch::async, std::move(publish)).share();
+  }
+
+  // Wait for the in-flight background snapshot publish, if any. Safe from any
+  // thread; the consumer thread calls it before starting the next checkpoint.
+  void waitCheckpointPublish()
+  {
+    std::shared_future<bool> f;
+    {
+      std::lock_guard<std::mutex> lk(ckptMx_);
+      f = ckptPending_;
+    }
+    if (f.valid())
+    {
+      f.wait();
+    }
+  }
+
+  void pruneGenerations()
+  {
+    namespace fs = std::filesystem;
+    const Generations g = scanGenerations(journalPath_);
+    const size_t retain =
+        checkpointCfg_.retainGenerations < 1 ? 1 : static_cast<size_t>(checkpointCfg_.retainGenerations);
+    std::error_code ec;
+    if (g.snapshots.size() > retain)
+    {
+      const int64_t keepFrom = g.snapshots[g.snapshots.size() - retain];
+      for (const int64_t ts : g.snapshots)
+      {
+        if (ts < keepFrom)
+        {
+          fs::remove(snapshotPath(journalPath_, ts), ec);
+        }
+      }
+      for (const int64_t ts : g.segments)
+      {
+        if (ts < keepFrom)
+        {
+          fs::remove(segmentPath(journalPath_, ts), ec);
+        }
+      }
+    }
+    if (g.snapshots.size() >= retain)
+    {
+      fs::remove(journalPath_, ec);  // legacy pre-checkpoint file: oldest generation
+    }
+  }
+
+  void syncDir() const
+  {
+    std::filesystem::path dir = std::filesystem::path(journalPath_).parent_path();
+    const std::string d = dir.empty() ? "." : dir.string();
+    const int fd = ::open(d.c_str(), O_RDONLY);
+    if (fd >= 0)
+    {
+      ::fsync(fd);
+      ::close(fd);
+    }
+  }
+
+  // Idle sweeper: while holds are open, inject a TimeTick through the normal
+  // ingress path at most once per idleSweepNs_ (per the injected TimeSource).
+  // The consumer thread stamps and journals it like any other command, so the
+  // sweep replays deterministically. The engine's openHolds() gauge keeps the
+  // journal free of ticks when nothing is pending.
+  void startIdleSweeper()
+  {
+    sweepStop_.store(false, std::memory_order_release);
+    sweeper_ = std::thread(
+        [this]
+        {
+          int64_t lastSweep = 0;
+          while (!sweepStop_.load(std::memory_order_acquire))
+          {
+            std::this_thread::sleep_for(std::chrono::microseconds(200));
+            // Checkpoint auto-trigger: the current segment crossed its
+            // record/byte threshold. Only requests (exchange guards against
+            // re-requesting); the snapshot itself runs on the consumer thread
+            // at the next command boundary, and the TimeTick nudge guarantees
+            // one on a quiet symbol.
+            if (((checkpointCfg_.maxSegmentRecords > 0 &&
+                  journal_.count() >= checkpointCfg_.maxSegmentRecords) ||
+                 (checkpointCfg_.maxSegmentBytes > 0 &&
+                  journal_.bytes() >= checkpointCfg_.maxSegmentBytes)) &&
+                !checkpointRequested_.exchange(true, std::memory_order_acq_rel))
+            {
+              submit(InboundCommand{TimeTick{symbol_}});
+            }
+            if (consumer_.engine().openHolds() == 0)
+            {
+              continue;
+            }
+            const int64_t now = sweepClock_();
+            if (now - lastSweep < idleSweepNs_)
+            {
+              continue;
+            }
+            lastSweep = now;
+            submit(InboundCommand{TimeTick{symbol_}});
+          }
+        });
+  }
+
+  void stopIdleSweeper()
+  {
+    if (sweeper_.joinable())
+    {
+      sweepStop_.store(true, std::memory_order_release);
+      sweeper_.join();
+    }
+  }
+
+  std::string journalPath_;
+  SymbolConfig cfg_;  // construction config (scratch validation engines)
+  Book bookProto_;    // pristine copy of the ctor book, cloned per validation
+  CheckpointConfig checkpointCfg_;
   Journal journal_;
   OutboundBus outbound_;
   MatchingConsumer consumer_;
   IngressBus ingress_;
+  SymbolId symbol_{};
+  TimeSource sweepClock_;
+  int64_t idleSweepNs_{0};
+  std::thread sweeper_;
+  std::atomic<bool> sweepStop_{false};
+  std::atomic<bool> checkpointRequested_{false};
+  std::function<void(int64_t)> checkpointHook_;
+  std::atomic<uint64_t> checkpoints_{0};
+  int64_t lastCheckpointTs_{0};  // consumer thread (and pre-start recovery) only
+  // Background snapshot publish: at most one in flight (doCheckpoint waits for
+  // the previous). Guarded by ckptMx_ against checkpointNow()/stop() readers.
+  std::mutex ckptMx_;
+  std::shared_future<bool> ckptPending_;
+  std::atomic<int64_t> lastCheckpointPauseNs_{0};
+  uint64_t recovered_{0};
+  uint64_t recoveredSnapshot_{0};
+  bool ready_{false};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/session.h
+++ b/venue/include/flox-venue/session.h
@@ -51,6 +51,24 @@ enum class SessionReject : uint8_t
   DecodeError,
 };
 
+// Wire form of a session-level rejection: reuse the exec-report reject (the
+// client already understands OrderRejected) with a session-scoped reason.
+inline RejectReason toRejectReason(SessionReject r) noexcept
+{
+  switch (r)
+  {
+    case SessionReject::Unauthenticated:
+      return RejectReason::Unauthenticated;
+    case SessionReject::RateLimited:
+      return RejectReason::RateLimited;
+    case SessionReject::DecodeError:
+      return RejectReason::MalformedMessage;
+    case SessionReject::None:
+      break;
+  }
+  return RejectReason::None;
+}
+
 inline const char* toString(SessionReject r) noexcept
 {
   switch (r)
@@ -82,6 +100,13 @@ class GatewaySession
   void authenticate(bool ok) noexcept { authed_ = ok; }
   bool authenticated() const noexcept { return authed_; }
   uint64_t account() const noexcept { return account_; }
+
+  // Per-SESSION cancel-on-disconnect. The gateway-wide atomic is only the
+  // default seeded into each new session; this flag is what the connection
+  // actually honours. Wire-level negotiation (a logon COD field / per-account
+  // config) is future work -- today deployments set it at accept time.
+  void setCancelOnDisconnect(bool on) noexcept { cancelOnDisconnect_ = on; }
+  bool cancelOnDisconnect() const noexcept { return cancelOnDisconnect_; }
   // Bind this session to an authenticated account (e.g. after logon resolves the
   // API key to an account). Once bound to a non-zero account, handle() forces
   // that account onto every command -- see stampAccount.
@@ -196,6 +221,7 @@ class GatewaySession
   flox::RateLimitPolicy limits_;
   std::string secret_;
   bool authed_{false};
+  bool cancelOnDisconnect_{false};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/session_registry.h
+++ b/venue/include/flox-venue/session_registry.h
@@ -1,0 +1,703 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Exec-report delivery: account -> session routing with per-session bounded
+ * outbound queues.
+ *
+ * The per-frame Responder in the gateways answers only the connection that
+ * carried the command; an asynchronous event (a maker fill from a foreign
+ * aggressor, a stop trigger, a GTD expiry, a liquidation cancel, a FillHeld)
+ * has no request context and previously had no path to its owner's session.
+ * SessionRegistry closes that hole:
+ *
+ *   engine sink -> registry.route(event) -> AccountStream (per account)
+ *     -> seq stamp + event log + encode -> SessionWriter (per connection)
+ *       -> bounded queue -> writer thread -> socket
+ *
+ * Threading contract: the matching thread NEVER blocks on a client socket.
+ * route() encodes and enqueues under the account-stream mutex; the socket
+ * write happens on the session's writer thread. A full queue is a slow
+ * consumer: the connection is shut down (the reader loop then exits and
+ * detaches), the frames are dropped, and GatewayCounters::
+ * slowConsumerDisconnects is bumped. The client recovers the gap via
+ * ResendRequest after reconnecting.
+ *
+ * The AccountStream OUTLIVES connections: the outbound sequence number and the
+ * bounded resend log persist across a disconnect, so an event that fires while
+ * the account is offline is logged and served on reconnect (session-layer
+ * recovery). Delivery starts at the account's first attach (an account that
+ * never connected has no encoder and its events are not logged).
+ *
+ * The resend log stores (seq, OutboundEvent, first-send timestamp), NOT
+ * encoded frames: frames are (re)encoded per the session's protocol at send
+ * and at resend time. SBE encoding is deterministic, so an SBE resend is
+ * byte-identical to the original transmission; FIX REQUIRES re-encoding on
+ * resend (PossDupFlag 43=Y and OrigSendingTime 122 change BodyLength and
+ * CheckSum, so a byte replay was never viable there).
+ */
+#pragma once
+
+#include "flox-venue/messages.h"
+#include "flox-venue/metrics.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+// Wall-clock nanoseconds: the timestamp logged with each outbound event (FIX
+// SendingTime 52 at first send, OrigSendingTime 122 on a PossDup resend).
+inline int64_t wallClockNs() noexcept
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+class SessionRegistry;
+
+// Gateway hook for session-layer verbs (resend / snapshot): return true when
+// the raw inbound frame was a session verb and was fully handled. The SBE
+// implementation lives in session_verbs.h.
+using SessionVerbHandler = std::function<bool(const uint8_t* frame, size_t n, uint64_t account,
+                                              SessionRegistry& registry)>;
+
+// Wire-negotiated per-session configuration (today: cancel-on-disconnect).
+// A gateway hook decodes an inbound frame into an update, or nullopt when the
+// frame is not a session-config verb; the gateway applies the update to the
+// live session. Fire-and-forget by design: the update takes effect
+// immediately and has no reply of its own (its effect is observable -- a
+// disconnect sweeps or keeps the orders). The SBE decoder lives in
+// session_verbs.h (makeSbeSessionConfigVerb).
+struct SessionConfigUpdate
+{
+  bool cancelOnDisconnect{false};
+};
+using SessionConfigHandler =
+    std::function<std::optional<SessionConfigUpdate>(const uint8_t* frame, size_t n)>;
+
+struct DeliveryConfig
+{
+  size_t queueCapacity{256};       // per-connection outbound frames before slow-consumer disconnect
+  size_t resendLogCapacity{1024};  // per-account retained events for ResendRequest
+};
+
+// Per-connection outbound writer: a bounded queue drained by a dedicated
+// thread. Producers (matching thread, session reader thread) never block on
+// the socket; overflow closes the connection.
+class SessionWriter
+{
+ public:
+  using WriteFn = std::function<bool(const uint8_t*, size_t)>;
+  using CloseFn = std::function<void()>;
+
+  SessionWriter(WriteFn write, CloseFn close, size_t capacity, GatewayCounters* counters = nullptr)
+      : write_(std::move(write)), close_(std::move(close)), capacity_(capacity), counters_(counters)
+  {
+    thread_ = std::thread([this]
+                          { run(); });
+  }
+  ~SessionWriter() { stop(); }
+
+  SessionWriter(const SessionWriter&) = delete;
+  SessionWriter& operator=(const SessionWriter&) = delete;
+
+  // Producer side. Never blocks. Returns false if the writer is dead (the
+  // frame was dropped). Overflow marks the writer dead, shuts the socket down
+  // (the reader loop exits and tears the session down) and bumps the
+  // slow-consumer counter exactly once.
+  bool enqueue(std::vector<uint8_t> frame)
+  {
+    CloseFn closeNow;
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      if (dead_ || stopping_)
+      {
+        return false;
+      }
+      if (q_.size() >= capacity_)
+      {
+        dead_ = true;
+        closeNow = close_;  // invoke outside the lock
+        if (counters_ != nullptr)
+        {
+          counters_->slowConsumerDisconnects.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+      else
+      {
+        q_.push_back(std::move(frame));
+      }
+    }
+    if (closeNow)
+    {
+      closeNow();
+      cv_.notify_one();
+      return false;
+    }
+    cv_.notify_one();
+    return true;
+  }
+
+  bool dead() const
+  {
+    std::lock_guard<std::mutex> lk(m_);
+    return dead_;
+  }
+
+  // Force-kill: mark dead and shut the connection down (used to displace an
+  // older connection of the same account). The connection's own reader thread
+  // still owns detach() + stop().
+  void kill()
+  {
+    CloseFn c;
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      if (dead_)
+      {
+        return;
+      }
+      dead_ = true;
+      c = close_;
+    }
+    cv_.notify_one();
+    if (c)
+    {
+      c();
+    }
+  }
+
+  // Drain what is queued (best effort unless dead), then join the writer
+  // thread. Called by the owning connection on teardown; idempotent.
+  void stop()
+  {
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      stopping_ = true;
+    }
+    cv_.notify_one();
+    if (thread_.joinable())
+    {
+      thread_.join();
+    }
+  }
+
+ private:
+  void run()
+  {
+    std::unique_lock<std::mutex> lk(m_);
+    while (true)
+    {
+      cv_.wait(lk, [this]
+               { return stopping_ || dead_ || !q_.empty(); });
+      if (dead_)
+      {
+        q_.clear();
+        return;
+      }
+      if (q_.empty())
+      {
+        if (stopping_)
+        {
+          return;  // drained
+        }
+        continue;
+      }
+      std::vector<uint8_t> f = std::move(q_.front());
+      q_.pop_front();
+      lk.unlock();
+      const bool ok = write_(f.data(), f.size());
+      lk.lock();
+      if (!ok)
+      {
+        dead_ = true;
+        q_.clear();
+        CloseFn c = close_;
+        lk.unlock();
+        if (c)
+        {
+          c();  // peer gone mid-write: make sure the reader unblocks too
+        }
+        return;
+      }
+    }
+  }
+
+  WriteFn write_;
+  CloseFn close_;
+  size_t capacity_;
+  GatewayCounters* counters_;
+  mutable std::mutex m_;
+  std::condition_variable cv_;
+  std::deque<std::vector<uint8_t>> q_;
+  bool dead_{false};
+  bool stopping_{false};
+  std::thread thread_;
+};
+
+class SessionRegistry
+{
+ public:
+  // Serialize an event for this account's protocol, stamped with the
+  // per-session outbound sequence number; `tsNs` is the wall-clock send time
+  // (FIX SendingTime; SBE ignores it). Return false when the event has no wire
+  // form for this protocol (nothing is sent or logged).
+  using Encoder =
+      std::function<bool(const OutboundEvent&, uint64_t seq, int64_t tsNs, std::vector<uint8_t>&)>;
+  // One retained outbound event: assigned seq, first-send wall-clock time, and
+  // the protocol-agnostic event itself (re-encoded on resend).
+  struct Logged
+  {
+    uint64_t seq;
+    int64_t tsNs;
+    OutboundEvent event;
+  };
+  // Observed on the producer thread for every event routed to the account
+  // while this connection is attached (terminal-event pruning hooks).
+  using EventObserver = std::function<void(const OutboundEvent&)>;
+
+  explicit SessionRegistry(DeliveryConfig cfg = {}, GatewayCounters* counters = nullptr)
+      : cfg_(cfg), counters_(counters)
+  {
+  }
+
+  // Bind a live connection to `account`. A concurrent older connection for the
+  // same account is displaced (its socket is shut down; its own reader loop
+  // detaches it). The returned writer is owned by the caller (the connection
+  // thread), which must detach() and stop() it on teardown.
+  std::shared_ptr<SessionWriter> attach(uint64_t account, Encoder encoder,
+                                        SessionWriter::WriteFn write, SessionWriter::CloseFn close,
+                                        EventObserver observer = {})
+  {
+    auto stream = streamOf(account, /*create*/ true);
+    auto writer =
+        std::make_shared<SessionWriter>(std::move(write), std::move(close), cfg_.queueCapacity,
+                                        counters_);
+    std::shared_ptr<SessionWriter> displaced;
+    {
+      std::lock_guard<std::mutex> lk(stream->m);
+      displaced = std::move(stream->writer);
+      stream->writer = writer;
+      stream->encoder = std::move(encoder);
+      stream->observer = std::move(observer);
+    }
+    if (displaced)
+    {
+      // One live connection per account: shut the older one down. Its reader
+      // thread unblocks, detaches (a no-op now) and joins its own writer.
+      displaced->kill();
+    }
+    return writer;
+  }
+
+  // Unbind `writer` from `account`. After detach returns, no further events or
+  // observer calls reach this writer (synchronized on the stream mutex); the
+  // seq counter and resend log stay for the next attach.
+  void detach(uint64_t account, const std::shared_ptr<SessionWriter>& writer)
+  {
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return;
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    if (stream->writer == writer)
+    {
+      stream->writer.reset();
+      stream->observer = {};
+    }
+  }
+
+  // Route one outbound event to the account(s) it belongs to. Called from the
+  // matching thread; never blocks on a socket.
+  void route(const OutboundEvent& e)
+  {
+    uint64_t targets[2] = {0, 0};
+    int n = 0;
+    targetsOf(e, targets, n);
+    for (int i = 0; i < n; ++i)
+    {
+      if (targets[i] == 0)
+      {
+        continue;  // unrouteable (unbound/trusted-transport account)
+      }
+      if (i == 1 && targets[1] == targets[0])
+      {
+        continue;  // self-trade: one report stream, not two
+      }
+      deliver(targets[i], e);
+    }
+  }
+
+  // Deliver an event to one specific account (session-level rejects).
+  void send(uint64_t account, const OutboundEvent& e) { deliver(account, e); }
+
+  enum class ResendResult : uint8_t
+  {
+    Served,     // frames (possibly zero: fromSeq > lastSeq) queued to the live writer
+    TooOld,     // fromSeq trimmed out of the log -> client needs a snapshot
+    NoSession,  // account unknown or no live connection
+  };
+
+  // Session-layer recovery: replay logged events with seq >= fromSeq into the
+  // account's live writer, re-encoded with their ORIGINAL seqs through the
+  // session's encoder. SBE encoding is deterministic, so the replayed frames
+  // are byte-identical to the original transmissions.
+  ResendResult resendFrom(uint64_t account, uint64_t fromSeq)
+  {
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return ResendResult::NoSession;
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    if (!stream->writer || !stream->encoder)
+    {
+      return ResendResult::NoSession;
+    }
+    if (!stream->log.empty() && fromSeq < stream->log.front().seq)
+    {
+      return ResendResult::TooOld;
+    }
+    if (stream->log.empty() && fromSeq <= stream->lastSeq)
+    {
+      return ResendResult::TooOld;  // everything requested was already trimmed
+    }
+    for (const auto& logged : stream->log)
+    {
+      if (logged.seq >= fromSeq)
+      {
+        std::vector<uint8_t> frame;
+        if (stream->encoder(logged.event, logged.seq, logged.tsNs, frame))
+        {
+          stream->writer->enqueue(std::move(frame));
+        }
+      }
+    }
+    if (counters_ != nullptr)
+    {
+      counters_->resendServed.fetch_add(1, std::memory_order_relaxed);
+    }
+    return ResendResult::Served;
+  }
+
+  // Copy of the retained log entries with fromSeq <= seq <= toSeq (toSeq 0 =
+  // no upper bound). Seqs absent from the slice inside that range were either
+  // trimmed or never logged (admin messages sent via sendSequencedRaw) -- a
+  // FIX resend covers them with SequenceReset-GapFill.
+  std::vector<Logged> logSlice(uint64_t account, uint64_t fromSeq, uint64_t toSeq = 0)
+  {
+    std::vector<Logged> out;
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return out;
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    for (const auto& logged : stream->log)
+    {
+      if (logged.seq >= fromSeq && (toSeq == 0 || logged.seq <= toSeq))
+      {
+        out.push_back(logged);
+      }
+    }
+    return out;
+  }
+
+  // Allocate the next outbound seq and enqueue the frame `build` produces for
+  // it, atomically with respect to routed events (same stream mutex, so the
+  // wire order matches the seq order). For session-layer messages that consume
+  // a seq but are NOT replayable from the event log -- FIX admin traffic
+  // (Logon/Heartbeat/TestRequest/ResendRequest/Logout); a later resend covers
+  // their seqs with GapFill. Returns false when the account has no live writer
+  // or `build` declined.
+  using SequencedBuild = std::function<bool(uint64_t seq, int64_t tsNs, std::vector<uint8_t>&)>;
+  bool sendSequencedRaw(uint64_t account, const SequencedBuild& build)
+  {
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return false;
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    if (!stream->writer)
+    {
+      return false;
+    }
+    std::vector<uint8_t> frame;
+    const uint64_t seq = stream->lastSeq + 1;
+    if (!build(seq, wallClockNs(), frame))
+    {
+      return false;
+    }
+    stream->lastSeq = seq;
+    return stream->writer->enqueue(std::move(frame));
+  }
+
+  // Reset the account's outbound stream to seq 1 (FIX Logon with
+  // ResetSeqNumFlag 141=Y): the seq counter restarts and the resend log is
+  // dropped -- nothing from the previous sequence space may replay into the
+  // new one.
+  void resetStream(uint64_t account)
+  {
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return;
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    stream->lastSeq = 0;
+    stream->log.clear();
+  }
+
+  // Last assigned outbound seq for the account (0 if none).
+  uint64_t lastSeq(uint64_t account)
+  {
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return 0;
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    return stream->lastSeq;
+  }
+
+  // Queue a pre-framed session-layer message (snapshot reply, SnapshotRequired)
+  // to the account's live writer. Not sequenced, not logged.
+  bool enqueueRaw(uint64_t account, std::vector<uint8_t> frame)
+  {
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return false;
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    return stream->writer && stream->writer->enqueue(std::move(frame));
+  }
+
+  // A protocol layer served a resend itself (the FIX 35=2 path replays via
+  // enqueueRaw, not resendFrom): account it on the shared counter.
+  void noteResendServed()
+  {
+    if (counters_ != nullptr)
+    {
+      counters_->resendServed.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+
+  // ---- outbound-seq persistence (FIX session sidecar) ----
+  // The outbound side of a FIX session (per-account lastSeq) survives a venue
+  // restart via the checkpoint sidecar (see FixSessionSidecar in
+  // fix_session.h). Only the COUNTER is persisted -- the resend log is not:
+  // a post-restart resend that reaches into the pre-restart range is answered
+  // with SequenceReset-GapFill (the honest signal for history the venue no
+  // longer holds; full state reconciliation is the snapshot path).
+  // Blob: [u32 count]{u64 account, u64 lastSeq}...
+  void serializeSeqs(std::vector<uint8_t>& out)
+  {
+    std::vector<std::pair<uint64_t, uint64_t>> entries;
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      for (const auto& [account, stream] : streams_)
+      {
+        std::lock_guard<std::mutex> slk(stream->m);
+        if (stream->lastSeq > 0)
+        {
+          entries.emplace_back(account, stream->lastSeq);
+        }
+      }
+    }
+    const uint32_t count = static_cast<uint32_t>(entries.size());
+    appendBytes(out, &count, sizeof count);
+    for (const auto& [account, lastSeq] : entries)
+    {
+      appendBytes(out, &account, sizeof account);
+      appendBytes(out, &lastSeq, sizeof lastSeq);
+    }
+  }
+
+  // Restore per-account outbound seq counters into a fresh registry (called
+  // before any session attaches). Returns bytes consumed, or 0 on a malformed
+  // blob (nothing partially applied before the error is detected).
+  size_t restoreSeqs(const uint8_t* p, size_t n)
+  {
+    uint32_t count = 0;
+    if (n < sizeof count)
+    {
+      return 0;
+    }
+    std::memcpy(&count, p, sizeof count);
+    const size_t need = sizeof count + static_cast<size_t>(count) * 16;
+    if (n < need)
+    {
+      return 0;
+    }
+    const uint8_t* b = p + sizeof count;
+    for (uint32_t i = 0; i < count; ++i, b += 16)
+    {
+      uint64_t account = 0;
+      uint64_t lastSeq = 0;
+      std::memcpy(&account, b, sizeof account);
+      std::memcpy(&lastSeq, b + 8, sizeof lastSeq);
+      auto stream = streamOf(account, /*create*/ true);
+      std::lock_guard<std::mutex> lk(stream->m);
+      stream->lastSeq = lastSeq;
+    }
+    return need;
+  }
+
+  static void appendBytes(std::vector<uint8_t>& out, const void* p, size_t n)
+  {
+    const auto* b = static_cast<const uint8_t*>(p);
+    out.insert(out.end(), b, b + n);
+  }
+
+ private:
+  struct AccountStream
+  {
+    std::mutex m;
+    uint64_t lastSeq{0};
+    std::deque<Logged> log;  // seq-ascending, events (not frames): re-encoded on resend
+    Encoder encoder;         // sticky across disconnects: offline events keep being logged
+    EventObserver observer;
+    std::shared_ptr<SessionWriter> writer;  // null while the account is offline
+  };
+
+  std::shared_ptr<AccountStream> streamOf(uint64_t account, bool create)
+  {
+    std::lock_guard<std::mutex> lk(m_);
+    auto it = streams_.find(account);
+    if (it != streams_.end())
+    {
+      return it->second;
+    }
+    if (!create)
+    {
+      return nullptr;
+    }
+    auto s = std::make_shared<AccountStream>();
+    streams_.emplace(account, s);
+    return s;
+  }
+
+  void deliver(uint64_t account, const OutboundEvent& e)
+  {
+    auto stream = streamOf(account, /*create*/ false);
+    if (!stream)
+    {
+      return;  // account never attached: no protocol to serialize with
+    }
+    std::lock_guard<std::mutex> lk(stream->m);
+    if (stream->observer)
+    {
+      stream->observer(e);
+    }
+    if (!stream->encoder)
+    {
+      return;
+    }
+    std::vector<uint8_t> frame;
+    const uint64_t seq = stream->lastSeq + 1;
+    const int64_t tsNs = wallClockNs();
+    if (!stream->encoder(e, seq, tsNs, frame))
+    {
+      return;  // no wire form for this event on this protocol
+    }
+    stream->lastSeq = seq;
+    stream->log.push_back(Logged{seq, tsNs, e});
+    while (stream->log.size() > cfg_.resendLogCapacity)
+    {
+      stream->log.pop_front();
+    }
+    if (stream->writer)
+    {
+      stream->writer->enqueue(std::move(frame));
+    }
+  }
+
+  // Owner account(s) of an outbound event. Events without an account concept
+  // (none today) or with account 0 are not routed.
+  static void targetsOf(const OutboundEvent& e, uint64_t out[2], int& n)
+  {
+    n = 0;
+    if (const auto* a = std::get_if<OrderAccepted>(&e))
+    {
+      out[n++] = a->account;
+    }
+    else if (const auto* r = std::get_if<OrderRejected>(&e))
+    {
+      out[n++] = r->account;
+    }
+    else if (const auto* t = std::get_if<Trade>(&e))
+    {
+      out[n++] = t->makerAccount;
+      out[n++] = t->takerAccount;
+    }
+    else if (const auto* x = std::get_if<OrderExecuted>(&e))
+    {
+      out[n++] = x->account;
+    }
+    else if (const auto* c = std::get_if<OrderCanceled>(&e))
+    {
+      out[n++] = c->account;
+    }
+    else if (const auto* m = std::get_if<OrderModified>(&e))
+    {
+      out[n++] = m->account;
+    }
+    else if (const auto* g = std::get_if<OrderTriggered>(&e))
+    {
+      out[n++] = g->account;
+    }
+    else if (const auto* fh = std::get_if<FillHeld>(&e))
+    {
+      out[n++] = fh->makerAccount;
+      out[n++] = fh->takerAccount;
+    }
+    else if (const auto* fr = std::get_if<FillRejected>(&e))
+    {
+      out[n++] = fr->takerAccount;
+      out[n++] = fr->makerAccount;
+    }
+    else if (const auto* mp = std::get_if<MmpTriggered>(&e))
+    {
+      out[n++] = mp->accountId;
+    }
+    else if (const auto* f = std::get_if<FeeCharged>(&e))
+    {
+      out[n++] = f->account;
+    }
+    else if (const auto* l = std::get_if<Liquidation>(&e))
+    {
+      out[n++] = l->account;
+    }
+    else if (const auto* b = std::get_if<BalanceUpdate>(&e))
+    {
+      out[n++] = b->account;
+    }
+  }
+
+  DeliveryConfig cfg_;
+  GatewayCounters* counters_;
+  std::mutex m_;
+  std::unordered_map<uint64_t, std::shared_ptr<AccountStream>> streams_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/session_verbs.h
+++ b/venue/include/flox-venue/session_verbs.h
@@ -1,0 +1,120 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * SBE session-layer verbs, served at the gateway BEFORE the frame reaches the
+ * order-entry decoder (they are session state, never matched or journaled):
+ *
+ *  - ResendRequest{fromSeq}: replay exec reports with seq >= fromSeq from the
+ *    account's resend log (SessionRegistry). A fromSeq older than the retained
+ *    log answers with SnapshotRequired{lastSeq} -- an explicit signal, never a
+ *    silent hole.
+ *  - AccountSnapshotRequest: reconnect reconciliation from
+ *    MatchingEngine::snapshotAccount -- open orders as a series of Accepted
+ *    frames (restingOnBook=0 for pending stops), terminated by
+ *    SnapshotEnd{position, lastSeq}. Snapshot frames are session-layer:
+ *    unsequenced (seq 0) and deliberately NOT in the resend log (a resend
+ *    replays what was originally sequenced; replaying a point-in-time
+ *    snapshot there would be stale and meaningless). SnapshotEnd carries the
+ *    stream's lastSeq so the client resumes gap detection from the exact
+ *    point (registry lastSeq is untouched by the snapshot itself).
+ *  - SetSessionConfig{codEnabled}: wire negotiation of per-session
+ *    cancel-on-disconnect. Fire-and-forget with an observable effect (a later
+ *    disconnect sweeps or keeps the orders); no reply frame. Decoded by
+ *    makeSbeSessionConfigVerb, applied by the gateway to the live session.
+ */
+#pragma once
+
+#include "flox-venue/sbe_order_entry_codec.h"
+#include "flox-venue/session_registry.h"
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+// Build the SBE verb handler over a matching engine (any Book instantiation).
+// The engine reference must outlive the gateway.
+template <class Engine>
+SessionVerbHandler makeSbeSessionVerbs(Engine& engine)
+{
+  return [&engine](const uint8_t* p, size_t n, uint64_t account, SessionRegistry& registry) -> bool
+  {
+    const uint16_t tid = SbeOrderEntryCodec::templateId(p, n);
+    if (tid == static_cast<uint16_t>(SbeOrderEntryCodec::InTmpl::ResendRequest))
+    {
+      const auto fromSeq = SbeOrderEntryCodec::decodeResendRequest(p, n);
+      if (!fromSeq)
+      {
+        return true;  // malformed verb: consumed, nothing to serve
+      }
+      if (registry.resendFrom(account, *fromSeq) == SessionRegistry::ResendResult::TooOld)
+      {
+        std::vector<uint8_t> rsp;
+        SbeOrderEntryCodec::encodeSnapshotRequired(registry.lastSeq(account), rsp);
+        registry.enqueueRaw(account, std::move(rsp));
+      }
+      return true;
+    }
+    if (tid == static_cast<uint16_t>(SbeOrderEntryCodec::InTmpl::AccountSnapshotRequest))
+    {
+      const auto snap = engine.snapshotAccount(account);
+      const SymbolId sym = engine.config().id;
+      std::vector<uint8_t> frame;
+      uint32_t count = 0;
+      for (const auto& o : snap.openOrders)
+      {
+        SbeOrderEntryCodec::encode(
+            OutboundEvent{OrderAccepted{o.id, sym, o.side, o.price, o.leaves, true, Quantity{},
+                                        account}},
+            frame);
+        registry.enqueueRaw(account, frame);
+        ++count;
+      }
+      for (const auto& st : snap.pendingStops)
+      {
+        SbeOrderEntryCodec::encode(
+            OutboundEvent{OrderAccepted{st.id, sym, st.side, st.trigger, st.quantity, false,
+                                        Quantity{}, account}},
+            frame);
+        registry.enqueueRaw(account, frame);
+        ++count;
+      }
+      SbeOrderEntryCodec::SnapshotEnd se;
+      se.account = account;
+      se.positionQtyRaw = snap.positionQty;
+      se.positionEntryRaw = snap.positionEntry.raw();
+      se.openOrders = count;
+      se.lastSeq = registry.lastSeq(account);
+      SbeOrderEntryCodec::encodeSnapshotEnd(se, frame);
+      registry.enqueueRaw(account, std::move(frame));
+      return true;
+    }
+    return false;
+  };
+}
+
+// SBE decoder for the session-config verb (SetSessionConfig -> per-session
+// cancel-on-disconnect). The gateway applies the returned update to the live
+// session; there is no reply frame (fire-and-forget by design).
+inline SessionConfigHandler makeSbeSessionConfigVerb()
+{
+  return [](const uint8_t* p, size_t n) -> std::optional<SessionConfigUpdate>
+  {
+    const auto cod = SbeOrderEntryCodec::decodeSetSessionConfig(p, n);
+    if (!cod)
+    {
+      return std::nullopt;
+    }
+    return SessionConfigUpdate{*cod};
+  };
+}
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/socket_acceptor.h
+++ b/venue/include/flox-venue/socket_acceptor.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <mutex>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -49,8 +50,12 @@ class SocketAcceptor
 
   ~SocketAcceptor() { stop(); }
 
-  // Listen on loopback:port (0 = ephemeral). Returns the bound port, or -1.
-  int start(uint16_t port, OnConn onConn)
+  // Listen on bindIp:port (0 = ephemeral). Returns the bound port, or -1.
+  // bindIp nullptr/"" keeps the historical loopback-only default; an explicit
+  // address ("0.0.0.0", a NIC address) exposes the listener beyond the host --
+  // callers own the hardening contract for that (TLS termination / firewall in
+  // front, see the per-server documentation). An unparseable address fails.
+  int start(uint16_t port, OnConn onConn, const char* bindIp = nullptr)
   {
     onConn_ = std::move(onConn);
     const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
@@ -64,6 +69,12 @@ class SocketAcceptor
     sockaddr_in a{};
     a.sin_family = AF_INET;
     a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bindIp != nullptr && bindIp[0] != '\0' && ::inet_pton(AF_INET, bindIp, &a.sin_addr) != 1)
+    {
+      ::close(fd);
+      listenFd_.store(-1);
+      return -1;
+    }
     a.sin_port = htons(port);
     if (::bind(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) < 0)
     {
@@ -98,6 +109,18 @@ class SocketAcceptor
     if (acceptThread_.joinable())
     {
       acceptThread_.join();
+    }
+    // Shut every live connection down BEFORE joining: a connection thread
+    // blocked in read()/SSL_read() on a silent peer would otherwise hold the
+    // join forever (one black-holed client used to hang stop() indefinitely).
+    // The fds in connFds_ are guaranteed open: a connection thread removes its
+    // fd from the set under the lock before closing it.
+    {
+      std::lock_guard<std::mutex> lk(connsMutex_);
+      for (int cfd : connFds_)
+      {
+        ::shutdown(cfd, SHUT_RDWR);
+      }
     }
     // The accept thread has been joined, so no new connection threads can be
     // appended; take them under the lock all the same and join outside it.
@@ -136,8 +159,18 @@ class SocketAcceptor
       ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
       suppressSigpipe(fd);
       std::lock_guard<std::mutex> lk(connsMutex_);
+      connFds_.insert(fd);
+      // The acceptor owns the fd lifecycle: the handler must NOT close it.
+      // Deregistering under the lock before close keeps stop()'s shutdown
+      // sweep away from a recycled descriptor number.
       conns_.emplace_back([this, fd]
-                          { onConn_(fd); });
+                          {
+                            onConn_(fd);
+                            {
+                              std::lock_guard<std::mutex> lg(connsMutex_);
+                              connFds_.erase(fd);
+                            }
+                            ::close(fd); });
     }
   }
 
@@ -148,6 +181,7 @@ class SocketAcceptor
   std::thread acceptThread_;
   std::mutex connsMutex_;
   std::vector<std::thread> conns_;
+  std::unordered_set<int> connFds_;  // open connection fds (for stop()'s shutdown sweep)
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/stop_book.h
+++ b/venue/include/flox-venue/stop_book.h
@@ -47,6 +47,14 @@ class StopBook
 
   bool contains(OrderId id) const noexcept { return loc_.count(id) != 0; }
 
+  // Owner of a pending conditional order (0 if unknown) -- so a cancel event
+  // for a parked stop can be routed to its session.
+  uint64_t accountOf(OrderId id) const noexcept
+  {
+    auto it = loc_.find(id);
+    return it == loc_.end() ? 0 : it->second.account;
+  }
+
   // All pending conditional-order ids (for venue-wide emergency cancel).
   std::vector<OrderId> ids() const
   {
@@ -86,7 +94,7 @@ class StopBook
     if (trailing)
     {
       trailing_.push_back(Pending{o, initialTrigger});
-      loc_[o.id] = Loc{Container::Trailing, initialTrigger};
+      loc_[o.id] = Loc{Container::Trailing, initialTrigger, o.accountId};
       return;
     }
     // Up = fires when ref >= trigger (BUY stop-loss, SELL take-profit).
@@ -94,12 +102,12 @@ class StopBook
     if (up)
     {
       up_.emplace(initialTrigger, Pending{o, initialTrigger});
-      loc_[o.id] = Loc{Container::Up, initialTrigger};
+      loc_[o.id] = Loc{Container::Up, initialTrigger, o.accountId};
     }
     else
     {
       down_.emplace(initialTrigger, Pending{o, initialTrigger});
-      loc_[o.id] = Loc{Container::Down, initialTrigger};
+      loc_[o.id] = Loc{Container::Down, initialTrigger, o.accountId};
     }
   }
 
@@ -297,6 +305,7 @@ class StopBook
   {
     Container container{};
     Price trigger{};
+    uint64_t account{};
   };
 
   static NewOrder toAggressor(const Pending& s)

--- a/venue/include/flox-venue/symbol_router.h
+++ b/venue/include/flox-venue/symbol_router.h
@@ -55,7 +55,35 @@ inline SymbolId symbolOf(const InboundCommand& c) noexcept
   {
     return af->symbol;
   }
-  return std::get<AdminCmd>(c).symbol;
+  if (const auto* ad = std::get_if<AdminCmd>(&c))
+  {
+    return ad->symbol;
+  }
+  if (const auto* d = std::get_if<Deposit>(&c))
+  {
+    return d->symbol;
+  }
+  if (const auto* w = std::get_if<Withdraw>(&c))
+  {
+    return w->symbol;
+  }
+  if (const auto* li = std::get_if<ListInstrument>(&c))
+  {
+    return li->symbol;
+  }
+  if (const auto* sb = std::get_if<SetBands>(&c))
+  {
+    return sb->symbol;
+  }
+  if (const auto* st = std::get_if<SetTriggerRef>(&c))
+  {
+    return st->symbol;
+  }
+  if (const auto* tt = std::get_if<TimeTick>(&c))
+  {
+    return tt->symbol;
+  }
+  return 0;  // snapshot-only records never route by symbol (recovery-path only)
 }
 
 template <class Book = MatchingBook>

--- a/venue/include/flox-venue/tcp_gateway.h
+++ b/venue/include/flox-venue/tcp_gateway.h
@@ -9,21 +9,46 @@
 #pragma once
 
 #include "flox-venue/cancel_on_disconnect.h"
+#include "flox-venue/fix_session.h"
 #include "flox-venue/messages.h"
+#include "flox-venue/metrics.h"
 #include "flox-venue/session.h"
+#include "flox-venue/session_registry.h"
 #include "flox-venue/socket_acceptor.h"
 #include "flox/util/transport.h"
 
+#include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
+#include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <utility>
 #include <vector>
 
 namespace flox::venue
 {
+
+// Apply a receive timeout so a blocking read wakes up: liveness (idle peers)
+// and shutdown (SocketAcceptor::stop's shutdown sweep) both depend on the
+// read loop not being parked in the kernel forever.
+inline void setRecvTimeoutMs(int fd, int64_t ms) noexcept
+{
+  if (ms <= 0)
+  {
+    return;
+  }
+  timeval tv{};
+  tv.tv_sec = static_cast<time_t>(ms / 1000);
+  tv.tv_usec = static_cast<suseconds_t>((ms % 1000) * 1000);
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+}
+
+inline bool wasRecvTimeout() noexcept { return errno == EAGAIN || errno == EWOULDBLOCK; }
 
 class TcpGateway
 {
@@ -40,17 +65,57 @@ class TcpGateway
   explicit TcpGateway(GatewaySession::Decoder decoder, uint64_t account = 0)
       : decoder_(std::move(decoder)), account_(account) {}
 
+  // Gateway-wide default for NEW sessions; each session carries its own flag
+  // (GatewaySession::setCancelOnDisconnect). Wire negotiation is future work.
   void setCancelOnDisconnect(bool on) noexcept { cancelOnDisconnect_.store(on); }
+
+  // Delivery mode: register every connection in `registry` (keyed by the bound
+  // account) and deliver exec reports through per-session bounded queues --
+  // asynchronous events (maker fills, stop triggers, expiries, liquidations,
+  // FillHeld) reach the session that owns them, and the matching thread never
+  // blocks on a client socket. `encoder` serializes an event with its
+  // per-session seq. Without a registry the gateway stays in the embedded
+  // per-frame-responder mode (no async delivery, rejects silent).
+  void setDelivery(SessionRegistry* registry, SessionRegistry::Encoder encoder)
+  {
+    registry_ = registry;
+    encoder_ = std::move(encoder);
+  }
+
+  // Session-layer verbs (SBE resend/snapshot; see session_verbs.h). Only
+  // consulted in delivery mode.
+  void setSessionVerbs(SessionVerbHandler verbs) { verbs_ = std::move(verbs); }
+
+  // Wire negotiation of per-session config (SBE SetSessionConfig -> COD; see
+  // session_verbs.h makeSbeSessionConfigVerb). Fire-and-forget: the update is
+  // applied to the live session, no reply frame.
+  void setSessionConfigVerb(SessionConfigHandler h) { sessionCfg_ = std::move(h); }
+
+  // FIX session layer (fix_session.h): every connection gets a FixConnection
+  // that gates inbound frames (Logon, Heartbeat/TestRequest, resend both
+  // ways) in front of the decoder and runs its timers on the idle tick.
+  // Requires delivery mode (outbound goes through the SessionWriter queue and
+  // the registry seq space); the encoder passed to setDelivery must produce
+  // session-framed FIX. Frames are FIX tag=value messages carried in the
+  // gateway's length-prefixed transport framing, one message per frame.
+  void setFixSession(FixSessionHost* host) noexcept { fixHost_ = host; }
+
+  void setCounters(GatewayCounters* counters) noexcept { counters_ = counters; }
+
+  // Liveness: a session with no inbound bytes for this long is disconnected
+  // (COD then fires normally). 0 disables.
+  void setIdleTimeout(std::chrono::milliseconds t) noexcept { idleTimeoutMs_.store(t.count()); }
 
   int start(uint16_t port, Handler handler)
   {
     handler_ = std::move(handler);
     // Contain any exception to this one connection -- connLoop is a thread body,
     // so an escape would reach std::terminate and take down the whole venue.
+    // The acceptor owns the fd (closes it after the handler returns).
     return acceptor_.start(port, [this](int fd)
                            {
                              try { connLoop(fd); }
-                             catch (...) { ::close(fd); } });
+                             catch (...) {} });
   }
   void stop() { acceptor_.stop(); }
   int port() const noexcept { return acceptor_.port(); }
@@ -60,12 +125,110 @@ class TcpGateway
   {
     GatewaySession session(account_, decoder_);
     session.authenticate(true);  // transport-level auth out of scope here
-    const Responder responder = [fd](const uint8_t* p, size_t n)
-    { net::writeFrame(fd, p, n); };
-    std::vector<uint8_t> frame;
-    DisconnectCanceller cod(cancelOnDisconnect_.load());
-    while (acceptor_.running() && net::readFrame(fd, frame))
+    session.setCancelOnDisconnect(cancelOnDisconnect_.load());
+    DisconnectCanceller cod(session.cancelOnDisconnect());
+
+    std::shared_ptr<SessionWriter> writer;
+    if (registry_ != nullptr)
     {
+      writer = registry_->attach(
+          session.account(), encoder_,
+          [fd](const uint8_t* p, size_t n)
+          { return net::writeFrame(fd, p, n); },
+          [fd]
+          { ::shutdown(fd, SHUT_RDWR); },
+          [&cod](const OutboundEvent& e)
+          { cod.observe(e); });
+    }
+    // In delivery mode the responder feeds the same per-session queue as the
+    // routed events, so a slow consumer can never stall the caller.
+    const Responder responder =
+        (writer != nullptr)
+            ? Responder([w = writer.get()](const uint8_t* p, size_t n)
+                        { w->enqueue(std::vector<uint8_t>(p, p + n)); })
+            : Responder([fd](const uint8_t* p, size_t n)
+                        { net::writeFrame(fd, p, n); });
+
+    // FIX mode: the connection carries a FixConnection whose timers run on
+    // the same SO_RCVTIMEO tick, just at heartbeat granularity instead of the
+    // idle window (FIX liveness -- TestRequest death -- replaces the plain
+    // idle disconnect).
+    const bool fixMode = fixHost_ != nullptr && writer != nullptr;
+    std::unique_ptr<FixConnection> fix;
+    if (fixMode)
+    {
+      fix = std::make_unique<FixConnection>(*fixHost_, *registry_, session.account(),
+                                            wallClockNs());
+      // Logon tag 20003 (CancelOnDisconnect=Y/N) lands on this session.
+      fix->setCodListener([&session, &cod](bool on)
+                          {
+                            session.setCancelOnDisconnect(on);
+                            cod.setEnabled(on); });
+    }
+    const int64_t idleMs = idleTimeoutMs_.load();
+    const int64_t tickMs = fixMode ? std::min<int64_t>(idleMs > 0 ? idleMs : 250, 250) : idleMs;
+    setRecvTimeoutMs(fd, tickMs);
+
+    std::vector<uint8_t> frame;
+    while (acceptor_.running())
+    {
+      errno = 0;
+      if (!net::readFrame(fd, frame))
+      {
+        if (wasRecvTimeout())
+        {
+          if (fixMode)
+          {
+            if (fix->onTick(wallClockNs()))
+            {
+              continue;  // timers serviced (heartbeat / test request), still live
+            }
+            // TestRequest went unanswered (or no Logon arrived): dead peer.
+            if (counters_ != nullptr)
+            {
+              counters_->idleDisconnects.fetch_add(1, std::memory_order_relaxed);
+            }
+          }
+          else if (idleMs > 0 && counters_ != nullptr)
+          {
+            // No inbound bytes for the whole idle window: half-open or wedged
+            // peer. Close the session; COD sweeps its orders below.
+            counters_->idleDisconnects.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+        break;
+      }
+      if (fixMode)
+      {
+        const auto verdict =
+            fix->onFrame(std::string(frame.begin(), frame.end()), wallClockNs());
+        if (verdict == FixConnection::Verdict::Disconnect)
+        {
+          break;  // Logout exchanged / fatal session error; COD sweeps below
+        }
+        if (verdict == FixConnection::Verdict::Handled)
+        {
+          continue;  // session-layer message, fully consumed
+        }
+        // Verdict::App: an in-sequence application message -- fall through to
+        // the decoder / admission path.
+      }
+      if (sessionCfg_)
+      {
+        if (const auto u = sessionCfg_(frame.data(), frame.size()))
+        {
+          // Session-config verb: applied in place, fire-and-forget (the
+          // effect -- a disconnect sweeping or keeping orders -- is the ack).
+          session.setCancelOnDisconnect(u->cancelOnDisconnect);
+          cod.setEnabled(u->cancelOnDisconnect);
+          continue;
+        }
+      }
+      if (writer != nullptr && verbs_ &&
+          verbs_(frame.data(), frame.size(), session.account(), *registry_))
+      {
+        continue;  // session-layer verb (resend / snapshot), fully handled
+      }
       SessionReject rej{};
       // Real monotonic nanoseconds: the rate-limit windows are wall-clock. A
       // per-connection frame counter (the old ++clock_) never advanced time, so
@@ -80,9 +243,23 @@ class TcpGateway
         cod.track(*cmd);
         handler_(*cmd, responder);
       }
+      else if (rej != SessionReject::None && registry_ != nullptr)
+      {
+        // A rejected frame answers with a sequenced exec-report reject (id 0:
+        // for a non-decodable frame there is no order id to echo) instead of
+        // the old silence.
+        registry_->send(session.account(),
+                        OutboundEvent{OrderRejected{0, 0, toRejectReason(rej),
+                                                    session.account()}});
+      }
+    }
+    if (writer != nullptr)
+    {
+      registry_->detach(session.account(), writer);
+      writer->stop();
     }
     cod.flush(handler_);
-    ::close(fd);
+    ::shutdown(fd, SHUT_RDWR);  // acceptor owns the close
   }
 
   GatewaySession::Decoder decoder_;
@@ -90,6 +267,13 @@ class TcpGateway
   Handler handler_;
   SocketAcceptor acceptor_;
   std::atomic<bool> cancelOnDisconnect_{false};
+  SessionRegistry* registry_{nullptr};
+  SessionRegistry::Encoder encoder_;
+  SessionVerbHandler verbs_;
+  SessionConfigHandler sessionCfg_;
+  FixSessionHost* fixHost_{nullptr};
+  GatewayCounters* counters_{nullptr};
+  std::atomic<int64_t> idleTimeoutMs_{30'000};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/tls_gateway.h
+++ b/venue/include/flox-venue/tls_gateway.h
@@ -9,20 +9,31 @@
 #pragma once
 
 #include "flox-venue/cancel_on_disconnect.h"
+#include "flox-venue/fix_session.h"
 #include "flox-venue/messages.h"
+#include "flox-venue/metrics.h"
 #include "flox-venue/session.h"
+#include "flox-venue/session_registry.h"
 #include "flox-venue/socket_acceptor.h"
+#include "flox-venue/tcp_gateway.h"  // setRecvTimeoutMs / wasRecvTimeout
 #include "flox/util/transport.h"
 
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 
+#include <poll.h>
 #include <unistd.h>
+#include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <functional>
+#include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -115,6 +126,16 @@ inline bool readFrame(SSL* s, std::vector<uint8_t>& out)
 
 }  // namespace tls
 
+// Delivery over TLS: OpenSSL forbids CONCURRENT SSL_read/SSL_write on one
+// SSL*, not serialized use from two threads. Each connection carries a
+// std::mutex over its SSL*: the read loop establishes readiness OUTSIDE the
+// lock (::poll on the fd / SSL_has_pending) and takes it only for the actual
+// SSL_read; the SessionWriter's write callback takes it for the SSL_write of
+// one frame -- the two interleave, never overlap, and an idle reader cannot
+// starve the writer by camping on the mutex. SSL_read keeps its own
+// partial-record state across WANT_READ, so a frame split across polls is
+// resumed, never lost. Without a registry the gateway stays in the embedded
+// per-frame responder mode, exactly like TcpGateway.
 class TlsGateway
 {
  public:
@@ -138,38 +159,283 @@ class TlsGateway
 
   void setCancelOnDisconnect(bool on) noexcept { cancelOnDisconnect_.store(on); }
 
+  // Delivery mode (see TcpGateway::setDelivery): register every connection in
+  // `registry` and deliver exec reports through per-session bounded queues.
+  void setDelivery(SessionRegistry* registry, SessionRegistry::Encoder encoder)
+  {
+    registry_ = registry;
+    encoder_ = std::move(encoder);
+  }
+
+  // Session-layer verbs (SBE resend/snapshot; see session_verbs.h). Only
+  // consulted in delivery mode.
+  void setSessionVerbs(SessionVerbHandler verbs) { verbs_ = std::move(verbs); }
+
+  // Wire negotiation of per-session config (SBE SetSessionConfig -> COD; see
+  // session_verbs.h makeSbeSessionConfigVerb). Fire-and-forget.
+  void setSessionConfigVerb(SessionConfigHandler h) { sessionCfg_ = std::move(h); }
+
+  // FIX session layer over TLS (fix_session.h; requires delivery mode). Same
+  // wire shape as TcpGateway -- one FIX message per length-prefixed frame,
+  // here inside the TLS stream: outbound goes through the existing
+  // per-connection sslMu writer path (writeFrameLocked adds the length
+  // prefix, so the FixConnection needs no wire wrap), inbound through the
+  // poll-before-lock read loop. The FIX timers run on the read loop's poll
+  // tick; FIX liveness (TestRequest death) replaces the plain idle timeout.
+  void setFixSession(FixSessionHost* host) noexcept { fixHost_ = host; }
+
+  void setCounters(GatewayCounters* counters) noexcept { counters_ = counters; }
+
+  // Liveness: no inbound bytes for this long closes the session (COD fires).
+  void setIdleTimeout(std::chrono::milliseconds t) noexcept { idleTimeoutMs_.store(t.count()); }
+
   int start(uint16_t port, Handler handler)
   {
     handler_ = std::move(handler);
     // Contain any exception to this one connection -- connLoop is a thread body,
     // so an escape would reach std::terminate and take down the whole venue.
+    // The acceptor owns the fd (closes it after the handler returns).
     return acceptor_.start(port, [this](int fd)
                            {
                              try { connLoop(fd); }
-                             catch (...) { ::close(fd); } });
+                             catch (...) {} });
   }
   void stop() { acceptor_.stop(); }
   int port() const noexcept { return acceptor_.port(); }
 
  private:
+  // Delivery mode polls SSL_read at this interval so the session writer can
+  // take the SSL mutex between polls (and the shutdown sweep is noticed).
+  static constexpr int64_t kPollMs = 20;
+
+  enum class ReadResult : uint8_t
+  {
+    Frame,
+    IdleTimeout,
+    Closed,
+  };
+
+  // One length-prefixed frame over TLS. The mutex is taken only while there is
+  // something to read: readiness is established OUTSIDE the lock (::poll on
+  // the fd, or SSL_has_pending for records already buffered inside the SSL),
+  // so an idle reader holds the mutex for microseconds per poll interval and
+  // the writer thread is never starved by an unfair unlock/relock cycle.
+  // SSL_read's internal record state and the running byte offset preserve a
+  // frame split across polls; SO_RCVTIMEO bounds the lock hold when poll
+  // reported a partial record. SSL_ERROR_ZERO_RETURN / SSL_ERROR_SYSCALL
+  // (peer close, shutdown sweep) end the session.
+  // `tick` (FIX mode): run on every idle poll interval; returning false ends
+  // the session (FIX liveness lost -- reported as IdleTimeout so the caller's
+  // counter accounting matches the plain-idle path).
+  ReadResult readFrameLocked(int fd, SSL* ssl, std::mutex& mu, std::vector<uint8_t>& out,
+                             int64_t idleMs, std::chrono::steady_clock::time_point& lastInbound,
+                             const std::function<bool()>* tick = nullptr)
+  {
+    uint8_t h[4];
+    uint32_t len = 0;
+    bool haveLen = false;
+    size_t got = 0;
+    out.clear();
+    while (acceptor_.running())
+    {
+      bool ready;
+      {
+        std::lock_guard<std::mutex> lk(mu);
+        ready = SSL_has_pending(ssl) != 0;
+      }
+      if (!ready)
+      {
+        pollfd pfd{fd, POLLIN, 0};
+        const int pr = ::poll(&pfd, 1, static_cast<int>(kPollMs));
+        if (pr < 0 && errno != EINTR)
+        {
+          return ReadResult::Closed;
+        }
+        ready = pr > 0 && (pfd.revents & (POLLIN | POLLHUP | POLLERR)) != 0;
+      }
+      if (!ready)
+      {
+        if (tick != nullptr)
+        {
+          if (!(*tick)())
+          {
+            return ReadResult::IdleTimeout;  // FIX liveness lost (TestRequest death)
+          }
+        }
+        else if (idleMs > 0)
+        {
+          const auto idle = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - lastInbound)
+                                .count();
+          if (idle >= idleMs)
+          {
+            return ReadResult::IdleTimeout;
+          }
+        }
+        continue;
+      }
+      uint8_t* dst = haveLen ? out.data() + got : h + got;
+      const size_t want = (haveLen ? len : sizeof h) - got;
+      int r;
+      int err = SSL_ERROR_NONE;
+      {
+        std::lock_guard<std::mutex> lk(mu);
+        errno = 0;
+        r = SSL_read(ssl, dst, static_cast<int>(want));
+        if (r <= 0)
+        {
+          err = SSL_get_error(ssl, r);  // before any other call touches the SSL*
+        }
+      }
+      if (r > 0)
+      {
+        lastInbound = std::chrono::steady_clock::now();
+        got += static_cast<size_t>(r);
+        if (!haveLen)
+        {
+          if (got < sizeof h)
+          {
+            continue;
+          }
+          len = (uint32_t(h[0]) << 24) | (uint32_t(h[1]) << 16) | (uint32_t(h[2]) << 8) | h[3];
+          if (len > flox::net::kMaxFrame)
+          {
+            return ReadResult::Closed;  // hostile length prefix (see tls::readFrame)
+          }
+          out.resize(len);
+          haveLen = true;
+          got = 0;
+        }
+        if (haveLen && got == len)
+        {
+          return ReadResult::Frame;
+        }
+        continue;
+      }
+      const bool retryable = err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE ||
+                             (err == SSL_ERROR_SYSCALL && wasRecvTimeout());
+      if (!retryable)
+      {
+        return ReadResult::Closed;
+      }
+    }
+    return ReadResult::Closed;
+  }
+
+  // One frame under one mutex acquisition: header and body leave as a single
+  // SSL_write so the writer holds the SSL* for a bounded, contiguous burst.
+  static bool writeFrameLocked(SSL* ssl, std::mutex& mu, const uint8_t* p, size_t n)
+  {
+    std::vector<uint8_t> buf(4 + n);
+    buf[0] = static_cast<uint8_t>(n >> 24);
+    buf[1] = static_cast<uint8_t>(n >> 16);
+    buf[2] = static_cast<uint8_t>(n >> 8);
+    buf[3] = static_cast<uint8_t>(n);
+    std::memcpy(buf.data() + 4, p, n);
+    std::lock_guard<std::mutex> lk(mu);
+    return tls::writeAll(ssl, buf.data(), buf.size());
+  }
+
   void connLoop(int fd)
   {
+    const int64_t idleMs = idleTimeoutMs_.load();
+    setRecvTimeoutMs(fd, idleMs);
     SSL* ssl = SSL_new(ctx_);
     SSL_set_fd(ssl, fd);
     if (SSL_accept(ssl) <= 0)
     {
       SSL_free(ssl);
-      ::close(fd);
-      return;
+      return;  // acceptor owns the fd
     }
     GatewaySession session(account_, decoder_);
     session.authenticate(true);
-    const Responder responder = [ssl](const uint8_t* p, size_t n)
-    { tls::writeFrame(ssl, p, n); };
-    std::vector<uint8_t> frame;
-    DisconnectCanceller cod(cancelOnDisconnect_.load());
-    while (acceptor_.running() && tls::readFrame(ssl, frame))
+    session.setCancelOnDisconnect(cancelOnDisconnect_.load());
+    DisconnectCanceller cod(session.cancelOnDisconnect());
+
+    std::mutex sslMu;  // serializes SSL_read (reader) vs SSL_write (writer thread)
+    std::shared_ptr<SessionWriter> writer;
+    if (registry_ != nullptr)
     {
+      // Handshake done: switch to the short poll so a blocked SSL_read never
+      // holds the mutex longer than one poll interval.
+      setRecvTimeoutMs(fd, idleMs > 0 ? std::min<int64_t>(idleMs, kPollMs) : kPollMs);
+      writer = registry_->attach(
+          session.account(), encoder_,
+          [ssl, &sslMu](const uint8_t* p, size_t n)
+          { return writeFrameLocked(ssl, sslMu, p, n); },
+          [fd]
+          { ::shutdown(fd, SHUT_RDWR); },
+          [&cod](const OutboundEvent& e)
+          { cod.observe(e); });
+    }
+    // In delivery mode the responder feeds the same per-session queue as the
+    // routed events (single writer owns the SSL*'s write side).
+    const Responder responder =
+        (writer != nullptr)
+            ? Responder([w = writer.get()](const uint8_t* p, size_t n)
+                        { w->enqueue(std::vector<uint8_t>(p, p + n)); })
+            : Responder([ssl](const uint8_t* p, size_t n)
+                        { tls::writeFrame(ssl, p, n); });
+
+    // FIX mode (see setFixSession): the FixConnection gates every inbound
+    // frame; its timers run on the read loop's poll tick via the tick hook.
+    const bool fixMode = fixHost_ != nullptr && writer != nullptr;
+    std::unique_ptr<FixConnection> fix;
+    std::function<bool()> fixTick;
+    if (fixMode)
+    {
+      fix = std::make_unique<FixConnection>(*fixHost_, *registry_, session.account(),
+                                            wallClockNs());
+      fix->setCodListener([&session, &cod](bool on)
+                          {
+                            session.setCancelOnDisconnect(on);
+                            cod.setEnabled(on); });
+      fixTick = [&fix]
+      { return fix->onTick(wallClockNs()); };
+    }
+
+    auto lastInbound = std::chrono::steady_clock::now();
+    std::vector<uint8_t> frame;
+    while (acceptor_.running())
+    {
+      const ReadResult rr = readFrameLocked(fd, ssl, sslMu, frame, idleMs, lastInbound,
+                                            fixMode ? &fixTick : nullptr);
+      if (rr != ReadResult::Frame)
+      {
+        if (rr == ReadResult::IdleTimeout && counters_ != nullptr)
+        {
+          counters_->idleDisconnects.fetch_add(1, std::memory_order_relaxed);
+        }
+        break;
+      }
+      if (fixMode)
+      {
+        const auto verdict =
+            fix->onFrame(std::string(frame.begin(), frame.end()), wallClockNs());
+        if (verdict == FixConnection::Verdict::Disconnect)
+        {
+          break;  // Logout exchanged / fatal session error; COD sweeps below
+        }
+        if (verdict == FixConnection::Verdict::Handled)
+        {
+          continue;  // session-layer message, fully consumed
+        }
+        // Verdict::App: fall through to the decoder / admission path.
+      }
+      if (sessionCfg_)
+      {
+        if (const auto u = sessionCfg_(frame.data(), frame.size()))
+        {
+          session.setCancelOnDisconnect(u->cancelOnDisconnect);
+          cod.setEnabled(u->cancelOnDisconnect);
+          continue;
+        }
+      }
+      if (writer != nullptr && verbs_ &&
+          verbs_(frame.data(), frame.size(), session.account(), *registry_))
+      {
+        continue;  // session-layer verb (resend / snapshot), fully handled
+      }
       SessionReject rej{};
       // Real monotonic nanoseconds (rate-limit windows are wall-clock); the old
       // ++clock_ frame counter never advanced time -> permanent bans.
@@ -182,11 +448,27 @@ class TlsGateway
         cod.track(*cmd);
         handler_(*cmd, responder);
       }
+      else if (rej != SessionReject::None && registry_ != nullptr)
+      {
+        // A rejected frame answers with a sequenced exec-report reject (id 0)
+        // instead of the old silence -- same policy as TcpGateway.
+        registry_->send(session.account(),
+                        OutboundEvent{OrderRejected{0, 0, toRejectReason(rej),
+                                                    session.account()}});
+      }
+    }
+    if (writer != nullptr)
+    {
+      // Order matters: detach (no new frames are routed here), stop (drain and
+      // JOIN the writer thread -- its last SSL_write finishes) and only then
+      // SSL_shutdown/SSL_free below. The writer never sees a freed SSL*.
+      registry_->detach(session.account(), writer);
+      writer->stop();
     }
     cod.flush(handler_);
     SSL_shutdown(ssl);
     SSL_free(ssl);
-    ::close(fd);
+    ::shutdown(fd, SHUT_RDWR);  // acceptor owns the close
   }
 
   GatewaySession::Decoder decoder_;
@@ -195,6 +477,13 @@ class TlsGateway
   Handler handler_;
   SocketAcceptor acceptor_;
   std::atomic<bool> cancelOnDisconnect_{false};
+  SessionRegistry* registry_{nullptr};
+  SessionRegistry::Encoder encoder_;
+  SessionVerbHandler verbs_;
+  SessionConfigHandler sessionCfg_;
+  FixSessionHost* fixHost_{nullptr};
+  GatewayCounters* counters_{nullptr};
+  std::atomic<int64_t> idleTimeoutMs_{30'000};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/udp_multicast.h
+++ b/venue/include/flox-venue/udp_multicast.h
@@ -9,15 +9,20 @@
 #pragma once
 
 #include "flox-venue/market_data.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/resend_buffer.h"
 #include "flox-venue/sbe_md_codec.h"
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <cstdint>
 #include <cstring>
+#include <deque>
+#include <utility>
 #include <vector>
 
 namespace flox::venue
@@ -68,13 +73,33 @@ class UdpMdPublisher
       ::setsockopt(fd_, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof loop);
       ::setsockopt(fd_, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof ttl);
     }
+    // Non-blocking: a full socket buffer must never stall the matching thread.
+    // The failed datagram is a counted drop, not a wait -- consumers recover
+    // the hole via gap detection + the recovery channel.
+    const int fl = ::fcntl(fd_, F_GETFL, 0);
+    ::fcntl(fd_, F_SETFL, fl | O_NONBLOCK);
     return true;
   }
 
-  void publish(const MdMessage& m)
+  void setCounters(MdCounters* counters) noexcept { counters_ = counters; }
+
+  // Returns false when the datagram was NOT handed to the kernel (socket
+  // buffer full, closed fd, ...). The drop is counted; the publisher never
+  // blocks and never retries -- gap recovery is the consumer's job.
+  bool publish(const MdMessage& m)
   {
     SbeMdCodec::encode(m, buf_);
-    ::sendto(fd_, buf_.data(), buf_.size(), 0, reinterpret_cast<sockaddr*>(&dst_), sizeof dst_);
+    const ssize_t n =
+        ::sendto(fd_, buf_.data(), buf_.size(), 0, reinterpret_cast<sockaddr*>(&dst_), sizeof dst_);
+    if (n != static_cast<ssize_t>(buf_.size()))
+    {
+      if (counters_ != nullptr)
+      {
+        counters_->sendDrops.fetch_add(1, std::memory_order_relaxed);
+      }
+      return false;
+    }
+    return true;
   }
 
   void close()
@@ -91,6 +116,7 @@ class UdpMdPublisher
   int fd_{-1};
   sockaddr_in dst_{};
   std::vector<uint8_t> buf_;
+  MdCounters* counters_{nullptr};
 };
 
 class UdpMdSubscriber
@@ -138,16 +164,53 @@ class UdpMdSubscriber
     ::setsockopt(fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
   }
 
-  // Receive and decode one message; returns false on timeout / error.
+  // Optional client-side sequencing: with a detector attached, recv() delivers
+  // messages strictly in seq order per (symbol, epoch) -- held-out reordered
+  // datagrams are buffered and drained when the missing seq arrives -- and
+  // gap / publisher-restart signals surface through the callbacks. The
+  // detector is owned by the caller and must outlive the subscriber. Without
+  // a detector recv() is the raw decode path, unchanged.
+  void setGapDetector(GapDetector* gd, GapDetector::GapFn onGap = {},
+                      GapDetector::EpochFn onEpoch = {})
+  {
+    gd_ = gd;
+    onGap_ = std::move(onGap);
+    onEpoch_ = std::move(onEpoch);
+  }
+
+  // Receive and decode one message; returns false on timeout / error. With a
+  // gap detector attached, keeps reading until an in-order message is
+  // deliverable (held-out datagrams do not surface) or the socket times out.
   bool recv(MdMessage& out)
   {
-    uint8_t buf[SbeMdCodec::kMaxSize];
-    const ssize_t n = ::recvfrom(fd_, buf, sizeof buf, 0, nullptr, nullptr);
-    if (n <= 0)
+    if (gd_ == nullptr)
     {
-      return false;
+      return recvRaw(out);
     }
-    return SbeMdCodec::decode(buf, static_cast<size_t>(n), out);
+    while (ready_.empty())
+    {
+      MdMessage m;
+      if (!recvRaw(m))
+      {
+        return false;
+      }
+      gd_->observe(m, [this](const MdMessage& d)
+                   { ready_.push_back(d); }, onGap_, onEpoch_);
+    }
+    out = ready_.front();
+    ready_.pop_front();
+    return true;
+  }
+
+  // After applying a snapshot with lastSeq L: fast-forward the stream to L+1.
+  // Held datagrams beyond the snapshot become deliverable immediately.
+  void resetSequencer(SymbolId symbol, uint64_t epoch, uint64_t nextSeq)
+  {
+    if (gd_ != nullptr)
+    {
+      gd_->reset(symbol, epoch, nextSeq, [this](const MdMessage& d)
+                 { ready_.push_back(d); });
+    }
   }
 
   int port() const noexcept { return port_; }
@@ -163,8 +226,23 @@ class UdpMdSubscriber
   ~UdpMdSubscriber() { close(); }
 
  private:
+  bool recvRaw(MdMessage& out)
+  {
+    uint8_t buf[SbeMdCodec::kMaxSize];
+    const ssize_t n = ::recvfrom(fd_, buf, sizeof buf, 0, nullptr, nullptr);
+    if (n <= 0)
+    {
+      return false;
+    }
+    return SbeMdCodec::decode(buf, static_cast<size_t>(n), out);
+  }
+
   int fd_{-1};
   int port_{0};
+  GapDetector* gd_{nullptr};
+  GapDetector::GapFn onGap_;
+  GapDetector::EpochFn onEpoch_;
+  std::deque<MdMessage> ready_;  // sequenced, deliverable messages
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/ws_gateway.h
+++ b/venue/include/flox-venue/ws_gateway.h
@@ -9,17 +9,25 @@
 #pragma once
 
 #include "flox-venue/cancel_on_disconnect.h"
+#include "flox-venue/fix_session.h"
 #include "flox-venue/messages.h"
+#include "flox-venue/metrics.h"
 #include "flox-venue/session.h"
+#include "flox-venue/session_registry.h"
 #include "flox-venue/socket_acceptor.h"
+#include "flox-venue/tcp_gateway.h"  // setRecvTimeoutMs / wasRecvTimeout
 #include "flox/util/transport.h"
 #include "flox/util/websocket.h"
 
+#include <sys/socket.h>
 #include <unistd.h>
+#include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -40,16 +48,48 @@ class WsGateway
 
   void setCancelOnDisconnect(bool on) noexcept { cancelOnDisconnect_.store(on); }
 
+  // Delivery mode (see TcpGateway::setDelivery). The registry carries
+  // fully-framed WebSocket bytes: the gateway wraps `encoder`'s payload in a
+  // Text frame, so the single writer thread owns the socket and control
+  // frames never interleave mid-message.
+  void setDelivery(SessionRegistry* registry, SessionRegistry::Encoder encoder)
+  {
+    registry_ = registry;
+    encoder_ = std::move(encoder);
+  }
+
+  void setCounters(GatewayCounters* counters) noexcept { counters_ = counters; }
+
+  // Wire negotiation of per-session config (SBE SetSessionConfig -> COD; see
+  // session_verbs.h makeSbeSessionConfigVerb). Fire-and-forget.
+  void setSessionConfigVerb(SessionConfigHandler h) { sessionCfg_ = std::move(h); }
+
+  // FIX session layer over WebSocket (fix_session.h; requires delivery mode).
+  // FIX messages travel ONE PER WebSocket data frame: the venue sends Text
+  // frames (FIX tag=value is ASCII; Text keeps the messages readable in any
+  // WS tooling) and accepts inbound FIX in Text or Binary frames alike --
+  // both carry the same payload bytes and RFC 6455 imposes no semantics
+  // beyond UTF-8 validity, which FIX satisfies. Fragmented data frames
+  // reassemble as usual before the session layer sees the message. FIX
+  // liveness (Heartbeat/TestRequest death) replaces the WS Ping probe on
+  // these connections; the timers run on the same recv-timeout tick at
+  // heartbeat granularity.
+  void setFixSession(FixSessionHost* host) noexcept { fixHost_ = host; }
+
+  // Liveness: the server pings at half this window; a peer with no inbound
+  // bytes (data or Pong) for the whole window is disconnected. 0 disables.
+  void setIdleTimeout(std::chrono::milliseconds t) noexcept { idleTimeoutMs_.store(t.count()); }
+
   int start(uint16_t port, Handler handler)
   {
     handler_ = std::move(handler);
     // connLoop runs as a per-connection thread body: an escaping exception would
     // reach std::terminate and kill the whole venue, so contain it to this one
-    // connection (close the fd and let the thread exit cleanly).
+    // connection (the acceptor closes the fd and the thread exits cleanly).
     return acceptor_.start(port, [this](int fd)
                            {
                              try { connLoop(fd); }
-                             catch (...) { ::close(fd); } });
+                             catch (...) {} });
   }
   void stop() { acceptor_.stop(); }
   int port() const noexcept { return acceptor_.port(); }
@@ -57,6 +97,9 @@ class WsGateway
  private:
   void connLoop(int fd)
   {
+    const int64_t idleMs = idleTimeoutMs_.load();
+    setRecvTimeoutMs(fd, idleMs > 0 ? std::max<int64_t>(idleMs / 2, 1) : 0);
+
     // 1. HTTP Upgrade handshake.
     std::string req;
     uint8_t tmp[2048];
@@ -65,7 +108,6 @@ class WsGateway
       const ssize_t r = ::read(fd, tmp, sizeof tmp);
       if (r <= 0 || req.size() > (1u << 16))
       {
-        ::close(fd);
         return;
       }
       req.append(reinterpret_cast<char*>(tmp), static_cast<size_t>(r));
@@ -73,7 +115,6 @@ class WsGateway
     const std::string resp = ws::handshakeResponse(req);
     if (resp.empty())
     {
-      ::close(fd);
       return;
     }
     net::writeAll(fd, reinterpret_cast<const uint8_t*>(resp.data()), resp.size());
@@ -81,14 +122,116 @@ class WsGateway
     // 2. Frame loop.
     GatewaySession session(account_, decoder_);
     session.authenticate(true);
-    const Responder responder = [fd](const uint8_t* p, size_t n)
+    session.setCancelOnDisconnect(cancelOnDisconnect_.load());
+    DisconnectCanceller cod(session.cancelOnDisconnect());
+
+    std::shared_ptr<SessionWriter> writer;
+    if (registry_ != nullptr)
     {
-      const auto f = ws::buildFrame(ws::Opcode::Text, p, n);
-      net::writeAll(fd, f.data(), f.size());
+      // The registry logs/queues COMPLETE WebSocket frames so replay and live
+      // delivery are byte-identical and only the writer thread touches the fd.
+      SessionRegistry::Encoder wsEncoder =
+          [enc = encoder_](const OutboundEvent& e, uint64_t seq, int64_t tsNs,
+                           std::vector<uint8_t>& out) -> bool
+      {
+        std::vector<uint8_t> payload;
+        if (!enc || !enc(e, seq, tsNs, payload))
+        {
+          return false;
+        }
+        out = ws::buildFrame(ws::Opcode::Text, payload.data(), payload.size());
+        return true;
+      };
+      writer = registry_->attach(
+          session.account(), std::move(wsEncoder),
+          [fd](const uint8_t* p, size_t n)
+          { return net::writeAll(fd, p, n); },
+          [fd]
+          { ::shutdown(fd, SHUT_RDWR); },
+          [&cod](const OutboundEvent& e)
+          { cod.observe(e); });
+    }
+    const Responder responder =
+        (writer != nullptr)
+            ? Responder([w = writer.get()](const uint8_t* p, size_t n)
+                        { w->enqueue(ws::buildFrame(ws::Opcode::Text, p, n)); })
+            : Responder([fd](const uint8_t* p, size_t n)
+                        {
+                          const auto f = ws::buildFrame(ws::Opcode::Text, p, n);
+                          net::writeAll(fd, f.data(), f.size()); });
+    // Single-writer rule: with a writer thread every outbound frame (including
+    // Pong/Ping control frames) goes through the queue; without one the read
+    // thread is the only writer and may write directly.
+    const auto sendControl = [&](std::vector<uint8_t> f)
+    {
+      if (writer != nullptr)
+      {
+        writer->enqueue(std::move(f));
+      }
+      else
+      {
+        net::writeAll(fd, f.data(), f.size());
+      }
+    };
+
+    // FIX mode (see setFixSession): the FixConnection gates every data
+    // message; its outbound raw messages (admin, PossDup replays) wrap into
+    // WS Text frames at enqueue time, matching the frame-at-encode model of
+    // this gateway's registry encoder. Timers run on a heartbeat-granularity
+    // recv-timeout tick instead of the half-idle Ping probe.
+    const bool fixMode = fixHost_ != nullptr && writer != nullptr;
+    std::unique_ptr<FixConnection> fix;
+    if (fixMode)
+    {
+      fix = std::make_unique<FixConnection>(*fixHost_, *registry_, session.account(),
+                                            wallClockNs());
+      fix->setWireWrap([](const uint8_t* p, size_t n)
+                       { return ws::buildFrame(ws::Opcode::Text, p, n); });
+      fix->setCodListener([&session, &cod](bool on)
+                          {
+                            session.setCancelOnDisconnect(on);
+                            cod.setEnabled(on); });
+      setRecvTimeoutMs(fd, idleMs > 0 ? std::min<int64_t>(idleMs, 250) : 250);
+    }
+
+    const auto now = []
+    { return std::chrono::steady_clock::now(); };
+    auto lastInbound = now();
+    bool idleTripped = false;
+
+    // One fully-assembled data message: session-config verb, then the FIX
+    // session gate (in FIX mode), then the normal decoder path. False = tear
+    // the connection down.
+    const auto onMessage = [&](const uint8_t* p, size_t n) -> bool
+    {
+      if (sessionCfg_)
+      {
+        if (const auto u = sessionCfg_(p, n))
+        {
+          session.setCancelOnDisconnect(u->cancelOnDisconnect);
+          cod.setEnabled(u->cancelOnDisconnect);
+          return true;
+        }
+      }
+      if (fixMode)
+      {
+        const auto verdict =
+            fix->onFrame(std::string(reinterpret_cast<const char*>(p), n), wallClockNs());
+        if (verdict == FixConnection::Verdict::Disconnect)
+        {
+          return false;  // Logout exchanged / fatal session error; COD sweeps below
+        }
+        if (verdict == FixConnection::Verdict::Handled)
+        {
+          return true;  // session-layer message, fully consumed
+        }
+        // Verdict::App: fall through to the decoder / admission path.
+      }
+      dispatch(session, cod, responder, p, n);
+      return true;
     };
 
     std::vector<uint8_t> buf;
-    DisconnectCanceller cod(cancelOnDisconnect_.load());
     // Fragmentation reassembly (RFC 6455 5.4): a data message may span a
     // FIN=0 Text/Binary frame followed by Continuation frames; control frames
     // (Ping/Pong/Close) may interleave and are handled immediately.
@@ -107,15 +250,48 @@ class WsGateway
       }
       if (consumed == 0)
       {
+        errno = 0;
         const ssize_t r = ::read(fd, tmp, sizeof tmp);
-        if (r <= 0)
+        if (r > 0)
         {
-          break;
+          lastInbound = now();
+          buf.insert(buf.end(), tmp, tmp + r);
+          continue;
         }
-        buf.insert(buf.end(), tmp, tmp + r);
-        continue;
+        if (r < 0 && wasRecvTimeout())
+        {
+          if (fixMode)
+          {
+            // FIX liveness replaces the WS Ping probe: heartbeat timers run
+            // here; an unanswered TestRequest is the dead-peer signal.
+            if (fix->onTick(wallClockNs()))
+            {
+              continue;
+            }
+            idleTripped = true;
+            break;
+          }
+          if (idleMs > 0)
+          {
+            // Half the idle window elapsed with no bytes. Past the full
+            // window: the peer is gone or wedged -- disconnect (COD fires
+            // below). Otherwise probe with a Ping; any inbound (Pong or data)
+            // before the deadline keeps the session alive.
+            const auto idle =
+                std::chrono::duration_cast<std::chrono::milliseconds>(now() - lastInbound).count();
+            if (idle >= idleMs)
+            {
+              idleTripped = true;
+              break;
+            }
+            sendControl(ws::buildFrame(ws::Opcode::Ping, nullptr, 0));
+            continue;
+          }
+        }
+        break;  // EOF / error / shutdown sweep
       }
       buf.erase(buf.begin(), buf.begin() + static_cast<std::ptrdiff_t>(consumed));
+      lastInbound = now();
 
       // Control frames are always final and may arrive mid-message.
       if (op == ws::Opcode::Close)
@@ -124,8 +300,7 @@ class WsGateway
       }
       if (op == ws::Opcode::Ping)
       {
-        const auto pong = ws::buildFrame(ws::Opcode::Pong, payload.data(), payload.size());
-        net::writeAll(fd, pong.data(), pong.size());
+        sendControl(ws::buildFrame(ws::Opcode::Pong, payload.data(), payload.size()));
         continue;
       }
       if (op == ws::Opcode::Pong)
@@ -142,7 +317,10 @@ class WsGateway
         }
         if (fin)
         {
-          dispatch(session, cod, responder, payload.data(), payload.size());
+          if (!onMessage(payload.data(), payload.size()))
+          {
+            break;
+          }
           continue;
         }
         assembling = true;
@@ -163,16 +341,29 @@ class WsGateway
         msg.insert(msg.end(), payload.begin(), payload.end());
         if (fin)
         {
-          dispatch(session, cod, responder, msg.data(), msg.size());
+          const bool keep = onMessage(msg.data(), msg.size());
           assembling = false;
           msg.clear();
+          if (!keep)
+          {
+            break;
+          }
         }
         continue;
       }
       break;  // unknown opcode
     }
+    if (idleTripped && counters_ != nullptr)
+    {
+      counters_->idleDisconnects.fetch_add(1, std::memory_order_relaxed);
+    }
+    if (writer != nullptr)
+    {
+      registry_->detach(session.account(), writer);
+      writer->stop();
+    }
     cod.flush(handler_);
-    ::close(fd);
+    ::shutdown(fd, SHUT_RDWR);  // acceptor owns the close
   }
 
   // Decode one fully-assembled message and, if it is a valid command, run it.
@@ -191,6 +382,11 @@ class WsGateway
       cod.track(*cmd);
       handler_(*cmd, responder);
     }
+    else if (rej != SessionReject::None && registry_ != nullptr)
+    {
+      registry_->send(session.account(),
+                      OutboundEvent{OrderRejected{0, 0, toRejectReason(rej), session.account()}});
+    }
   }
 
   GatewaySession::Decoder decoder_;
@@ -198,6 +394,12 @@ class WsGateway
   Handler handler_;
   SocketAcceptor acceptor_;
   std::atomic<bool> cancelOnDisconnect_{false};
+  SessionRegistry* registry_{nullptr};
+  SessionRegistry::Encoder encoder_;
+  SessionConfigHandler sessionCfg_;
+  FixSessionHost* fixHost_{nullptr};
+  GatewayCounters* counters_{nullptr};
+  std::atomic<int64_t> idleTimeoutMs_{30'000};
 };
 
 }  // namespace flox::venue

--- a/venue/schema/md-sbe.xml
+++ b/venue/schema/md-sbe.xml
@@ -13,11 +13,28 @@
   The C++ codec is hand-written against THIS schema rather than generated, to
   avoid a Java codegen toolchain in a C++/Python build. Keep the two in sync:
   field order, ids, block lengths, schema id and version here are authoritative.
+
+  Version 1 (snapshot + recovery):
+  - Every incremental template gained a trailing `epoch` field (uint64,
+    sinceVersion="1"): a random value fixed for one publisher lifetime.
+    Appended to the END of each root block, so a version-0 reader skips it via
+    the header blockLength (same extension path as order-entry v1). A restart
+    mints a new epoch; a consumer that sees the epoch change knows its book is
+    stale and re-snapshots. This replaces persisting the sequence counter
+    across restarts: the feed is rebuildable from the matching state, so the
+    venue restarts with seq=1 under a fresh epoch instead of carrying seq
+    durability it does not need.
+  - New recovery templates: ResendRequest (7, inbound on the TCP recovery
+    channel) asks for increments with seq >= fromSeq; the server replays them
+    from a bounded ring, or answers SnapshotRequired (10) followed by
+    SnapshotBegin (8) + AddOrder body + SnapshotEnd (9) when fromSeq is older
+    than the ring's tail. Snapshot body AddOrders carry seq=0 and the epoch;
+    the incremental feed resumes at lastSeq+1.
 -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="flox.venue.md"
                    id="91"
-                   version="0"
+                   version="1"
                    semanticVersion="1.0"
                    description="Flox venue market-data feed"
                    byteOrder="littleEndian">
@@ -38,6 +55,8 @@
     <type name="OrderId" primitiveType="uint64"/>
     <type name="PriceRaw" primitiveType="int64"/>
     <type name="QtyRaw"   primitiveType="int64"/>
+    <type name="Epoch"   primitiveType="uint64"/>  <!-- publisher lifetime id -->
+    <type name="Count"   primitiveType="uint32"/>
   </types>
 
   <!-- A resting order was added to the book (displayed size). -->
@@ -48,6 +67,7 @@
     <field name="side"    id="4" type="Side"/>
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
+    <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
   </sbe:message>
 
   <!-- A trade printed. orderId = taker, side = taker side, plus the maker id. -->
@@ -59,6 +79,7 @@
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
     <field name="makerId" id="7" type="OrderId"/>
+    <field name="epoch"   id="8" type="Epoch" sinceVersion="1"/>
   </sbe:message>
 
   <!-- A resting order was (partially) executed; qty = displayed leaves. -->
@@ -69,6 +90,7 @@
     <field name="side"    id="4" type="Side"/>
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
+    <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
   </sbe:message>
 
   <!-- A resting order was canceled/expired off the book. -->
@@ -79,6 +101,7 @@
     <field name="side"    id="4" type="Side"/>
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
+    <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
   </sbe:message>
 
   <!-- A resting order was repriced/replaced; qty = new displayed leaves. -->
@@ -89,6 +112,7 @@
     <field name="side"    id="4" type="Side"/>
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
+    <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
   </sbe:message>
 
   <!-- A conditional (stop/take-profit) order triggered; price = reference. -->
@@ -97,5 +121,41 @@
     <field name="symbol"  id="2" type="Symbol"/>
     <field name="orderId" id="3" type="OrderId"/>
     <field name="price"   id="5" type="PriceRaw"/>
+    <field name="epoch"   id="6" type="Epoch" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Recovery channel (TCP, length-prefixed frames): ask for increments with
+       seq >= fromSeq. fromSeq=0 is the late-joiner form: always answered with
+       a snapshot. One request per connection; the reply ends at EOF (replay)
+       or after SnapshotEnd (snapshot). -->
+  <sbe:message name="ResendRequest" id="7" sinceVersion="1">
+    <field name="symbol"  id="1" type="Symbol" sinceVersion="1"/>
+    <field name="fromSeq" id="2" type="Seq" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Opens a full-book snapshot: orderCount AddOrder messages (seq=0, epoch
+       set) follow, closed by SnapshotEnd. The incremental feed resumes at
+       lastSeq+1. -->
+  <sbe:message name="SnapshotBegin" id="8" sinceVersion="1">
+    <field name="symbol"     id="1" type="Symbol" sinceVersion="1"/>
+    <field name="epoch"      id="2" type="Epoch" sinceVersion="1"/>
+    <field name="lastSeq"    id="3" type="Seq" sinceVersion="1"/>
+    <field name="orderCount" id="4" type="Count" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Closes a full-book snapshot. -->
+  <sbe:message name="SnapshotEnd" id="9" sinceVersion="1">
+    <field name="symbol"  id="1" type="Symbol" sinceVersion="1"/>
+    <field name="epoch"   id="2" type="Epoch" sinceVersion="1"/>
+    <field name="lastSeq" id="3" type="Seq" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Answers a ResendRequest whose fromSeq is older than the retained ring:
+       the requested increments are gone, a full snapshot follows immediately
+       on the same connection. -->
+  <sbe:message name="SnapshotRequired" id="10" sinceVersion="1">
+    <field name="symbol"  id="1" type="Symbol" sinceVersion="1"/>
+    <field name="epoch"   id="2" type="Epoch" sinceVersion="1"/>
+    <field name="lastSeq" id="3" type="Seq" sinceVersion="1"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/venue/schema/order-entry-sbe.xml
+++ b/venue/schema/order-entry-sbe.xml
@@ -10,7 +10,7 @@
   the fields that type needs.
 
   Direction is by templateId: inbound (client -> venue) uses ids 1..3, outbound
-  exec reports (venue -> client) use ids 10..16. Real crypto venues run binary
+  exec reports (venue -> client) use ids 10..18. Real crypto venues run binary
   order entry over SBE (Deribit Binary Order Entry, Binance SBE); this is the
   venue's own SBE order-entry schema, replacing a homegrown record that was
   misleadingly named "OUCH".
@@ -18,11 +18,40 @@
   Prices and quantities are the engine's fixed-point raw values (scale 1e-8).
   Enum byte fields (side, ordType, tif, stp, peg, cancel/reject reason) carry
   the engine enum's underlying uint8 value.
+
+  Version 1 (session-layer recovery):
+  - Every OUTBOUND template gained a trailing `seq` field (uint64,
+    sinceVersion="1"): the per-session monotonic execution-report sequence
+    number. Appended to the END of each root block, so a version-0 reader
+    skips it via the header blockLength -- the SBE-sanctioned extension path
+    (no wrapper template, no re-layout).
+  - New inbound session verbs: ResendRequest (4) replays reports with
+    seq >= fromSeq from the venue's per-session log; AccountSnapshotRequest
+    (5) requests open orders (a series of Accepted frames) + position,
+    terminated by SnapshotEnd (20). SnapshotRequired (19) answers a
+    ResendRequest whose fromSeq is older than the retained log.
+  These verbs are handled at the gateway session layer and never reach
+  matching.
+
+  Version 2:
+  - SnapshotEnd gained a trailing `lastSeq` field (uint64, sinceVersion="2"):
+    the last assigned outbound seq of the account's exec-report stream at
+    snapshot time, so the client resumes gap detection from the exact point.
+    Snapshot frames themselves stay unsequenced and are never in the resend
+    log.
+  - New inbound session verb SetSessionConfig (6): per-session
+    cancel-on-disconnect negotiation. Fire-and-forget -- the update takes
+    effect immediately, there is no reply frame (the effect is observable: a
+    later disconnect sweeps or keeps the session's orders).
+  - New outbound BalanceUpdate (21): balance change on a sequenced
+    Deposit/Withdraw, carrying the post-event available/reserved of the
+    touched (account, asset). reason: 0=Deposit, 1=Withdraw,
+    2=WithdrawRejected (insufficient available; balances unchanged).
 -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="flox.venue.oe"
                    id="92"
-                   version="0"
+                   version="2"
                    semanticVersion="1.0"
                    description="Flox venue order entry + execution reports"
                    byteOrder="littleEndian">
@@ -41,6 +70,7 @@
     <type name="Flag"     primitiveType="uint8"/>   <!-- boolean 0/1 -->
     <type name="EnumU8"   primitiveType="uint8"/>   <!-- engine enum underlying value -->
     <type name="Nanos"    primitiveType="int64"/>
+    <type name="SeqNum"   primitiveType="uint64"/>  <!-- per-session exec-report sequence -->
   </types>
 
   <!-- ============ inbound: client -> venue ============ -->
@@ -87,6 +117,25 @@
     <field name="account"  id="5" type="Account"/>
   </sbe:message>
 
+  <!-- Session verb: replay exec reports with seq >= fromSeq from the venue's
+       per-session resend log (reconnect gap-fill). Answered by the replayed
+       frames, or by SnapshotRequired when fromSeq is older than the log. -->
+  <sbe:message name="ResendRequest" id="4" sinceVersion="1">
+    <field name="fromSeq" id="1" type="SeqNum" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Session verb: request the session account's open orders + position.
+       Carries no fields -- the authenticated session IS the account. Answered
+       by a series of Accepted frames (restingOnBook=0 for pending stops)
+       terminated by SnapshotEnd. -->
+  <sbe:message name="AccountSnapshotRequest" id="5" sinceVersion="1"/>
+
+  <!-- Session verb: per-session config negotiation (today: cancel-on-
+       disconnect). Fire-and-forget, applied at the gateway; no reply frame. -->
+  <sbe:message name="SetSessionConfig" id="6" sinceVersion="2">
+    <field name="codEnabled" id="1" type="Flag" sinceVersion="2"/>
+  </sbe:message>
+
   <!-- ============ outbound: venue -> client (execution reports) ============ -->
 
   <!-- Order accepted / working. -->
@@ -97,6 +146,7 @@
     <field name="price"        id="4" type="PriceRaw"/>
     <field name="leavesQty"    id="5" type="QtyRaw"/>
     <field name="restingOnBook" id="6" type="Flag"/>
+    <field name="seq"     id="7" type="SeqNum" sinceVersion="1"/>
   </sbe:message>
 
   <!-- Order (partially) executed. -->
@@ -108,6 +158,7 @@
     <field name="leavesQty" id="5" type="QtyRaw"/>
     <field name="aggressor" id="6" type="Flag"/>
     <field name="complete"  id="7" type="Flag"/>
+    <field name="seq"     id="8" type="SeqNum" sinceVersion="1"/>
   </sbe:message>
 
   <!-- Trade print. -->
@@ -119,6 +170,7 @@
     <field name="makerId"   id="5" type="OrderId"/>
     <field name="takerId"   id="6" type="OrderId"/>
     <field name="takerSide" id="7" type="EnumU8"/>
+    <field name="seq"     id="8" type="SeqNum" sinceVersion="1"/>
   </sbe:message>
 
   <!-- Order canceled (reason = CancelReason underlying value). -->
@@ -126,6 +178,7 @@
     <field name="orderId" id="1" type="OrderId"/>
     <field name="symbol"  id="2" type="Symbol"/>
     <field name="reason"  id="3" type="EnumU8"/>
+    <field name="seq"     id="4" type="SeqNum" sinceVersion="1"/>
   </sbe:message>
 
   <!-- Order rejected (reason = RejectReason underlying value). -->
@@ -133,6 +186,7 @@
     <field name="orderId" id="1" type="OrderId"/>
     <field name="symbol"  id="2" type="Symbol"/>
     <field name="reason"  id="3" type="EnumU8"/>
+    <field name="seq"     id="4" type="SeqNum" sinceVersion="1"/>
   </sbe:message>
 
   <!-- Order replaced (priorityKept = kept time priority in place). -->
@@ -142,6 +196,7 @@
     <field name="price"        id="3" type="PriceRaw"/>
     <field name="leavesQty"    id="4" type="QtyRaw"/>
     <field name="priorityKept" id="5" type="Flag"/>
+    <field name="seq"     id="6" type="SeqNum" sinceVersion="1"/>
   </sbe:message>
 
   <!-- Conditional order triggered (refPrice = reference that crossed). -->
@@ -149,5 +204,63 @@
     <field name="orderId"  id="1" type="OrderId"/>
     <field name="symbol"   id="2" type="Symbol"/>
     <field name="refPrice" id="3" type="PriceRaw"/>
+    <field name="seq"     id="4" type="SeqNum" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Last look: a fill is held pending the maker's decision. heldId is the
+       handle a LastLookDecision answers with. makerDisplayAfter is the maker's
+       displayed remaining after the held qty left the book (public feed sync). -->
+  <sbe:message name="FillHeld" id="17">
+    <field name="heldId"            id="1" type="OrderId"/>
+    <field name="symbol"            id="2" type="Symbol"/>
+    <field name="makerId"           id="3" type="OrderId"/>
+    <field name="takerId"           id="4" type="OrderId"/>
+    <field name="price"             id="5" type="PriceRaw"/>
+    <field name="qty"               id="6" type="QtyRaw"/>
+    <field name="makerDisplayAfter" id="7" type="QtyRaw"/>
+    <field name="seq"     id="8" type="SeqNum" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Last look: the held fill was rejected (or timed out). Carries the
+       counterparty order, price and size so the taker has a usable report. -->
+  <sbe:message name="FillRejected" id="18">
+    <field name="heldId"  id="1" type="OrderId"/>
+    <field name="symbol"  id="2" type="Symbol"/>
+    <field name="takerId" id="3" type="OrderId"/>
+    <field name="makerId" id="4" type="OrderId"/>
+    <field name="price"   id="5" type="PriceRaw"/>
+    <field name="qty"     id="6" type="QtyRaw"/>
+    <field name="seq"     id="7" type="SeqNum" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Session layer: the requested resend fromSeq is older than the retained
+       log -- the client must reconcile via AccountSnapshotRequest instead.
+       lastSeq = the venue's current per-session sequence. -->
+  <sbe:message name="SnapshotRequired" id="19" sinceVersion="1">
+    <field name="lastSeq" id="1" type="SeqNum" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Session layer: terminates an account snapshot reply. lastSeq = the
+       stream's last assigned outbound seq at snapshot time (snapshot frames
+       are unsequenced and never in the resend log); the client resumes gap
+       detection from it. -->
+  <sbe:message name="SnapshotEnd" id="20" sinceVersion="1">
+    <field name="account"          id="1" type="Account" sinceVersion="1"/>
+    <field name="positionQtyRaw"   id="2" type="QtyRaw" sinceVersion="1"/>
+    <field name="positionEntryRaw" id="3" type="PriceRaw" sinceVersion="1"/>
+    <field name="openOrders"       id="4" type="uint32" sinceVersion="1"/>
+    <field name="lastSeq"          id="5" type="SeqNum" sinceVersion="2"/>
+  </sbe:message>
+
+  <!-- Balance change on a sequenced Deposit/Withdraw: post-event available/
+       reserved of the touched (account, asset). reason: 0=Deposit,
+       1=Withdraw, 2=WithdrawRejected (insufficient available; unchanged). -->
+  <sbe:message name="BalanceUpdate" id="21" sinceVersion="2">
+    <field name="account"      id="1" type="Account" sinceVersion="2"/>
+    <field name="asset"        id="2" type="uint16" sinceVersion="2"/>
+    <field name="availableRaw" id="3" type="QtyRaw" sinceVersion="2"/>
+    <field name="reservedRaw"  id="4" type="QtyRaw" sinceVersion="2"/>
+    <field name="reason"       id="5" type="EnumU8" sinceVersion="2"/>
+    <field name="seq"          id="6" type="SeqNum" sinceVersion="2"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/venue/src/reject_reason.cpp
+++ b/venue/src/reject_reason.cpp
@@ -48,6 +48,20 @@ const char* toString(RejectReason r) noexcept
       return "PositionLimitExceeded";
     case RejectReason::TooManyOpenOrders:
       return "TooManyOpenOrders";
+    case RejectReason::NotOrderOwner:
+      return "NotOrderOwner";
+    case RejectReason::DuplicateClientOrderId:
+      return "DuplicateClientOrderId";
+    case RejectReason::LastLookUnsupported:
+      return "LastLookUnsupported";
+    case RejectReason::RateLimited:
+      return "RateLimited";
+    case RejectReason::MalformedMessage:
+      return "MalformedMessage";
+    case RejectReason::Unauthenticated:
+      return "Unauthenticated";
+    case RejectReason::SessionSeqGap:
+      return "SessionSeqGap";
   }
   return "?";
 }

--- a/venue/tests/test_venue_checkpoint.cpp
+++ b/venue/tests/test_venue_checkpoint.cpp
@@ -1,0 +1,1608 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Checkpoint + journal rotation. The snapshot is a journal-format file whose
+ * records rebuild engine state through the same apply paths live traffic uses;
+ * these tests pin the property that makes that safe: recovery from
+ * snapshot+tail is indistinguishable from a full-history replay -- state hash
+ * equal AND the event stream of identical subsequent traffic equal -- with
+ * open last-look holds, pending stops, GTD, OCO, icebergs, pegs, perp
+ * positions and reservations all restored, torn snapshots falling back a
+ * generation, retention pruning old generations, and snapshot-only records
+ * rejected from live traffic.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/fix_session.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/sequenced_shard.h"
+#include "flox-venue/session_registry.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE_ACCT = 900;
+constexpr int NACCT = 6;
+constexpr uint64_t kHashSeed = 1469598103934665603ULL;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+int64_t baseRaw(double v) { return static_cast<int64_t>(amountOf(qty(v))); }
+int64_t quoteRaw(double v) { return static_cast<int64_t>(amountOf(Volume::fromDouble(v))); }
+
+venue::SymbolConfig cfg()
+{
+  venue::SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// Settable deterministic clock: strictly advancing by `step` per call, with a
+// jumpable base (post-restart GTD expiry needs a controlled time jump).
+using ClockState = std::shared_ptr<std::atomic<int64_t>>;
+ClockState clockState(int64_t base) { return std::make_shared<std::atomic<int64_t>>(base); }
+SequencedShard<>::TimeSource clockOf(ClockState t, int64_t step = 1000)
+{
+  return [t, step]()
+  { return t->fetch_add(step) + step; };
+}
+
+struct HashSink : IEngineEventListener
+{
+  uint64_t h = kHashSeed;
+  uint64_t count = 0;
+  uint64_t fillHeld = 0;
+  std::vector<OutboundEvent> events;
+  void onEngineEvent(const EngineEventMsg& e) override
+  {
+    h = hashEvent(h, e.event);
+    ++count;
+    if (std::get_if<FillHeld>(&e.event))
+    {
+      ++fillHeld;
+    }
+    events.push_back(e.event);
+  }
+};
+
+bool ledgersEqual(const Ledger& a, const Ledger& b, int maxAcct)
+{
+  for (int acct = 1; acct <= maxAcct; ++acct)
+  {
+    for (AssetId asset : {BASE, QUOTE})
+    {
+      if (a.available(acct, asset) != b.available(acct, asset) ||
+          a.reserved(acct, asset) != b.reserved(acct, asset))
+      {
+        return false;
+      }
+    }
+  }
+  return a.total(VENUE_ACCT, BASE) == b.total(VENUE_ACCT, BASE) &&
+         a.total(VENUE_ACCT, QUOTE) == b.total(VENUE_ACCT, QUOTE);
+}
+
+// Remove the legacy file and every checkpoint generation of `base`.
+void cleanFiles(const std::string& base)
+{
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  fs::remove(base, ec);
+  const auto g = SequencedShard<>::scanGenerations(base);
+  for (int64_t ts : g.snapshots)
+  {
+    fs::remove(SequencedShard<>::snapshotPath(base, ts), ec);
+    fs::remove(SequencedShard<>::snapshotPath(base, ts) + ".tmp", ec);
+  }
+  for (int64_t ts : g.segments)
+  {
+    fs::remove(SequencedShard<>::segmentPath(base, ts), ec);
+  }
+}
+
+// Full retained history: legacy file (if present) followed by every journal
+// segment in checkpoint order -- the "full replay" reference stream.
+std::vector<std::pair<int64_t, InboundCommand>> allRecords(const std::string& base)
+{
+  auto all = Journal::loadTimed(base);
+  for (int64_t ts : SequencedShard<>::scanGenerations(base).segments)
+  {
+    const auto seg = Journal::loadTimed(SequencedShard<>::segmentPath(base, ts));
+    all.insert(all.end(), seg.begin(), seg.end());
+  }
+  return all;
+}
+
+struct Rng
+{
+  uint64_t s;
+  uint64_t next()
+  {
+    s ^= s << 13;
+    s ^= s >> 7;
+    s ^= s << 17;
+    return s;
+  }
+};
+
+// Random command mix covering the whole surface the checkpoint must carry:
+// limits (lastLook / iceberg / GTD / OCO / peg / IOC / FOK / postOnly / STP),
+// markets, stops (market / limit / trailing), cancels, modifies, quotes,
+// last-look decisions, time ticks and (optionally) deposits/withdrawals.
+InboundCommand randomCmd(Rng& rng, OrderId& nextId, int i, bool moneyFlow)
+{
+  const uint64_t r = rng.next();
+  const uint32_t kind = r % 100;
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  const uint64_t acct = 1 + (r >> 8) % NACCT;
+
+  if (kind < 10 && nextId > 1)
+  {
+    return InboundCommand{CancelOrder{1 + (r >> 16) % (nextId - 1), SYM, 0}};
+  }
+  if (kind < 16 && nextId > 1)
+  {
+    const OrderId vid = 1 + (r >> 16) % (nextId - 1);
+    const int ticks = static_cast<int>((r >> 32) % 81) - 40;
+    const Price np = ((r >> 40) % 4 == 0)
+                         ? Price{}  // keep current price
+                         : Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+    return InboundCommand{ModifyOrder{vid, SYM, np, qty(1.0 + static_cast<double>((r >> 44) % 4)), 0}};
+  }
+  if (kind < 20)
+  {
+    // Random held id: mostly stale/wrong (deterministic rejects), sometimes live.
+    return InboundCommand{LastLookDecision{1 + (r >> 16) % 64, SYM, (r & 8) != 0, acct}};
+  }
+  if (kind < 23)
+  {
+    const OrderId bidId = nextId;
+    const OrderId askId = nextId + 1;
+    nextId += 2;
+    const int bt = static_cast<int>((r >> 32) % 30);
+    return InboundCommand{Quote{bidId, askId, SYM, Price::fromRaw(midRaw - (1 + bt) * tickRaw),
+                                qty(1.0 + static_cast<double>((r >> 40) % 3)),
+                                Price::fromRaw(midRaw + (1 + bt) * tickRaw),
+                                qty(1.0 + static_cast<double>((r >> 44) % 3)), acct}};
+  }
+  if (kind < 25 && moneyFlow)
+  {
+    return (r & 4) != 0
+               ? InboundCommand{Deposit{acct, QUOTE, quoteRaw(500.0), SYM}}
+               : InboundCommand{Deposit{acct, BASE, baseRaw(5.0), SYM}};
+  }
+  if (kind < 27 && moneyFlow)
+  {
+    return (r & 4) != 0 ? InboundCommand{Withdraw{acct, QUOTE, quoteRaw(200.0), SYM}}
+                        : InboundCommand{Withdraw{acct, BASE, baseRaw(2.0), SYM}};
+  }
+  if (kind < 29)
+  {
+    return InboundCommand{TimeTick{SYM}};
+  }
+
+  NewOrder o;
+  o.id = nextId++;
+  o.symbol = SYM;
+  o.side = (r & 1) ? Side::BUY : Side::SELL;
+  o.accountId = acct;
+  const int ticks = static_cast<int>((r >> 1) % 101) - 50;
+  o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+  o.quantity = qty(1.0 + static_cast<double>((r >> 20) % 5));
+  o.type = (kind < 34) ? OrderType::MARKET : OrderType::LIMIT;
+  if (kind >= 34 && kind < 40)  // conditional flavors
+  {
+    const uint32_t which = static_cast<uint32_t>((r >> 36) % 4);
+    const int tt = static_cast<int>((r >> 33) % 61) - 30;
+    o.triggerPrice = Price::fromRaw(midRaw + static_cast<int64_t>(tt) * tickRaw);
+    if (which == 0)
+    {
+      o.type = OrderType::STOP_MARKET;
+    }
+    else if (which == 1)
+    {
+      o.type = OrderType::STOP_LIMIT;
+    }
+    else if (which == 2)
+    {
+      o.type = OrderType::TAKE_PROFIT_MARKET;
+    }
+    else
+    {
+      o.type = OrderType::TRAILING_STOP;
+      o.trailingOffset = Price::fromRaw((1 + static_cast<int64_t>((r >> 48) % 50)) * tickRaw);
+    }
+  }
+  else if (o.type == OrderType::LIMIT)
+  {
+    const uint32_t t = static_cast<uint32_t>((r >> 32) % 100);
+    if (t < 25)
+    {
+      o.lastLook = true;
+    }
+    else if (t < 35)
+    {
+      o.visibleQuantity = qty(1.0);  // iceberg peak
+    }
+    else if (t < 45)
+    {
+      o.tif = TimeInForce::GTD;
+      o.expiryNs = 1'000'000 + static_cast<int64_t>(i) * 1000 +
+                   (1 + static_cast<int64_t>((r >> 40) % 60)) * 1000;
+    }
+    else if (t < 53)
+    {
+      o.ocoGroup = 1 + ((r >> 44) % 5);
+    }
+    else if (t < 60)
+    {
+      const uint32_t pr = static_cast<uint32_t>((r >> 48) % 3);
+      o.peg = pr == 0 ? PegRef::Bid : (pr == 1 ? PegRef::Ask : PegRef::Mid);
+      o.pegOffsetRaw = (static_cast<int64_t>((r >> 52) % 5) - 2) * tickRaw;
+    }
+    else if (t < 68)
+    {
+      o.tif = TimeInForce::IOC;
+    }
+    else if (t < 74)
+    {
+      o.tif = TimeInForce::FOK;
+    }
+    else if (t < 80)
+    {
+      o.postOnly = true;
+    }
+    else if (t < 85)
+    {
+      o.stp = STPMode::CancelOldest;
+    }
+    else if (t < 90)
+    {
+      o.clientOrderId = 1 + (r >> 52) % 500;  // dedup set gets real load
+    }
+  }
+  return InboundCommand{o};
+}
+
+}  // namespace
+
+// Engine-level round trip: writeSnapshot -> applySnapshotRecord into a fresh
+// engine + empty ledger reproduces the exact state (hash, book, balances) --
+// no shard machinery involved.
+TEST(VenueCheckpoint, EngineSnapshotRoundTrip)
+{
+  const std::string path = "/tmp/flox_test_venue_checkpoint_roundtrip.snap";
+  std::remove(path.c_str());
+
+  venue::SymbolConfig c = cfg();
+  c.lastLookWindowNs = 10'000'000;
+
+  Ledger led;
+  MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+  eng.submit(InboundCommand{Deposit{1, BASE, baseRaw(100), SYM}}, 1000);
+  eng.submit(InboundCommand{Deposit{2, QUOTE, quoteRaw(100000), SYM}}, 2000);
+  NewOrder maker = limit(1, Side::SELL, 100.00, 5.0, 1);
+  maker.lastLook = true;
+  eng.submit(InboundCommand{maker}, 3000);
+  NewOrder ice = limit(2, Side::SELL, 101.00, 10.0, 1);
+  ice.visibleQuantity = qty(2.0);
+  eng.submit(InboundCommand{ice}, 4000);
+  NewOrder taker = limit(3, Side::BUY, 100.00, 3.0, 2);
+  taker.tif = TimeInForce::IOC;
+  eng.submit(InboundCommand{taker}, 5000);  // held fill stays open
+  NewOrder stop = limit(4, Side::SELL, 0.0, 2.0, 1);
+  stop.type = OrderType::STOP_MARKET;
+  stop.triggerPrice = px(95.0);
+  eng.submit(InboundCommand{stop}, 6000);
+  NewOrder gtd = limit(5, Side::BUY, 99.0, 2.0, 2);
+  gtd.tif = TimeInForce::GTD;
+  gtd.expiryNs = 50'000'000;
+  eng.submit(InboundCommand{gtd}, 7000);
+
+  {
+    Journal out(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    eng.writeSnapshot(out);
+    out.flush();
+  }
+
+  Ledger led2;
+  MatchingEngine<MatchingBook> rec(c, [](const OutboundEvent&) {});
+  rec.setLedger(&led2, VENUE_ACCT);
+  const auto records = Journal::loadTimed(path);
+  ASSERT_GE(records.size(), 2u);
+  EXPECT_TRUE(std::holds_alternative<SnapshotBegin>(records.front().second));
+  EXPECT_TRUE(std::holds_alternative<SnapshotEnd>(records.back().second));
+  for (const auto& [ts, cmd] : records)
+  {
+    ASSERT_TRUE(rec.applySnapshotRecord(cmd, ts));
+  }
+
+  EXPECT_EQ(rec.stateHash(), eng.stateHash());
+  EXPECT_EQ(rec.book().bestBid(), eng.book().bestBid());
+  EXPECT_EQ(rec.book().bestAsk(), eng.book().bestAsk());
+  EXPECT_TRUE(ledgersEqual(led2, led, 2));
+  ASSERT_NE(rec.book().find(2), nullptr);
+  EXPECT_EQ(rec.book().find(2)->hidden, qty(8.0));
+  EXPECT_EQ(rec.book().find(2)->leaves, qty(2.0));
+  std::remove(path.c_str());
+}
+
+// The core differential guarantee: a long random session with a checkpoint at
+// an arbitrary point recovers (snapshot + tail segments) into EXACTLY the
+// state a full-history replay produces -- state hash equal AND the event hash
+// of identical subsequent traffic equal.
+TEST(VenueCheckpoint, DifferentialRandomSessionCheckpointInvisible)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_diff.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  c.lastLookWindowNs = 20'000;  // 20 clock steps: holds open and expire mid-stream
+  c.lastLookAcceptOnTimeout = false;
+
+  Ledger led1;
+  HashSink sink1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->subscribeOutbound(&sink1);
+  s1->start();
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    s1->submit(InboundCommand{Deposit{static_cast<uint64_t>(a), BASE, baseRaw(1000), SYM}});
+    s1->submit(InboundCommand{Deposit{static_cast<uint64_t>(a), QUOTE, quoteRaw(100000), SYM}});
+  }
+
+  Rng rng{0xC0FFEE0DDBA11ULL};
+  OrderId nextId = 1;
+  const int N = 4000;
+  const int checkpointAt = 2400;
+  for (int i = 0; i < N; ++i)
+  {
+    if (i == checkpointAt)
+    {
+      // Force checkpoint-relevant state RIGHT before the snapshot: an open
+      // hold, a pending stop and an iceberg must be in the file.
+      NewOrder mk = limit(nextId++, Side::SELL, 100.00, 4.0, 1);
+      mk.lastLook = true;
+      s1->submit(InboundCommand{mk});
+      NewOrder tk = limit(nextId++, Side::BUY, 100.00, 2.0, 2);
+      tk.tif = TimeInForce::IOC;
+      s1->submit(InboundCommand{tk});
+      NewOrder st = limit(nextId++, Side::SELL, 0.0, 1.0, 3);
+      st.type = OrderType::STOP_MARKET;
+      st.triggerPrice = px(60.0);
+      s1->submit(InboundCommand{st});
+      NewOrder ic = limit(nextId++, Side::BUY, 51.0, 6.0, 4);
+      ic.visibleQuantity = qty(1.0);
+      s1->submit(InboundCommand{ic});
+      ASSERT_TRUE(s1->checkpointNow());
+    }
+    s1->submit(randomCmd(rng, nextId, i, /*moneyFlow*/ true));
+  }
+  s1->flush();
+  EXPECT_GT(sink1.fillHeld, 20u);  // coverage: holds really happened
+  const uint64_t liveHash = s1->engine().stateHash();
+  s1->stop();
+  s1.reset();
+
+  // Anti-vacuum guard: the snapshot FILE itself must carry the hard state --
+  // a checkpoint that silently serialized an earlier/emptier boundary (or
+  // nothing) must fail here, not be papered over by the tail replay below.
+  const auto gens = SequencedShard<>::scanGenerations(base);
+  ASSERT_EQ(gens.snapshots.size(), 1u);
+  ASSERT_EQ(gens.segments.size(), 1u);
+  const auto snapRecords =
+      Journal::loadTimed(SequencedShard<>::snapshotPath(base, gens.snapshots[0]));
+  size_t nHeld = 0, nStops = 0, nIceberg = 0, nOrders = 0, nBalances = 0;
+  for (const auto& [ts, cmd] : snapRecords)
+  {
+    if (std::get_if<RestoreHeld>(&cmd))
+    {
+      ++nHeld;
+    }
+    if (std::get_if<RestoreStop>(&cmd))
+    {
+      ++nStops;
+    }
+    if (std::get_if<RestoreBalance>(&cmd))
+    {
+      ++nBalances;
+    }
+    if (const auto* r = std::get_if<RestoreOrder>(&cmd))
+    {
+      ++nOrders;
+      nIceberg += r->hidden.raw() > 0 ? 1 : 0;
+    }
+  }
+  EXPECT_GE(nHeld, 1u);
+  EXPECT_GE(nStops, 1u);
+  EXPECT_GE(nIceberg, 1u);
+  EXPECT_GT(nOrders, 2u);
+  EXPECT_GE(nBalances, static_cast<size_t>(NACCT));  // every funded account x asset
+
+  // Reference: full-history replay (legacy + all segments) from empty.
+  const auto all = allRecords(base);
+  ASSERT_FALSE(all.empty());
+  Ledger refLed;
+  uint64_t refH = kHashSeed;
+  MatchingEngine<MatchingBook> ref(c, [&](const OutboundEvent& e)
+                                   { refH = hashEvent(refH, e); });
+  ref.setLedger(&refLed, VENUE_ACCT);
+  for (const auto& [ts, cmd] : all)
+  {
+    ref.submit(cmd, ts);
+  }
+  EXPECT_EQ(ref.stateHash(), liveHash);  // the reference really reproduces live
+
+  // Recovered shard: snapshot + tail. State hash AND ledger split must match.
+  Ledger led2;
+  HashSink sink2;
+  const int64_t tailBase = all.back().first + 1'000'000;
+  auto t2 = clockState(tailBase);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  s2->subscribeOutbound(&sink2);
+  s2->start();
+  // Recovery PROVABLY consumed the snapshot, not a full-history replay: it
+  // applied exactly the snapshot's records plus the tail segment's.
+  const size_t tailRecords =
+      Journal::loadTimed(SequencedShard<>::segmentPath(base, gens.segments[0])).size();
+  EXPECT_EQ(s2->recoveredFromSnapshotRecords(), snapRecords.size());
+  EXPECT_EQ(s2->recoveredCommands(), snapRecords.size() + tailRecords);
+  EXPECT_LT(s2->recoveredCommands(), all.size());  // strictly fewer than full history
+  EXPECT_EQ(s2->engine().stateHash(), liveHash);
+  EXPECT_EQ(s2->engine().stateHash(), ref.stateHash());
+  EXPECT_TRUE(ledgersEqual(led2, refLed, NACCT));
+
+  // Reserved invariant: available+reserved per account x asset unchanged.
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    for (AssetId asset : {BASE, QUOTE})
+    {
+      EXPECT_EQ(led2.available(a, asset) + led2.reserved(a, asset),
+                refLed.available(a, asset) + refLed.reserved(a, asset));
+    }
+  }
+
+  // Identical subsequent traffic must produce an identical event stream.
+  refH = kHashSeed;
+  sink2.h = kHashSeed;
+  std::vector<InboundCommand> tail;
+  Rng rng2{0xFACEFEEDULL};
+  for (int i = 0; i < 200; ++i)
+  {
+    tail.push_back(randomCmd(rng2, nextId, N + i, true));
+  }
+  for (size_t i = 0; i < tail.size(); ++i)
+  {
+    s2->submit(tail[i]);
+    ref.submit(tail[i], tailBase + static_cast<int64_t>(i + 1) * 1000);
+  }
+  s2->flush();
+  EXPECT_EQ(sink2.h, refH);
+  EXPECT_EQ(s2->engine().stateHash(), ref.stateHash());
+  EXPECT_TRUE(ledgersEqual(led2, refLed, NACCT));
+  s2->stop();
+  cleanFiles(base);
+}
+
+// Addressable restore checks: open hold (acceptable post-restart, settles),
+// pending stop + trailing stop, GTD (expires on the restored deadline), OCO
+// across book and stop book, iceberg (hidden reserve intact), peg (keeps
+// repricing), clientOrderId dedup, and the reserved invariant.
+TEST(VenueCheckpoint, CheckpointRestoresOpenStateAddressably)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_state.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  c.lastLookWindowNs = 100'000'000;  // survives the restart window
+  c.lastLookAcceptOnTimeout = false;
+
+  Ledger led1;
+  HashSink sink1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->engine().setMmp(1, qty(100.0), 1'000'000'000);
+  s1->subscribeOutbound(&sink1);
+  s1->start();
+
+  s1->submit(InboundCommand{Deposit{1, BASE, baseRaw(1000), SYM}});
+  s1->submit(InboundCommand{Deposit{2, QUOTE, quoteRaw(100000), SYM}});
+  s1->submit(InboundCommand{Deposit{3, BASE, baseRaw(1000), SYM}});
+  s1->submit(InboundCommand{Deposit{3, QUOTE, quoteRaw(100000), SYM}});
+  s1->submit(InboundCommand{Deposit{4, QUOTE, quoteRaw(100000), SYM}});
+
+  NewOrder mk = limit(1, Side::SELL, 100.00, 5.0, 1);
+  mk.lastLook = true;
+  s1->submit(InboundCommand{mk});
+  NewOrder tk = limit(2, Side::BUY, 100.00, 3.0, 2);
+  tk.tif = TimeInForce::IOC;
+  s1->submit(InboundCommand{tk});  // hold #1 (qty 3) stays open
+  NewOrder ice = limit(3, Side::SELL, 101.00, 10.0, 1);
+  ice.visibleQuantity = qty(2.0);
+  s1->submit(InboundCommand{ice});
+  NewOrder gtd = limit(4, Side::BUY, 99.00, 2.0, 2);
+  gtd.tif = TimeInForce::GTD;
+  gtd.expiryNs = 5'000'000;
+  s1->submit(InboundCommand{gtd});
+  NewOrder ocoBook = limit(5, Side::BUY, 98.00, 2.0, 2);
+  ocoBook.ocoGroup = 7;
+  s1->submit(InboundCommand{ocoBook});
+  NewOrder ocoStop = limit(6, Side::SELL, 0.0, 2.0, 3);
+  ocoStop.type = OrderType::STOP_MARKET;
+  ocoStop.triggerPrice = px(90.0);
+  ocoStop.ocoGroup = 7;
+  s1->submit(InboundCommand{ocoStop});
+  NewOrder trail = limit(7, Side::SELL, 0.0, 1.0, 3);
+  trail.type = OrderType::TRAILING_STOP;
+  trail.trailingOffset = px(1.00);
+  s1->submit(InboundCommand{trail});
+  NewOrder peg = limit(8, Side::BUY, 0.0, 1.0, 4);
+  peg.peg = PegRef::Bid;
+  s1->submit(InboundCommand{peg});
+  NewOrder clord = limit(9, Side::BUY, 97.00, 1.0, 4);
+  clord.clientOrderId = 555;
+  s1->submit(InboundCommand{clord});
+
+  ASSERT_TRUE(s1->checkpointNow());
+  s1->flush();
+  const uint64_t liveHash = s1->engine().stateHash();
+  s1->stop();
+  s1.reset();
+
+  Ledger led2;
+  HashSink sink2;
+  auto t2 = clockState(1'200'000);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  s2->subscribeOutbound(&sink2);
+  s2->start();
+
+  // Full state equality first (covers MMP config, pegs, counters, ...), and
+  // recovery provably came through the snapshot.
+  EXPECT_GT(s2->recoveredFromSnapshotRecords(), 0u);
+  EXPECT_EQ(s2->engine().stateHash(), liveHash);
+  EXPECT_TRUE(ledgersEqual(led2, led1, 4));
+
+  // Iceberg: displayed peak and hidden reserve intact.
+  const RestingOrder* iceR = s2->engine().book().find(3);
+  ASSERT_NE(iceR, nullptr);
+  EXPECT_EQ(iceR->leaves, qty(2.0));
+  EXPECT_EQ(iceR->hidden, qty(8.0));
+  EXPECT_EQ(iceR->peak, qty(2.0));
+
+  // Maker with the open hold: displayed remainder resting, lastLook intact.
+  const RestingOrder* mkR = s2->engine().book().find(1);
+  ASSERT_NE(mkR, nullptr);
+  EXPECT_EQ(mkR->leaves, qty(2.0));
+  EXPECT_TRUE(mkR->lastLook);
+
+  // Pending stops (incl. trailing) visible in the account snapshot.
+  const auto acct3 = s2->engine().snapshotAccount(3);
+  ASSERT_EQ(acct3.pendingStops.size(), 2u);
+
+  // The restored hold accepts and SETTLES: trade at 100 x 3, money moves.
+  const Amount a1qBefore = led2.available(1, QUOTE);
+  const Amount a2bBefore = led2.available(2, BASE);
+  s2->submit(InboundCommand{LastLookDecision{1, SYM, true, 1}});
+  s2->flush();
+  bool sawTrade = false;
+  for (const auto& e : sink2.events)
+  {
+    if (const auto* t = std::get_if<venue::Trade>(&e);
+        t && t->makerId == 1 && t->takerId == 2 && t->quantity == qty(3.0) && t->price == px(100.0))
+    {
+      sawTrade = true;
+    }
+  }
+  EXPECT_TRUE(sawTrade);
+  EXPECT_EQ(led2.available(1, QUOTE) - a1qBefore, quoteRaw(300.0));
+  EXPECT_EQ(led2.available(2, BASE) - a2bBefore, baseRaw(3.0));
+
+  // clientOrderId dedup survived: same clOrdId rejects post-restart.
+  NewOrder dup = limit(20, Side::BUY, 97.50, 1.0, 4);
+  dup.clientOrderId = 555;
+  s2->submit(InboundCommand{dup});
+  s2->flush();
+  bool sawDupReject = false;
+  for (const auto& e : sink2.events)
+  {
+    if (const auto* r = std::get_if<OrderRejected>(&e);
+        r && r->id == 20 && r->reason == RejectReason::DuplicateClientOrderId)
+    {
+      sawDupReject = true;
+    }
+  }
+  EXPECT_TRUE(sawDupReject);
+
+  // GTD: jump time past the restored expiry -> canceled Expired.
+  t2->store(6'000'000);
+  s2->submit(InboundCommand{TimeTick{SYM}});
+  s2->flush();
+  bool sawExpiry = false;
+  for (const auto& e : sink2.events)
+  {
+    if (const auto* x = std::get_if<OrderCanceled>(&e);
+        x && x->id == 4 && x->reason == CancelReason::Expired)
+    {
+      sawExpiry = true;
+    }
+  }
+  EXPECT_TRUE(sawExpiry);
+
+  // OCO across book and stop book: filling the book leg cancels the stop leg.
+  s2->submit(InboundCommand{limit(21, Side::SELL, 98.00, 2.0, 3)});
+  s2->flush();
+  bool sawOco = false;
+  for (const auto& e : sink2.events)
+  {
+    if (const auto* x = std::get_if<OrderCanceled>(&e);
+        x && x->id == 6 && x->reason == CancelReason::OcoTriggered)
+    {
+      sawOco = true;
+    }
+  }
+  EXPECT_TRUE(sawOco);
+
+  // Peg: still live and repricing (an OrderModified for it appeared after the
+  // book moved under it).
+  EXPECT_TRUE(s2->engine().book().contains(8));
+  bool sawRepeg = false;
+  for (const auto& e : sink2.events)
+  {
+    if (const auto* m = std::get_if<OrderModified>(&e); m && m->id == 8)
+    {
+      sawRepeg = true;
+    }
+  }
+  EXPECT_TRUE(sawRepeg);
+
+  // Drain: every reservation returns to available.
+  for (OrderId id = 1; id <= 21; ++id)
+  {
+    s2->submit(InboundCommand{CancelOrder{id, SYM, 0}});
+  }
+  s2->flush();
+  for (int a = 1; a <= 4; ++a)
+  {
+    EXPECT_EQ(led2.reserved(a, BASE), 0);
+    EXPECT_EQ(led2.reserved(a, QUOTE), 0);
+  }
+  s2->stop();
+  cleanFiles(base);
+}
+
+// Perp: positions (qty, entry, posted margin) restore, margin is re-reserved,
+// and closing the position post-restart releases it -- conservation holds.
+TEST(VenueCheckpoint, PerpPositionAndMarginRestored)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_perp.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  c.baseAsset = 0;
+  c.quoteAsset = QUOTE;
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;
+  c.maintenanceMarginBps = 500;
+
+  Ledger led1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->start();
+  s1->submit(InboundCommand{Deposit{1, QUOTE, quoteRaw(100000), SYM}});
+  s1->submit(InboundCommand{Deposit{2, QUOTE, quoteRaw(100000), SYM}});
+  s1->submit(InboundCommand{limit(1, Side::SELL, 100.00, 5.0, 2)});
+  s1->submit(InboundCommand{limit(2, Side::BUY, 100.00, 5.0, 1)});  // +5 / -5 @ 100
+  s1->submit(InboundCommand{SetMark{SYM, px(100.0)}});
+  ASSERT_TRUE(s1->checkpointNow());
+  s1->flush();
+  const uint64_t liveHash = s1->engine().stateHash();
+  const Amount margin1 = led1.reserved(1, QUOTE);
+  const Amount margin2 = led1.reserved(2, QUOTE);
+  ASSERT_GT(margin1, 0);
+  ASSERT_GT(margin2, 0);
+  s1->stop();
+  s1.reset();
+
+  Ledger led2;
+  auto t2 = clockState(2'000'000);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  s2->start();
+  EXPECT_GT(s2->recoveredFromSnapshotRecords(), 0u);
+  EXPECT_EQ(s2->engine().stateHash(), liveHash);
+  EXPECT_EQ(s2->engine().positionQty(1), qty(5.0).raw());
+  EXPECT_EQ(s2->engine().positionQty(2), -qty(5.0).raw());
+  EXPECT_EQ(s2->engine().positionEntry(1), px(100.0));
+  EXPECT_EQ(led2.reserved(1, QUOTE), margin1);
+  EXPECT_EQ(led2.reserved(2, QUOTE), margin2);
+  EXPECT_EQ(s2->engine().totalPositionMargin(), margin1 + margin2);
+
+  // Close both positions at entry: margins release, totals conserve exactly.
+  s2->submit(InboundCommand{limit(11, Side::BUY, 100.00, 5.0, 2)});
+  s2->submit(InboundCommand{limit(12, Side::SELL, 100.00, 5.0, 1)});
+  s2->flush();
+  EXPECT_EQ(s2->engine().positionQty(1), 0);
+  EXPECT_EQ(s2->engine().positionQty(2), 0);
+  EXPECT_EQ(led2.reserved(1, QUOTE), 0);
+  EXPECT_EQ(led2.reserved(2, QUOTE), 0);
+  EXPECT_EQ(led2.total(1, QUOTE) + led2.total(2, QUOTE) + led2.total(VENUE_ACCT, QUOTE),
+            static_cast<Amount>(quoteRaw(100000)) * 2);
+  s2->stop();
+  cleanFiles(base);
+}
+
+// Torn snapshot: truncating the newest snapshot at EVERY byte offset makes
+// recovery fall back to the previous generation, whose snapshot + both tail
+// segments reproduce the exact final state.
+TEST(VenueCheckpoint, TornSnapshotFallsBackToPreviousGeneration)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_torn.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  Ledger led1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->start();
+  s1->submit(InboundCommand{Deposit{1, BASE, baseRaw(100), SYM}});
+  s1->submit(InboundCommand{Deposit{2, QUOTE, quoteRaw(10000), SYM}});
+  s1->submit(InboundCommand{limit(1, Side::SELL, 100.00, 2.0, 1)});
+  s1->submit(InboundCommand{limit(2, Side::BUY, 99.00, 1.0, 2)});
+  ASSERT_TRUE(s1->checkpointNow());                                 // generation A
+  s1->submit(InboundCommand{limit(3, Side::BUY, 100.00, 1.0, 2)});  // trades vs 1
+  s1->submit(InboundCommand{limit(4, Side::SELL, 101.00, 1.0, 1)});
+  ASSERT_TRUE(s1->checkpointNow());  // generation B
+  s1->submit(InboundCommand{CancelOrder{2, SYM, 2}});
+  s1->flush();
+  const uint64_t liveHash = s1->engine().stateHash();
+  s1->stop();
+  s1.reset();
+
+  const auto gens = SequencedShard<>::scanGenerations(base);
+  ASSERT_EQ(gens.snapshots.size(), 2u);
+  const std::string snapB = SequencedShard<>::snapshotPath(base, gens.snapshots[1]);
+
+  // Pristine copy of snapshot B.
+  std::vector<char> pristine;
+  {
+    std::ifstream in(snapB, std::ios::binary);
+    pristine.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+  }
+  ASSERT_GT(pristine.size(), 64u);
+
+  for (size_t len = 0; len < pristine.size(); ++len)
+  {
+    {
+      std::ofstream out(snapB, std::ios::binary | std::ios::trunc);
+      out.write(pristine.data(), static_cast<std::streamsize>(len));
+    }
+    Ledger led2;
+    auto t2 = clockState(9'000'000 + static_cast<int64_t>(len) * 10'000);
+    // Heap-allocated: a shard embeds its 64k EventBus rings (~27 MB).
+    auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                                 clockOf(t2));
+    s2->engine().setLedger(&led2, VENUE_ACCT);
+    s2->start();
+    // Fallback still recovers THROUGH a snapshot (generation A), not a bare
+    // journal replay -- and reproduces the exact final state.
+    ASSERT_GT(s2->recoveredFromSnapshotRecords(), 0u) << "truncation at " << len;
+    ASSERT_EQ(s2->engine().stateHash(), liveHash) << "truncation at " << len;
+    ASSERT_TRUE(ledgersEqual(led2, led1, 2)) << "truncation at " << len;
+    s2->stop();
+  }
+
+  // Restore pristine B: recovery prefers it again.
+  {
+    std::ofstream out(snapB, std::ios::binary | std::ios::trunc);
+    out.write(pristine.data(), static_cast<std::streamsize>(pristine.size()));
+  }
+  {
+    Ledger led2;
+    auto t2 = clockState(50'000'000);
+    auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                                 clockOf(t2));
+    s2->engine().setLedger(&led2, VENUE_ACCT);
+    s2->start();
+    EXPECT_EQ(s2->engine().stateHash(), liveHash);
+    s2->stop();
+  }
+  cleanFiles(base);
+}
+
+// Retention: with the default 2 generations, a third checkpoint deletes the
+// first snapshot+segment pair and the legacy file; recovery from the retained
+// window still reproduces the live state exactly.
+TEST(VenueCheckpoint, RotationRetainsConfiguredGenerations)
+{
+  namespace fs = std::filesystem;
+  const std::string base = "/tmp/flox_test_venue_checkpoint_rotate.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  Ledger led1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->start();
+  s1->submit(InboundCommand{Deposit{1, BASE, baseRaw(100), SYM}});
+  s1->submit(InboundCommand{Deposit{2, QUOTE, quoteRaw(10000), SYM}});
+
+  std::vector<int64_t> cpTs;
+  for (int gen = 0; gen < 3; ++gen)
+  {
+    s1->submit(InboundCommand{limit(10 + gen * 2, Side::SELL,
+                                    100.00 + gen * 0.01, 1.0, 1)});
+    s1->submit(InboundCommand{limit(11 + gen * 2, Side::BUY, 99.00 - gen * 0.01, 1.0, 2)});
+    ASSERT_TRUE(s1->checkpointNow());
+    const auto g = SequencedShard<>::scanGenerations(base);
+    cpTs.push_back(g.snapshots.back());
+  }
+  s1->flush();
+  const uint64_t liveHash = s1->engine().stateHash();
+  s1->stop();
+  s1.reset();
+
+  const auto g = SequencedShard<>::scanGenerations(base);
+  EXPECT_EQ(g.snapshots.size(), 2u);  // retainGenerations default = 2
+  EXPECT_EQ(g.segments.size(), 2u);
+  EXPECT_FALSE(fs::exists(base));  // legacy pre-checkpoint file pruned
+  EXPECT_FALSE(fs::exists(SequencedShard<>::snapshotPath(base, cpTs[0])));
+  EXPECT_FALSE(fs::exists(SequencedShard<>::segmentPath(base, cpTs[0])));
+  EXPECT_TRUE(fs::exists(SequencedShard<>::snapshotPath(base, cpTs[1])));
+  EXPECT_TRUE(fs::exists(SequencedShard<>::snapshotPath(base, cpTs[2])));
+
+  // The pre-checkpoint history is GONE (legacy pruned): state equality below
+  // is provable ONLY if recovery consumed a snapshot -- deposits exist
+  // nowhere else. The counter makes that explicit.
+  Ledger led2;
+  auto t2 = clockState(9'000'000);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  s2->start();
+  EXPECT_GT(s2->recoveredFromSnapshotRecords(), 0u);
+  EXPECT_EQ(s2->engine().stateHash(), liveHash);
+  EXPECT_TRUE(ledgersEqual(led2, led1, 2));
+  s2->stop();
+  cleanFiles(base);
+}
+
+// Snapshot-only records must never apply from live traffic: a client that
+// could submit RestoreOrder would mint itself a resting order.
+TEST(VenueCheckpoint, LiveSubmitOfSnapshotRecordIsDropped)
+{
+  // Engine level.
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  RestoreOrder forged{};
+  forged.id = 42;
+  forged.accountId = 7;
+  forged.price = px(100.0);
+  forged.leaves = qty(5.0);
+  forged.side = Side::BUY;
+  eng.submit(InboundCommand{forged}, 1000);
+  EXPECT_EQ(eng.droppedSnapshotRecords(), 1u);
+  EXPECT_FALSE(eng.book().contains(42));
+  eng.submit(InboundCommand{SnapshotEnd{}}, 2000);
+  EXPECT_EQ(eng.droppedSnapshotRecords(), 2u);
+  EXPECT_EQ(eng.tradesGenerated(), 0u);
+
+  // Shard level: journaled or not, the record never materializes -- including
+  // across a restart replay.
+  const std::string base = "/tmp/flox_test_venue_checkpoint_forged.bin";
+  cleanFiles(base);
+  {
+    auto t = clockState(1'000'000);
+    auto s = std::make_unique<SequencedShard<>>(cfg(), base, MatchingBook{}, Journal::Sync::Off,
+                                                clockOf(t));
+    s->start();
+    s->submit(InboundCommand{forged});
+    s->flush();
+    EXPECT_EQ(s->engine().droppedSnapshotRecords(), 1u);
+    EXPECT_FALSE(s->engine().book().contains(42));
+    s->stop();
+  }
+  {
+    auto t = clockState(2'000'000);
+    auto s = std::make_unique<SequencedShard<>>(cfg(), base, MatchingBook{}, Journal::Sync::Off,
+                                                clockOf(t));
+    s->start();  // replay drops it again, deterministically
+    EXPECT_FALSE(s->engine().book().contains(42));
+    s->stop();
+  }
+  cleanFiles(base);
+}
+
+// Pause measurement (no threshold assert -- just the numbers) on a ~100k-order
+// book. With the asynchronous checkpoint the consumer pause is the CLONE time
+// (cloneForSnapshot); serialization+fsync runs in the background against the
+// clone. Both are measured: the clone must be a small fraction of the old
+// synchronous writeSnapshot pause, and the clone must be state-identical.
+TEST(VenueCheckpoint, SnapshotPauseMeasuredOn100kOrders)
+{
+  const std::string path = "/tmp/flox_test_venue_checkpoint_pause.snap";
+  std::remove(path.c_str());
+
+  venue::SymbolConfig c = cfg();
+  Ledger led;
+  MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    eng.submit(InboundCommand{Deposit{static_cast<uint64_t>(a), BASE, baseRaw(10'000'000), SYM}}, a);
+    eng.submit(InboundCommand{Deposit{static_cast<uint64_t>(a), QUOTE, quoteRaw(1'000'000'000), SYM}},
+               NACCT + a);
+  }
+  Rng rng{0xBEEFCAFEULL};
+  const int64_t tickRaw = px(0.01).raw();
+  const int kOrders = 100'000;
+  for (int i = 0; i < kOrders; ++i)
+  {
+    const uint64_t r = rng.next();
+    NewOrder o;
+    o.id = static_cast<OrderId>(i + 1);
+    o.symbol = SYM;
+    o.side = (r & 1) ? Side::BUY : Side::SELL;
+    o.accountId = 1 + (r >> 8) % NACCT;
+    // Non-crossing: bids in [60, 90), asks in [110, 140).
+    const int64_t off = static_cast<int64_t>((r >> 16) % 3000);
+    o.price = (r & 1) ? Price::fromRaw(px(60.0).raw() + off * tickRaw)
+                      : Price::fromRaw(px(110.0).raw() + off * tickRaw);
+    o.quantity = qty(1.0 + static_cast<double>((r >> 40) % 3));
+    o.type = OrderType::LIMIT;
+    eng.submit(InboundCommand{o}, 100 + i);
+  }
+  ASSERT_GT(eng.restingOrderCount(), 90'000u);
+
+  // Old synchronous pause (reference): serialize the live engine directly.
+  uint64_t bytes = 0;
+  const auto t0 = std::chrono::steady_clock::now();
+  {
+    Journal out(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    eng.writeSnapshot(out);
+    bytes = out.bytes();
+  }
+  const auto t1 = std::chrono::steady_clock::now();
+  const double serializeMs =
+      std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(t1 - t0).count();
+
+  // New pause: the clone taken under the consumer pause of the async path.
+  const auto c0 = std::chrono::steady_clock::now();
+  auto clone = eng.cloneForSnapshot();
+  const auto c1 = std::chrono::steady_clock::now();
+  const double cloneMs =
+      std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(c1 - c0).count();
+
+  // The clone is state-identical: the background writer serializes exactly
+  // what the live engine held at the boundary.
+  EXPECT_EQ(clone.engine->stateHash(), eng.stateHash());
+  EXPECT_EQ(clone.engine->restingOrderCount(), eng.restingOrderCount());
+  {
+    Journal out(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    clone.engine->writeSnapshot(out);
+    EXPECT_EQ(out.bytes(), bytes);
+  }
+
+  std::printf("[ PAUSE    ] writeSnapshot (old sync pause): %zu resting orders, %.1f MiB, %.2f ms\n",
+              static_cast<size_t>(eng.restingOrderCount()),
+              static_cast<double>(bytes) / (1024.0 * 1024.0), serializeMs);
+  std::printf("[ PAUSE    ] cloneForSnapshot (new async pause): %.2f ms (%.1fx shorter)\n",
+              cloneMs, serializeMs / (cloneMs > 0.0 ? cloneMs : 1e-9));
+  EXPECT_LT(cloneMs, serializeMs);  // the async pause must beat the serialize pause
+  std::remove(path.c_str());
+}
+
+// Conservation fuzz with periodic checkpoints: checkpointing at arbitrary
+// command boundaries must be invisible to the money-conservation invariant,
+// and a final recovery must reproduce the ledger split exactly, draining to
+// zero reserved.
+TEST(VenueCheckpoint, ConservationHoldsAcrossPeriodicCheckpoints)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_fuzz.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  c.lastLookWindowNs = 40'000;
+  c.lastLookAcceptOnTimeout = true;  // timeout-accepts settle like real fills
+
+  Ledger led1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->start();
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    s1->submit(InboundCommand{Deposit{static_cast<uint64_t>(a), BASE, baseRaw(1000), SYM}});
+    s1->submit(InboundCommand{Deposit{static_cast<uint64_t>(a), QUOTE, quoteRaw(100000), SYM}});
+  }
+  const Amount initBase = static_cast<Amount>(baseRaw(1000)) * NACCT;
+  const Amount initQuote = static_cast<Amount>(quoteRaw(100000)) * NACCT;
+  auto sumAsset = [&](const Ledger& led, AssetId asset)
+  {
+    Amount t = led.total(VENUE_ACCT, asset);
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, asset);
+    }
+    return t;
+  };
+
+  Rng rng{0xA5A5A5A51234ULL};
+  OrderId nextId = 1;
+  const int N = 20'000;
+  int checkpoints = 0;
+  for (int i = 0; i < N; ++i)
+  {
+    if (i > 0 && i % 4000 == 0)
+    {
+      ASSERT_TRUE(s1->checkpointNow());
+      ++checkpoints;
+      EXPECT_EQ(sumAsset(led1, BASE), initBase) << "at checkpoint after op " << i;
+      EXPECT_EQ(sumAsset(led1, QUOTE), initQuote) << "at checkpoint after op " << i;
+    }
+    s1->submit(randomCmd(rng, nextId, i, /*moneyFlow*/ false));
+  }
+  s1->flush();
+  EXPECT_EQ(checkpoints, 4);
+  EXPECT_EQ(sumAsset(led1, BASE), initBase);
+  EXPECT_EQ(sumAsset(led1, QUOTE), initQuote);
+  s1->stop();
+  s1.reset();
+
+  // Recovery reproduces the split; conservation holds; draining releases all.
+  Ledger led2;
+  auto t2 = clockState(t1->load() + 1'000'000);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  s2->start();
+  EXPECT_TRUE(ledgersEqual(led2, led1, NACCT));
+  EXPECT_EQ(sumAsset(led2, BASE), initBase);
+  EXPECT_EQ(sumAsset(led2, QUOTE), initQuote);
+
+  for (OrderId id = 1; id < nextId; ++id)
+  {
+    s2->submit(InboundCommand{CancelOrder{id, SYM, 0}});
+  }
+  // Cancel-while-held resolves holds; sweep any residual timeout holds too.
+  t2->fetch_add(100'000'000);
+  s2->submit(InboundCommand{TimeTick{SYM}});
+  s2->flush();
+  EXPECT_EQ(sumAsset(led2, BASE), initBase);
+  EXPECT_EQ(sumAsset(led2, QUOTE), initQuote);
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    EXPECT_EQ(led2.reserved(a, BASE), 0);
+    EXPECT_EQ(led2.reserved(a, QUOTE), 0);
+  }
+  s2->stop();
+  cleanFiles(base);
+}
+
+// BalanceUpdate across checkpoint/recovery: a live deposit emits exactly one
+// BalanceUpdate; recovery (snapshot Deposit records + journal tail) publishes
+// NOTHING outbound -- reconnecting clients reconcile via snapshots, not a
+// re-broadcast; a fresh post-recovery deposit emits exactly one again. The
+// onCheckpoint hook fires at the checkpoint boundary and the FIX session
+// sidecar written there restores into a fresh host + registry.
+TEST(VenueCheckpoint, BalanceUpdateRecoverySuppressionAndSidecarHook)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_balance.bin";
+  const std::string sidecar = FixSessionSidecar::pathFor(base);
+  cleanFiles(base);
+  std::remove(sidecar.c_str());
+
+  const auto countBalance = [](const std::vector<OutboundEvent>& events)
+  {
+    size_t n = 0;
+    for (const auto& e : events)
+    {
+      n += std::get_if<BalanceUpdate>(&e) != nullptr ? 1 : 0;
+    }
+    return n;
+  };
+
+  Ledger led1;
+  HashSink sink1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(cfg(), base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->subscribeOutbound(&sink1);
+
+  // FIX session state as the gateway harness would hold it at runtime.
+  FixSessionHost host;
+  SessionRegistry registry;
+  {
+    auto st = host.stateOf(7);
+    std::lock_guard<std::mutex> lk(st->m);
+    st->expectedIn = 42;
+    st->established = true;
+  }
+  int64_t hookTs = 0;
+  s1->onCheckpoint([&](int64_t ts)
+                   {
+                     hookTs = ts;
+                     ASSERT_TRUE(FixSessionSidecar::write(sidecar, host, registry)); });
+  s1->start();
+
+  s1->submit(InboundCommand{Deposit{1, QUOTE, quoteRaw(100), SYM}});
+  s1->flush();
+  EXPECT_EQ(countBalance(sink1.events), 1u);  // the live deposit reported once
+
+  ASSERT_TRUE(s1->checkpointNow());
+  EXPECT_GT(hookTs, 0);                                               // the hook rode the checkpoint boundary
+  s1->submit(InboundCommand{Withdraw{1, QUOTE, quoteRaw(30), SYM}});  // journal-tail record
+  s1->flush();
+  EXPECT_EQ(countBalance(sink1.events), 2u);
+  s1->stop();
+  s1.reset();
+
+  // The sidecar restores into a fresh host + registry (restart semantics are
+  // pinned end-to-end in test_venue_fix_session).
+  FixSessionHost host2;
+  SessionRegistry registry2;
+  ASSERT_TRUE(FixSessionSidecar::load(sidecar, host2, registry2));
+  {
+    auto st = host2.stateOf(7);
+    std::lock_guard<std::mutex> lk(st->m);
+    EXPECT_EQ(st->expectedIn, 42u);
+    EXPECT_TRUE(st->established);
+  }
+
+  // Recovery: snapshot RestoreBalance records AND the journal-tail Withdraw
+  // replay into the engine without a single outbound event.
+  Ledger led2;
+  HashSink sink2;
+  auto t2 = clockState(t1->load() + 1'000'000);
+  auto s2 = std::make_unique<SequencedShard<>>(cfg(), base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  s2->subscribeOutbound(&sink2);
+  s2->start();
+  EXPECT_GT(s2->recoveredCommands(), 0u);
+  EXPECT_EQ(sink2.count, 0u);  // no re-broadcast of recovered history at all
+  EXPECT_EQ(led2.available(1, QUOTE), led1.available(1, QUOTE));
+
+  // A fresh deposit after recovery reports exactly once, as live.
+  s2->submit(InboundCommand{Deposit{1, QUOTE, quoteRaw(5), SYM}});
+  s2->flush();
+  EXPECT_EQ(countBalance(sink2.events), 1u);
+  s2->stop();
+  cleanFiles(base);
+  std::remove(sidecar.c_str());
+}
+
+// Exact balances: a moment the old Deposit-total encoding could not represent
+// (negative available mid-liquidation) now snapshots and restores bit-for-bit
+// via RestoreBalance -- no generation fallback, no hash mismatch.
+TEST(VenueCheckpoint, NegativeAvailableBalanceRestoredExactly)
+{
+  const std::string path = "/tmp/flox_test_venue_checkpoint_negbal.snap";
+  std::remove(path.c_str());
+
+  venue::SymbolConfig c = cfg();
+  Ledger led;
+  MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
+  eng.setLedger(&led, VENUE_ACCT);
+  eng.submit(InboundCommand{Deposit{1, QUOTE, quoteRaw(100.0), SYM}}, 1000);
+  eng.submit(InboundCommand{Deposit{2, BASE, baseRaw(10.0), SYM}}, 2000);
+  // Account 2 keeps a live reservation (resting ask) on top of the distortion.
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100.00, 3.0, 2)}, 3000);
+  // Force the "impossible" moments directly (the liquidation path produces the
+  // same shape through funding/fees; the ledger is the state being tested):
+  // acct 1 wallet negative, acct 3 negative available with zero total.
+  led.credit(1, QUOTE, -static_cast<Amount>(quoteRaw(150.0)));  // avail = -50
+  led.credit(3, QUOTE, -static_cast<Amount>(quoteRaw(7.0)));    // avail = -7, no deposit at all
+  ASSERT_LT(led.available(1, QUOTE), 0);
+  ASSERT_GT(led.reserved(2, BASE), 0);
+
+  {
+    Journal out(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    eng.writeSnapshot(out);
+    out.flush();
+  }
+
+  Ledger led2;
+  MatchingEngine<MatchingBook> rec(c, [](const OutboundEvent&) {});
+  rec.setLedger(&led2, VENUE_ACCT);
+  for (const auto& [ts, cmd] : Journal::loadTimed(path))
+  {
+    ASSERT_TRUE(rec.applySnapshotRecord(cmd, ts));  // incl. the SnapshotEnd hash check
+  }
+  EXPECT_EQ(rec.stateHash(), eng.stateHash());
+  EXPECT_EQ(led2.available(1, QUOTE), led.available(1, QUOTE));  // exact, negative
+  EXPECT_EQ(led2.available(3, QUOTE), led.available(3, QUOTE));
+  EXPECT_EQ(led2.available(2, BASE), led.available(2, BASE));
+  EXPECT_EQ(led2.reserved(2, BASE), led.reserved(2, BASE));  // reservation split intact
+  // The restored reservation is live: cancel releases it back to available.
+  rec.submit(InboundCommand{CancelOrder{1, SYM, 2}}, 9000);
+  EXPECT_EQ(led2.reserved(2, BASE), 0);
+  EXPECT_EQ(led2.available(2, BASE), static_cast<Amount>(baseRaw(10.0)));
+  std::remove(path.c_str());
+}
+
+// Backward read compatibility: Deposit records inside a snapshot (the v1
+// balance encoding) still apply through the journaled-deposit path, and the
+// reserved side reconstitutes by re-reservation out of the deposited total.
+TEST(VenueCheckpoint, LegacyDepositSnapshotRecordsStillApply)
+{
+  const std::string path = "/tmp/flox_test_venue_checkpoint_legacy.snap";
+  std::remove(path.c_str());
+  const int64_t ts = 5000;
+
+  venue::SymbolConfig c = cfg();
+
+  // Reference pass: apply the legacy-style body to one engine to learn the
+  // state hash the crafted SnapshotEnd must carry.
+  RestoreReservation rr{};
+  rr.id = 5;
+  rr.account = 1;
+  rr.asset = QUOTE;
+  rr.side = Side::BUY;
+  rr.limitPriceRaw = px(100.0).raw();
+  rr.reservedRaw = static_cast<Amount>(quoteRaw(300.0));
+  const Deposit dep{1, QUOTE, quoteRaw(1000.0), SYM};
+
+  Ledger refLed;
+  MatchingEngine<MatchingBook> ref(c, [](const OutboundEvent&) {});
+  ref.setLedger(&refLed, VENUE_ACCT);
+  ASSERT_TRUE(ref.applySnapshotRecord(InboundCommand{dep}, ts));
+  ASSERT_TRUE(ref.applySnapshotRecord(InboundCommand{rr}, ts));
+  const uint64_t h = ref.stateHash();
+
+  {
+    Journal out(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    out.append(InboundCommand{SnapshotBegin{kSnapshotFormatVersion, ts, h, 0}}, ts);
+    out.append(InboundCommand{dep}, ts);
+    out.append(InboundCommand{rr}, ts);
+    SnapshotEnd end{};
+    end.stateHash = h;
+    end.nowNs = ts;
+    out.append(InboundCommand{end}, ts);
+    out.flush();
+  }
+
+  Ledger led2;
+  MatchingEngine<MatchingBook> rec(c, [](const OutboundEvent&) {});
+  rec.setLedger(&led2, VENUE_ACCT);
+  for (const auto& [rts, cmd] : Journal::loadTimed(path))
+  {
+    ASSERT_TRUE(rec.applySnapshotRecord(cmd, rts));  // SnapshotEnd verifies the hash
+  }
+  // The deposited TOTAL split back into available/reserved by re-reservation.
+  EXPECT_EQ(led2.available(1, QUOTE), static_cast<Amount>(quoteRaw(700.0)));
+  EXPECT_EQ(led2.reserved(1, QUOTE), static_cast<Amount>(quoteRaw(300.0)));
+  EXPECT_EQ(rec.stateHash(), h);
+  std::remove(path.c_str());
+}
+
+// MMP fill windows restore EXACTLY: a maker one fill from its qtyLimit before
+// the checkpoint is still one fill from it after recovery -- the next fill
+// trips the breach precisely as it would have without the restart.
+TEST(VenueCheckpoint, MmpWindowRestoredExactly)
+{
+  const std::string path = "/tmp/flox_test_venue_checkpoint_mmpwin.snap";
+  std::remove(path.c_str());
+
+  venue::SymbolConfig c = cfg();
+  std::vector<OutboundEvent> evA;
+  MatchingEngine<MatchingBook> a(c, [&](const OutboundEvent& e)
+                                 { evA.push_back(e); });
+  a.setMmp(1, qty(10.0), 1'000'000'000);
+
+  // Two fills, 9.0 total inside the window: one unit below the limit.
+  a.submit(InboundCommand{limit(1, Side::SELL, 100.00, 4.0, 1)}, 1000);
+  a.submit(InboundCommand{limit(2, Side::BUY, 100.00, 4.0, 2)}, 2000);
+  a.submit(InboundCommand{limit(3, Side::SELL, 100.00, 5.0, 1)}, 3000);
+  a.submit(InboundCommand{limit(4, Side::BUY, 100.00, 5.0, 2)}, 4000);
+  // A resting quote that the breach must pull after recovery.
+  a.submit(InboundCommand{limit(5, Side::SELL, 101.00, 2.0, 1)}, 5000);
+  for (const auto& e : evA)
+  {
+    ASSERT_EQ(std::get_if<MmpTriggered>(&e), nullptr);  // not breached yet
+  }
+
+  {
+    Journal out(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    a.writeSnapshot(out);
+    out.flush();
+  }
+  std::vector<OutboundEvent> evB;
+  MatchingEngine<MatchingBook> b(c, [&](const OutboundEvent& e)
+                                 { evB.push_back(e); });
+  for (const auto& [ts, cmd] : Journal::loadTimed(path))
+  {
+    ASSERT_TRUE(b.applySnapshotRecord(cmd, ts));
+  }
+  ASSERT_EQ(b.stateHash(), a.stateHash());
+
+  // Identical next fill into both: 1.0 more -> sum 10 >= limit -> breach, on
+  // the live engine AND the recovered one, at the same point.
+  const auto trigger = [](MatchingEngine<MatchingBook>& e, std::vector<OutboundEvent>& ev)
+  {
+    e.submit(InboundCommand{limit(6, Side::SELL, 100.00, 1.0, 1)}, 6000);
+    e.submit(InboundCommand{limit(7, Side::BUY, 100.00, 1.0, 2)}, 7000);
+    bool mmp = false, pulled = false;
+    for (const auto& x : ev)
+    {
+      if (const auto* m = std::get_if<MmpTriggered>(&x); m && m->accountId == 1)
+      {
+        mmp = true;
+      }
+      if (const auto* cxl = std::get_if<OrderCanceled>(&x); cxl && cxl->id == 5)
+      {
+        pulled = true;
+      }
+    }
+    return mmp && pulled;
+  };
+  EXPECT_TRUE(trigger(a, evA));
+  EXPECT_TRUE(trigger(b, evB));
+  EXPECT_EQ(b.stateHash(), a.stateHash());
+  std::remove(path.c_str());
+}
+
+// STP groups: a runtime SetStpGroup is a sequenced, journaled command; the
+// table survives a snapshot restore AND a journal-tail replay, and firm-group
+// STP keeps firing after recovery.
+TEST(VenueCheckpoint, StpGroupsJournaledSnapshottedAndRestored)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_stp.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  const auto stpCanceled = [](const std::vector<OutboundEvent>& events, OrderId id)
+  {
+    for (const auto& e : events)
+    {
+      if (const auto* x = std::get_if<OrderCanceled>(&e);
+          x && x->id == id && x->reason == CancelReason::SelfTradePrevention)
+      {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  HashSink sink1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->subscribeOutbound(&sink1);
+  s1->start();
+  s1->submit(InboundCommand{SetStpGroup{SYM, 1, 77}});
+  s1->submit(InboundCommand{SetStpGroup{SYM, 2, 77}});
+  s1->submit(InboundCommand{limit(1, Side::SELL, 100.00, 1.0, 1)});
+  NewOrder tk = limit(2, Side::BUY, 100.00, 1.0, 2);
+  tk.stp = STPMode::CancelNewest;
+  s1->submit(InboundCommand{tk});  // same firm group: canceled, never trades
+  s1->flush();
+  EXPECT_TRUE(stpCanceled(sink1.events, 2));
+  ASSERT_TRUE(s1->checkpointNow());
+  s1->submit(InboundCommand{SetStpGroup{SYM, 3, 77}});  // journal-tail mutation
+  s1->flush();
+  const uint64_t liveHash = s1->engine().stateHash();
+  s1->stop();
+  s1.reset();
+
+  HashSink sink2;
+  auto t2 = clockState(2'000'000);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->subscribeOutbound(&sink2);
+  s2->start();
+  EXPECT_GT(s2->recoveredFromSnapshotRecords(), 0u);
+  EXPECT_EQ(s2->engine().stateHash(), liveHash);  // incl. the STP-group fold
+
+  // Snapshot-carried membership (acct 2) and tail-replayed membership (acct 3)
+  // both still fire; an ungrouped account trades normally.
+  NewOrder tk2 = limit(3, Side::BUY, 100.00, 1.0, 2);
+  tk2.stp = STPMode::CancelNewest;
+  s2->submit(InboundCommand{tk2});
+  NewOrder tk3 = limit(4, Side::BUY, 100.00, 1.0, 3);
+  tk3.stp = STPMode::CancelNewest;
+  s2->submit(InboundCommand{tk3});
+  s2->flush();
+  EXPECT_TRUE(stpCanceled(sink2.events, 3));
+  EXPECT_TRUE(stpCanceled(sink2.events, 4));
+  bool traded = false;
+  NewOrder tk4 = limit(5, Side::BUY, 100.00, 1.0, 9);  // no group: crosses maker 1
+  tk4.stp = STPMode::CancelNewest;
+  s2->submit(InboundCommand{tk4});
+  s2->flush();
+  for (const auto& e : sink2.events)
+  {
+    if (const auto* t = std::get_if<venue::Trade>(&e); t && t->takerId == 5 && t->makerId == 1)
+    {
+      traded = true;
+    }
+  }
+  EXPECT_TRUE(traded);
+  s2->stop();
+  cleanFiles(base);
+}
+
+// Constructor-config guard: a snapshot restored into an engine built with
+// different structural parameters (here: another qtyScale) is rejected at
+// SnapshotBegin, and shard recovery falls back to full-history replay instead
+// of silently reinterpreting fixed-point state.
+TEST(VenueCheckpoint, ConfigHashMismatchRejectsSnapshot)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_cfghash.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  {
+    auto t1 = clockState(1'000'000);
+    auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                                 clockOf(t1));
+    s1->start();
+    s1->submit(InboundCommand{limit(1, Side::SELL, 100.00, 2.0, 1)});
+    ASSERT_TRUE(s1->checkpointNow());
+    s1->flush();
+    s1->stop();
+  }
+
+  // Engine level: SnapshotBegin refuses the foreign config outright.
+  venue::SymbolConfig other = cfg();
+  other.qtyScale = 1'000'000;  // valid scale, different from the writer's 1e8
+  {
+    const auto gens = SequencedShard<>::scanGenerations(base);
+    ASSERT_EQ(gens.snapshots.size(), 1u);
+    const auto records =
+        Journal::loadTimed(SequencedShard<>::snapshotPath(base, gens.snapshots[0]));
+    ASSERT_FALSE(records.empty());
+    MatchingEngine<MatchingBook> alien(other, [](const OutboundEvent&) {});
+    EXPECT_FALSE(alien.applySnapshotRecord(records.front().second, records.front().first));
+    MatchingEngine<MatchingBook> same(c, [](const OutboundEvent&) {});
+    EXPECT_TRUE(same.applySnapshotRecord(records.front().second, records.front().first));
+  }
+
+  // Shard level: recovery rejects the snapshot (config mismatch) and falls
+  // back to replaying the full retained history.
+  {
+    auto t2 = clockState(9'000'000);
+    auto s2 = std::make_unique<SequencedShard<>>(other, base, MatchingBook{}, Journal::Sync::Off,
+                                                 clockOf(t2));
+    s2->start();
+    EXPECT_EQ(s2->recoveredFromSnapshotRecords(), 0u);  // snapshot refused
+    EXPECT_GT(s2->recoveredCommands(), 0u);             // full-history replay ran
+    s2->stop();
+  }
+  cleanFiles(base);
+}
+
+// THE async-checkpoint crash window: the journal rotates at the clone boundary
+// while the snapshot publishes in the background, so a crash mid-serialization
+// leaves "segment ts on disk, snapshot ts absent (a torn .tmp at most)".
+// Recovery must ignore the .tmp, fall back to the previous snapshot and replay
+// BOTH tail segments after it -- reproducing the live state exactly.
+TEST(VenueCheckpoint, CrashBeforeSnapshotPublishRecoversViaPreviousGeneration)
+{
+  namespace fs = std::filesystem;
+  const std::string base = "/tmp/flox_test_venue_checkpoint_crashpub.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  Ledger led1;
+  auto t1 = clockState(1'000'000);
+  auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t1));
+  s1->engine().setLedger(&led1, VENUE_ACCT);
+  s1->start();
+  s1->submit(InboundCommand{Deposit{1, BASE, baseRaw(100), SYM}});
+  s1->submit(InboundCommand{Deposit{2, QUOTE, quoteRaw(10000), SYM}});
+  s1->submit(InboundCommand{limit(1, Side::SELL, 100.00, 2.0, 1)});
+  ASSERT_TRUE(s1->checkpointNow());                                 // generation A
+  s1->submit(InboundCommand{limit(2, Side::BUY, 100.00, 1.0, 2)});  // trades vs 1
+  ASSERT_TRUE(s1->checkpointNow());                                 // generation B
+  s1->submit(InboundCommand{limit(3, Side::BUY, 99.00, 1.0, 2)});   // tail after B
+  s1->flush();
+  EXPECT_GT(s1->lastCheckpointPauseNs(), 0);  // the async pause gauge moved
+  const uint64_t liveHash = s1->engine().stateHash();
+  s1->stop();
+  s1.reset();
+
+  const auto gens = SequencedShard<>::scanGenerations(base);
+  ASSERT_EQ(gens.snapshots.size(), 2u);
+  ASSERT_EQ(gens.segments.size(), 2u);
+  const std::string snapA = SequencedShard<>::snapshotPath(base, gens.snapshots[0]);
+  const std::string snapB = SequencedShard<>::snapshotPath(base, gens.snapshots[1]);
+
+  // Simulate the crash: snapshot B never renamed in; only a torn .tmp exists.
+  {
+    std::vector<char> bytes;
+    {
+      std::ifstream in(snapB, std::ios::binary);
+      bytes.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+    fs::remove(snapB);
+    std::ofstream tmp(snapB + ".tmp", std::ios::binary | std::ios::trunc);
+    tmp.write(bytes.data(), static_cast<std::streamsize>(bytes.size() / 2));
+  }
+
+  Ledger led2;
+  auto t2 = clockState(9'000'000);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  s2->start();
+  // Recovery went through snapshot A (the .tmp is not a generation), then
+  // replayed segment A AND segment B as the tail.
+  const size_t snapARecords = Journal::loadTimed(snapA).size();
+  const size_t segARecords =
+      Journal::loadTimed(SequencedShard<>::segmentPath(base, gens.segments[0])).size();
+  const size_t segBRecords =
+      Journal::loadTimed(SequencedShard<>::segmentPath(base, gens.segments[1])).size();
+  EXPECT_EQ(s2->recoveredFromSnapshotRecords(), snapARecords);
+  EXPECT_EQ(s2->recoveredCommands(), snapARecords + segARecords + segBRecords);
+  EXPECT_EQ(s2->engine().stateHash(), liveHash);
+  EXPECT_TRUE(ledgersEqual(led2, led1, 2));
+
+  // The revived shard checkpoints normally on top of the fallback.
+  ASSERT_TRUE(s2->checkpointNow());
+  s2->stop();
+  cleanFiles(base);
+  std::error_code ec;
+  fs::remove(snapB + ".tmp", ec);
+}

--- a/venue/tests/test_venue_conservation_fuzz.cpp
+++ b/venue/tests/test_venue_conservation_fuzz.cpp
@@ -23,6 +23,9 @@
 #include <gtest/gtest.h>
 #include <array>
 #include <cstdint>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <cstdio>
 #include <cstdlib>
@@ -217,6 +220,148 @@ void test_spot_conservation()
   CHECK(reservedLeaks == 0);
   std::printf("  200000 ops, base/quote conserved (%d breaches); reserved drained clean (%d leaks)\n",
               breaches, reservedLeaks);
+}
+
+// Last-look lifecycle under the conservation invariant: a slice of the flow is
+// lastLook makers, and holds resolve through every path -- explicit accepts,
+// explicit rejects, wrong-owner decision attempts, timeout (acceptOnTimeout
+// exercises the timeout-accept settle), and cancel-while-held during the
+// drain. Money must never be created or destroyed, and after the drain every
+// reservation (including restored held slices) must return to zero.
+void test_spot_conservation_lastlook()
+{
+  std::printf("test_spot_conservation_lastlook\n");
+  Ledger led;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    led.deposit(a, BASE, base(1000));
+    led.deposit(a, QUOTE, quote(100000));
+  }
+  const Amount initBase = base(1000) * NACCT;
+  const Amount initQuote = quote(100000) * NACCT;
+
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50);
+  c.maxPrice = px(150);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  c.lastLookWindowNs = 40;           // fuzz time = op index, so holds expire quickly
+  c.lastLookAcceptOnTimeout = true;  // timeout-accept settles like a real fill
+  std::unordered_map<OrderId, uint64_t> acctOf;
+  std::vector<std::pair<uint64_t, uint64_t>> pendingHolds;  // (heldId, makerAccount)
+  uint64_t totalHolds = 0;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   {
+                                     if (const auto* h = std::get_if<FillHeld>(&e))
+                                     {
+                                       ++totalHolds;
+                                       pendingHolds.emplace_back(h->heldId, acctOf[h->makerId]);
+                                     } });
+  flox::FeeSchedule fs;
+  fs.addTier(0.0, -1.0, 2.0);
+  eng.setFeeSchedule(fs);
+  eng.setLedger(&led, VENUE);
+
+  auto sumAsset = [&](AssetId asset)
+  {
+    Amount t = 0;
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      t += led.total(a, asset);
+    }
+    t += led.total(VENUE, asset);
+    return t;
+  };
+
+  Rng rng{0xFEEDFACE77ULL};
+  const int64_t midRaw = px(100).raw();
+  const int64_t tickRaw = px(0.01).raw();
+  int breaches = 0;
+  OrderId nextId = 1;
+  for (int i = 0; i < 100000; ++i)
+  {
+    const uint64_t r = rng.next();
+    const uint32_t kind = r % 100;
+    if (kind < 12 && !pendingHolds.empty())
+    {
+      // Resolve a random pending hold: correct owner half the time (accept or
+      // reject), a random -- usually wrong -- account otherwise (NotOrderOwner
+      // reject path, the hold stays pending until timeout).
+      const size_t pick = (r >> 16) % pendingHolds.size();
+      const auto [hid, makerAcct] = pendingHolds[pick];
+      pendingHolds.erase(pendingHolds.begin() + static_cast<ptrdiff_t>(pick));
+      const uint64_t acct = (r & 4) ? makerAcct : 1 + ((r >> 24) % NACCT);
+      eng.submit(InboundCommand{LastLookDecision{hid, SYM, (r & 8) != 0, acct}}, i);
+    }
+    else if (kind < 27 && nextId > 1)
+    {
+      eng.submit(InboundCommand{CancelOrder{1 + (rng.next() % (nextId - 1)), SYM, 0}}, i);
+    }
+    else
+    {
+      NewOrder o;
+      o.id = nextId++;
+      o.symbol = SYM;
+      o.side = (r & 1) ? Side::BUY : Side::SELL;
+      o.accountId = 1 + (r >> 8) % NACCT;
+      const int ticks = static_cast<int>((r >> 1) % 101) - 50;
+      o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
+      o.quantity = qty(1.0 + static_cast<double>((r >> 20) % 5));
+      o.type = (kind < 32) ? OrderType::MARKET : OrderType::LIMIT;
+      if (o.type == OrderType::LIMIT)
+      {
+        const uint32_t t = static_cast<uint32_t>((r >> 32) % 100);
+        if (t < 35)
+        {
+          o.lastLook = true;  // a third of the resting flow quotes with last look
+        }
+        else if (t < 45)
+        {
+          o.tif = TimeInForce::IOC;  // held IOC residual must cancel + release
+        }
+        else if (t < 52)
+        {
+          o.tif = TimeInForce::FOK;  // FOK never executes into last-look range
+        }
+      }
+      acctOf[o.id] = o.accountId;
+      eng.submit(InboundCommand{o}, i);
+    }
+    if (sumAsset(BASE) != initBase || sumAsset(QUOTE) != initQuote)
+    {
+      ++breaches;
+      if (breaches == 1)
+      {
+        std::printf("  first breach at op %d\n", i);
+      }
+    }
+  }
+  CHECK(breaches == 0);
+
+  // Drain: cancel everything (cancel-while-held resolves any hold left), then
+  // every account's reserved must be zero -- a held slice whose reservation
+  // was stripped or stranded shows up here.
+  for (OrderId id = 1; id < nextId; ++id)
+  {
+    eng.submit(InboundCommand{CancelOrder{id, SYM, 0}}, 999999);
+  }
+  CHECK(sumAsset(BASE) == initBase && sumAsset(QUOTE) == initQuote);
+  int reservedLeaks = 0;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    if (led.reserved(a, BASE) != 0 || led.reserved(a, QUOTE) != 0)
+    {
+      ++reservedLeaks;
+    }
+  }
+  CHECK(reservedLeaks == 0);
+  CHECK(totalHolds > 1000);  // coverage guard: the scenario really exercised holds
+  std::printf(
+      "  100000 ops, %llu holds (accept/reject/wrong-owner/timeout-accept/cancel-while-held), "
+      "base/quote conserved (%d breaches); reserved drained clean (%d leaks)\n",
+      static_cast<unsigned long long>(totalHolds), breaches, reservedLeaks);
 }
 
 void test_perp_conservation(bool adl)
@@ -490,6 +635,13 @@ TEST(VenueConservationFuzz, SpotValueAndReservationsConserved)
 {
   g_failures = 0;  // independent baseline: a prior scenario must not taint this one
   test_spot_conservation();
+  EXPECT_EQ(g_failures, 0);
+}
+
+TEST(VenueConservationFuzz, SpotLastLookConserved)
+{
+  g_failures = 0;  // independent baseline: a prior scenario must not taint this one
+  test_spot_conservation_lastlook();
   EXPECT_EQ(g_failures, 0);
 }
 

--- a/venue/tests/test_venue_control_plane.cpp
+++ b/venue/tests/test_venue_control_plane.cpp
@@ -133,6 +133,65 @@ TEST(ControlPlane, EngineSuite)
   CHECK(has(api.handle(R"({"method":"bogus"})"), "unknown_method"));
   CHECK(has(api.handle(R"({"method":"halt","symbol":99,"halted":true})"), "unknown_symbol"));
 
+  // Configuration mutations forward journalable commands to the sink, so they
+  // reach the WAL and replay on restart (InstrumentRegistry::apply consumes
+  // the same records). Failed mutations must NOT forward.
+  std::printf("test_control_api_command_sink\n");
+  InstrumentRegistry reg3;
+  std::vector<InboundCommand> forwarded;
+  ControlApi api2(reg3, [&](const InboundCommand& c)
+                  { forwarded.push_back(c); });
+  CHECK(has(api2.handle(R"({"method":"listInstrument","symbol":7,"tick":0.01,"minPrice":50,"maxPrice":150})"),
+            "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"setBand","symbol":7,"minPrice":90,"maxPrice":110})"),
+            "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"setTriggerRef","symbol":7,"ref":"mark"})"), "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"halt","symbol":7,"halted":true})"), "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"halt","symbol":42,"halted":true})"), "unknown_symbol"));
+  CHECK(has(api2.handle(R"({"method":"setTriggerRef","symbol":42,"ref":"mark"})"), "unknown_symbol"));
+
+  // SnapshotNow: triggers the shard-checkpoint hook. Deliberately NOT
+  // forwarded to the command sink -- a snapshot must never become a
+  // journaled, replay-visible record (verified by the sink count below).
+  CHECK(has(api2.handle(R"({"method":"snapshotNow","symbol":7})"), "unsupported"));  // no hook yet
+  SymbolId snapSym = 0;
+  api2.setSnapshotHook([&](SymbolId s)
+                       {
+                         snapSym = s;
+                         return true; });
+  CHECK(has(api2.handle(R"({"method":"snapshotNow","symbol":7})"), "\"ok\":true"));
+  CHECK(snapSym == 7);
+  CHECK(has(api2.handle(R"({"method":"snapshotNow","symbol":42})"), "unknown_symbol"));
+
+  // setStpGroup: engine state (not registry state) -- forwarded onto the
+  // sequenced stream so it journals, snapshots and replays with matching.
+  CHECK(has(api2.handle(R"({"method":"setStpGroup","symbol":7,"account":11,"group":77})"),
+            "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"setStpGroup","symbol":42,"account":11,"group":77})"),
+            "unknown_symbol"));
+
+  CHECK(forwarded.size() == 5);  // failed halt / setTriggerRef / snapshotNow forwarded nothing
+  CHECK(std::get_if<ListInstrument>(&forwarded[0]) != nullptr);
+  CHECK(std::get_if<SetBands>(&forwarded[1]) != nullptr);
+  const auto* trigCmd = std::get_if<SetTriggerRef>(&forwarded[2]);
+  CHECK(trigCmd != nullptr && trigCmd->ref == TriggerRef::Mark && trigCmd->symbol == 7);
+  const auto* haltCmd = std::get_if<AdminCmd>(&forwarded[3]);
+  CHECK(haltCmd != nullptr && haltCmd->action == AdminAction::Halt && haltCmd->symbol == 7);
+  const auto* stpCmd = std::get_if<SetStpGroup>(&forwarded[4]);
+  CHECK(stpCmd != nullptr && stpCmd->symbol == 7 && stpCmd->account == 11 && stpCmd->group == 77);
+
+  // Replaying the forwarded commands into a FRESH registry reproduces the
+  // configuration -- the stream is the configuration store.
+  InstrumentRegistry reg4;
+  for (const auto& c : forwarded)
+  {
+    CHECK(reg4.apply(c));
+  }
+  CHECK(reg4.has(7));
+  CHECK(reg4.get(7)->minPrice == px(90) && reg4.get(7)->maxPrice == px(110));
+  CHECK(reg4.get(7)->triggerRef == TriggerRef::Mark);
+  CHECK(reg4.get(7)->halted);
+
   std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
   EXPECT_EQ(g_failures, 0);
 }

--- a/venue/tests/test_venue_delivery.cpp
+++ b/venue/tests/test_venue_delivery.cpp
@@ -1,0 +1,533 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Exec-report delivery perimeter (SessionRegistry + gateways):
+ *  - an asynchronous maker report reaches the MAKER's session, not the
+ *    aggressor's (the old per-frame responder wrote into whoever's frame was
+ *    being handled);
+ *  - a rejected frame answers on the wire instead of silence;
+ *  - a slow consumer is disconnected and never stalls matching or the other
+ *    sessions;
+ *  - reconnect recovery: ResendRequest replays missed reports with their
+ *    original seqs, AccountSnapshotRequest rebuilds open state, and a
+ *    too-old fromSeq gets an explicit SnapshotRequired.
+ */
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/sbe.h"
+#include "flox-venue/sbe_order_entry_codec.h"
+#include "flox-venue/session_registry.h"
+#include "flox-venue/session_verbs.h"
+#include "flox-venue/tcp_gateway.h"
+#include "flox/util/transport.h"
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+NewOrder mk(OrderId id, Side s, double p, double q, uint64_t acct = 0)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+uint8_t tmpl(const std::vector<uint8_t>& f)
+{
+  return static_cast<uint8_t>(SbeOrderEntryCodec::templateId(f.data(), f.size()));
+}
+uint64_t rootU64(const std::vector<uint8_t>& f, size_t off)
+{
+  return sbe::getU64(f.data() + sbe::kHeaderSize + off);
+}
+
+// The shared venue: one engine whose sink routes through the registry.
+struct Venue
+{
+  GatewayCounters counters;
+  SessionRegistry registry;
+  std::mutex m;  // serializes engine access across gateway handler threads
+  MatchingEngine<MatchingBook> eng;
+
+  explicit Venue(DeliveryConfig dc = {})
+      : registry(dc, &counters), eng(cfg(), [this](const OutboundEvent& e)
+                                     { registry.route(e); })
+  {
+  }
+
+  void submit(const InboundCommand& c)
+  {
+    std::lock_guard<std::mutex> lk(m);
+    eng.submit(c);
+  }
+
+  static SessionRegistry::Encoder encoder()
+  {
+    return [](const OutboundEvent& e, uint64_t seq, int64_t, std::vector<uint8_t>& out)
+    {
+      SbeOrderEntryCodec::encode(e, out, seq);
+      return !out.empty();
+    };
+  }
+
+  std::unique_ptr<TcpGateway> gateway(uint64_t account, bool cod = false)
+  {
+    auto gw = std::make_unique<TcpGateway>(
+        [](const uint8_t* p, size_t n)
+        { return SbeOrderEntryCodec::decode(p, n); },
+        account);
+    gw->setDelivery(&registry, encoder());
+    gw->setSessionVerbs(makeSbeSessionVerbs(eng));
+    gw->setSessionConfigVerb(makeSbeSessionConfigVerb());
+    gw->setCounters(&counters);
+    gw->setCancelOnDisconnect(cod);
+    return gw;
+  }
+
+  size_t openOrders(uint64_t account)
+  {
+    std::lock_guard<std::mutex> lk(m);
+    return eng.snapshotAccount(account).openOrders.size();
+  }
+
+  TcpGateway::Handler handler()
+  {
+    return [this](const InboundCommand& c, const TcpGateway::Responder&)
+    { submit(c); };
+  }
+};
+
+struct Client
+{
+  int fd{-1};
+
+  bool connectTo(int port, int rcvbuf = 0)
+  {
+    fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (rcvbuf > 0)
+    {
+      ::setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof rcvbuf);
+    }
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = htons(static_cast<uint16_t>(port));
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) != 0)
+    {
+      return false;
+    }
+    timeval tv{2, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    return true;
+  }
+  void sendCmd(const InboundCommand& c)
+  {
+    std::vector<uint8_t> b;
+    SbeOrderEntryCodec::encode(c, b);
+    net::writeFrame(fd, b.data(), b.size());
+  }
+  void sendRaw(const std::vector<uint8_t>& b) { net::writeFrame(fd, b.data(), b.size()); }
+  bool readFrame(std::vector<uint8_t>& f) { return net::readFrame(fd, f); }
+  // Read until a frame with `wantTmpl` arrives (or timeout); returns it.
+  bool readUntil(uint8_t wantTmpl, std::vector<uint8_t>& out)
+  {
+    std::vector<uint8_t> f;
+    while (readFrame(f))
+    {
+      if (tmpl(f) == wantTmpl)
+      {
+        out = f;
+        return true;
+      }
+    }
+    return false;
+  }
+  void close()
+  {
+    if (fd >= 0)
+    {
+      ::close(fd);
+      fd = -1;
+    }
+  }
+  ~Client() { close(); }
+};
+
+// (1) The asynchronous maker exec report is delivered to the MAKER's session.
+void test_cross_session_delivery()
+{
+  std::printf("test_cross_session_delivery\n");
+  Venue v;
+  auto gwA = v.gateway(1);
+  auto gwB = v.gateway(2);
+  const int pA = gwA->start(0, v.handler());
+  const int pB = gwB->start(0, v.handler());
+  CHECK(pA > 0 && pB > 0);
+
+  Client a;
+  Client b;
+  CHECK(a.connectTo(pA) && b.connectTo(pB));
+
+  // Maker rests on session A.
+  a.sendCmd(InboundCommand{mk(1, Side::SELL, 100, 5)});
+  std::vector<uint8_t> f;
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+  CHECK(rootU64(f, 0) == 1);  // orderId
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) == 1);
+
+  // Aggressor on session B fills it.
+  b.sendCmd(InboundCommand{mk(2, Side::BUY, 100, 5)});
+  CHECK(b.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Executed), f));
+  CHECK(rootU64(f, 0) == 2);  // the taker's own report
+
+  // The maker fill arrives on session A -- an event A never asked for on this
+  // frame exchange (the old responder had no path here).
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Executed), f));
+  CHECK(rootU64(f, 0) == 1);             // maker order id
+  CHECK(f[sbe::kHeaderSize + 37] == 1);  // complete flag (5 of 5 filled)
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) > 1);
+
+  a.close();
+  b.close();
+  gwA->stop();
+  gwB->stop();
+}
+
+// (2) A rejected frame answers on the wire (sequenced OrderRejected), not
+// silence.
+void test_reject_on_wire()
+{
+  std::printf("test_reject_on_wire\n");
+  Venue v;
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  Client c;
+  CHECK(c.connectTo(port));
+  c.sendRaw({0xDE, 0xAD, 0xBE, 0xEF});  // non-decodable frame
+
+  std::vector<uint8_t> f;
+  CHECK(c.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Rejected), f));
+  CHECK(f[sbe::kHeaderSize + 12] == static_cast<uint8_t>(RejectReason::MalformedMessage));
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) == 1);
+
+  c.close();
+  gw->stop();
+}
+
+// (3) A stalled reader is disconnected by queue overflow; matching and the
+// other sessions keep running; the counter records it.
+void test_slow_consumer_disconnect()
+{
+  std::printf("test_slow_consumer_disconnect\n");
+  Venue v(DeliveryConfig{/*queueCapacity*/ 8, /*resendLogCapacity*/ 16});
+  auto gwA = v.gateway(1);
+  auto gwB = v.gateway(2);
+  const int pA = gwA->start(0, v.handler());
+  const int pB = gwB->start(0, v.handler());
+  CHECK(pA > 0 && pB > 0);
+
+  Client a;  // will stop reading
+  Client b;
+  CHECK(a.connectTo(pA, /*rcvbuf*/ 2048) && b.connectTo(pB));
+
+  // Make sure A is attached (round-trip one ack).
+  a.sendCmd(InboundCommand{mk(1, Side::SELL, 149, 1)});
+  std::vector<uint8_t> f;
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+
+  // Flood account 1 with routed events while A never reads: kernel buffers
+  // fill, the writer blocks, the bounded queue overflows -> disconnect policy.
+  for (int i = 0; i < 200000 && v.counters.slowConsumerDisconnects.load() == 0; ++i)
+  {
+    v.registry.route(
+        OutboundEvent{OrderCanceled{static_cast<OrderId>(1000 + i), SYM,
+                                    CancelReason::UserRequested, /*account*/ 1}});
+  }
+  CHECK(v.counters.slowConsumerDisconnects.load() >= 1);
+
+  // Matching keeps serving other sessions.
+  b.sendCmd(InboundCommand{mk(2, Side::BUY, 99, 1)});
+  CHECK(b.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+
+  a.close();
+  b.close();
+  gwA->stop();
+  gwB->stop();
+}
+
+// (4) Reconnect recovery: a fill that happened while the session was offline
+// is served by ResendRequest with its original seq; AccountSnapshotRequest
+// rebuilds the open-order state; a too-old fromSeq answers SnapshotRequired.
+void test_resend_and_snapshot()
+{
+  std::printf("test_resend_and_snapshot\n");
+  Venue v;
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  uint64_t seenSeq = 0;
+  {
+    Client a;
+    CHECK(a.connectTo(port));
+    a.sendCmd(InboundCommand{mk(1, Side::SELL, 100, 5)});
+    std::vector<uint8_t> f;
+    CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+    seenSeq = SbeOrderEntryCodec::seqOf(f.data(), f.size());
+    CHECK(seenSeq == 1);
+    a.close();  // disconnect with the order resting
+  }
+
+  // A foreign aggressor fills the resting maker while account 1 is offline;
+  // the reports are sequenced into account 1's log.
+  v.submit(InboundCommand{mk(2, Side::BUY, 100, 5, /*acct*/ 2)});
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (v.registry.lastSeq(1) <= seenSeq && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  CHECK(v.registry.lastSeq(1) > seenSeq);
+
+  // Reconnect + ResendRequest(fromSeq = seen + 1): the missed Trade and the
+  // maker's Executed replay with their original seqs.
+  Client a2;
+  CHECK(a2.connectTo(port));
+  std::vector<uint8_t> req;
+  SbeOrderEntryCodec::encodeResendRequest(seenSeq + 1, req);
+  a2.sendRaw(req);
+  std::vector<uint8_t> f;
+  CHECK(a2.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Executed), f));
+  CHECK(rootU64(f, 0) == 1);  // the missed maker fill
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) > seenSeq);
+  CHECK(v.counters.resendServed.load() >= 1);
+
+  // Place a new resting order, then snapshot: it must show exactly that order
+  // and a flat position, terminated by SnapshotEnd.
+  a2.sendCmd(InboundCommand{mk(3, Side::SELL, 101, 2)});
+  CHECK(a2.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+  const uint64_t seqBeforeSnap = SbeOrderEntryCodec::seqOf(f.data(), f.size());
+  SbeOrderEntryCodec::encodeSnapshotRequest(req);
+  a2.sendRaw(req);
+  CHECK(a2.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+  CHECK(rootU64(f, 0) == 3);                                  // the open order, replayed as a snapshot record
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) == 0);  // snapshot frames are unsequenced
+  CHECK(a2.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::SnapshotEnd), f));
+  const auto se = SbeOrderEntryCodec::decodeSnapshotEnd(f.data(), f.size());
+  CHECK(se.has_value());
+  CHECK(se->account == 1 && se->openOrders == 1 && se->positionQtyRaw == 0);
+  // SnapshotEnd carries the stream's lastSeq: gap detection resumes from the
+  // exact point, and the next sequenced event continues the numbering (the
+  // snapshot itself consumed no seqs and entered no resend log).
+  CHECK(se->lastSeq == seqBeforeSnap);
+  CHECK(se->lastSeq == v.registry.lastSeq(1));
+  a2.sendCmd(InboundCommand{mk(4, Side::SELL, 102, 1)});
+  CHECK(a2.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) == se->lastSeq + 1);
+  a2.close();
+  gw->stop();
+}
+
+// (5) A fromSeq older than the retained log answers SnapshotRequired -- an
+// explicit signal, never a silent hole.
+void test_resend_too_old()
+{
+  std::printf("test_resend_too_old\n");
+  Venue v(DeliveryConfig{/*queueCapacity*/ 64, /*resendLogCapacity*/ 1});
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  Client a;
+  CHECK(a.connectTo(port));
+  a.sendCmd(InboundCommand{mk(1, Side::SELL, 100, 1)});
+  std::vector<uint8_t> f;
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+  a.sendCmd(InboundCommand{mk(2, Side::SELL, 101, 1)});
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+
+  std::vector<uint8_t> req;
+  SbeOrderEntryCodec::encodeResendRequest(1, req);  // seq 1 was trimmed (log holds 1 frame)
+  a.sendRaw(req);
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::SnapshotRequired), f));
+  CHECK(rootU64(f, 0) == v.registry.lastSeq(1));  // lastSeq echoed for re-sync
+
+  a.close();
+  gw->stop();
+}
+
+// (6) SetSessionConfig negotiates cancel-on-disconnect on the wire: enabling
+// it makes a disconnect sweep the resting order; disabling it overrides a
+// gateway-default ON. Fire-and-forget -- no reply frame, the sweep (or its
+// absence) is the observable effect.
+void test_session_config_cod()
+{
+  std::printf("test_session_config_cod\n");
+  Venue v;
+
+  // Gateway default OFF, SetSessionConfig{cod=1}: disconnect sweeps.
+  {
+    auto gw = v.gateway(1, /*cod*/ false);
+    const int port = gw->start(0, v.handler());
+    CHECK(port > 0);
+    Client a;
+    CHECK(a.connectTo(port));
+    std::vector<uint8_t> req;
+    SbeOrderEntryCodec::encodeSetSessionConfig(true, req);
+    a.sendRaw(req);
+    a.sendCmd(InboundCommand{mk(1, Side::SELL, 100, 1)});
+    std::vector<uint8_t> f;
+    CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+    CHECK(v.openOrders(1) == 1);
+    a.close();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (v.openOrders(1) != 0 && std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    CHECK(v.openOrders(1) == 0);  // negotiated COD swept the order
+    gw->stop();
+  }
+
+  // Gateway default ON, SetSessionConfig{cod=0}: the resting order survives.
+  {
+    auto gw = v.gateway(2, /*cod*/ true);
+    const int port = gw->start(0, v.handler());
+    CHECK(port > 0);
+    Client a;
+    CHECK(a.connectTo(port));
+    std::vector<uint8_t> req;
+    SbeOrderEntryCodec::encodeSetSessionConfig(false, req);
+    a.sendRaw(req);
+    a.sendCmd(InboundCommand{mk(2, Side::SELL, 100, 1)});
+    std::vector<uint8_t> f;
+    CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+    CHECK(v.openOrders(2) == 1);
+    a.close();
+    gw->stop();                   // joins the connection thread: any COD flush has run
+    CHECK(v.openOrders(2) == 1);  // negotiated OFF: nothing swept
+  }
+}
+
+// (7) BalanceUpdate reaches the owner over the wire: a deposit reports the
+// credited balance, a covered withdraw the debited one, and an uncovered
+// withdraw an explicit WithdrawRejected with unchanged balances -- all
+// sequenced on the exec-report stream.
+void test_balance_update_on_wire()
+{
+  std::printf("test_balance_update_on_wire\n");
+  constexpr AssetId QUOTE = 1;
+  Venue v;
+  Ledger led;
+  {
+    std::lock_guard<std::mutex> lk(v.m);
+    v.eng.setLedger(&led, /*venueAccount*/ 900);
+  }
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  Client a;
+  CHECK(a.connectTo(port));
+  // Round-trip one frame so the session is attached before the deposit fires
+  // (the buy has no funds yet -> a sequenced InsufficientFunds reject, seq 1).
+  a.sendCmd(InboundCommand{mk(1, Side::BUY, 100, 1)});
+  std::vector<uint8_t> f;
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Rejected), f));
+
+  v.submit(InboundCommand{Deposit{1, QUOTE, 5'000, SYM}});
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::BalanceUpdate), f));
+  auto bu = SbeOrderEntryCodec::decodeBalanceUpdate(f.data(), f.size());
+  CHECK(bu.has_value());
+  CHECK(bu->account == 1 && bu->asset == QUOTE);
+  CHECK(bu->availableRaw == 5'000 && bu->reservedRaw == 0);
+  CHECK(bu->reason == BalanceReason::Deposit);
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) == 2);  // sequenced stream
+
+  // Covered withdraw: balances shrink, reason Withdraw.
+  v.submit(InboundCommand{Withdraw{1, QUOTE, 2'000, SYM}});
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::BalanceUpdate), f));
+  bu = SbeOrderEntryCodec::decodeBalanceUpdate(f.data(), f.size());
+  CHECK(bu.has_value());
+  CHECK(bu->availableRaw == 3'000 && bu->reason == BalanceReason::Withdraw);
+
+  // Uncovered withdraw: nothing moves, the client is told explicitly.
+  v.submit(InboundCommand{Withdraw{1, QUOTE, 1'000'000, SYM}});
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::BalanceUpdate), f));
+  bu = SbeOrderEntryCodec::decodeBalanceUpdate(f.data(), f.size());
+  CHECK(bu.has_value());
+  CHECK(bu->availableRaw == 3'000 && bu->reason == BalanceReason::WithdrawRejected);
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) == 4);
+
+  a.close();
+  gw->stop();
+}
+
+}  // namespace
+
+TEST(Delivery, EngineSuite)
+{
+  test_cross_session_delivery();
+  test_reject_on_wire();
+  test_slow_consumer_disconnect();
+  test_resend_and_snapshot();
+  test_resend_too_old();
+  test_session_config_cod();
+  test_balance_update_on_wire();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_engine.cpp
+++ b/venue/tests/test_venue_engine.cpp
@@ -108,7 +108,11 @@ TEST(VenueEngine, CancelReleasesReservation)
 TEST(VenueEngine, JournalReplayIsDeterministic)
 {
   const std::string path = "/tmp/flox_venue_journal_test.bin";
+  // Deposits are commands in the stream, not out-of-band Ledger calls: the
+  // journal alone must rebuild balances from an EMPTY ledger.
   std::vector<std::pair<int64_t, InboundCommand>> cmds{
+      {1, InboundCommand{Deposit{1, BASE, static_cast<int64_t>(base(10)), SYM}}},
+      {2, InboundCommand{Deposit{2, QUOTE, static_cast<int64_t>(quote(10000)), SYM}}},
       {10, InboundCommand{limitOrder(1, Side::SELL, 100, 5, 1)}},
       {20, InboundCommand{limitOrder(2, Side::BUY, 100, 3, 2)}},
       {30, InboundCommand{CancelOrder{1, SYM, 1}}},
@@ -116,8 +120,6 @@ TEST(VenueEngine, JournalReplayIsDeterministic)
 
   auto run = [&](Ledger& led, const std::vector<std::pair<int64_t, InboundCommand>>& in)
   {
-    led.deposit(1, BASE, base(10));
-    led.deposit(2, QUOTE, quote(10000));
     uint64_t h = 1469598103934665603ULL;
     MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
                                      { h = hashEvent(h, e); });
@@ -141,14 +143,18 @@ TEST(VenueEngine, JournalReplayIsDeterministic)
   }
   const uint64_t liveHash = run(liveLed, cmds);
 
-  // Recovery run from the journal.
+  // Recovery run from the journal into an EMPTY ledger: the replayed deposits
+  // reproduce the balances without any manual seeding.
   const auto replayed = Journal::loadTimed(path);
   ASSERT_EQ(replayed.size(), cmds.size());
   Ledger recLed;
+  EXPECT_EQ(i64(recLed.available(1, BASE)), 0);  // nothing seeded
   const uint64_t recHash = run(recLed, replayed);
 
   EXPECT_EQ(recHash, liveHash);  // identical event stream
   EXPECT_EQ(i64(recLed.available(2, BASE)), i64(liveLed.available(2, BASE)));
   EXPECT_EQ(i64(recLed.available(1, QUOTE)), i64(liveLed.available(1, QUOTE)));
+  EXPECT_EQ(i64(recLed.available(2, BASE)), i64(base(3)));      // buyer's fill, from replay alone
+  EXPECT_EQ(i64(recLed.available(1, QUOTE)), i64(quote(300)));  // seller's proceeds
   std::remove(path.c_str());
 }

--- a/venue/tests/test_venue_fix_session.cpp
+++ b/venue/tests/test_venue_fix_session.cpp
@@ -1,0 +1,919 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * FIX session-layer recovery (fix_session.h + SessionRegistry event log),
+ * driven by a scripted counterparty over TCP:
+ *  - Logon with ResetSeqNumFlag, a trading cycle, Heartbeat exchange, clean
+ *    Logout;
+ *  - our resend: a fill delivered while the client was offline replays on
+ *    ResendRequest with PossDupFlag + OrigSendingTime and its ORIGINAL seq,
+ *    admin seqs (Heartbeat, Logon reply) collapse into SequenceReset-GapFill;
+ *  - their ResendRequest older than the retained log gap-fills up to the
+ *    first available seq and replays the rest;
+ *  - our inbound gap: the venue sends its own ResendRequest, drops messages
+ *    above the hole, and applies them exactly once after the PossDup replay
+ *    closes it;
+ *  - TestRequest timeout disconnects and cancel-on-disconnect sweeps the
+ *    resting order;
+ *  - venue restart: a Logon without 141=Y against lost session state answers
+ *    Logout with a reason; 141=Y starts a fresh sequence space;
+ *  - venue restart WITH the session sidecar (FixSessionSidecar): the sequence
+ *    counters survive, a Logon without 141=Y continues the old space, trading
+ *    continues, and a resend into the pre-restart range answers GapFill;
+ *  - unknown MsgType answers a session Reject (35=3) instead of silence;
+ *  - Logon tag 20003 negotiates cancel-on-disconnect on the wire;
+ *  - the same session layer runs over WebSocket (one FIX message per Text
+ *    frame; FIX heartbeats replace the WS Ping probe).
+ */
+#include "flox-venue/fix_codec.h"
+#include "flox-venue/fix_session.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/session_registry.h"
+#include "flox-venue/tcp_gateway.h"
+#include "flox-venue/ws_gateway.h"
+#include "flox/util/transport.h"
+#include "flox/util/websocket.h"
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+NewOrder mk(OrderId id, Side s, double p, double q, uint64_t acct = 0)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// The venue under test: engine sink -> registry, one FIX gateway per account.
+struct Venue
+{
+  GatewayCounters counters;
+  SessionRegistry registry;
+  std::mutex m;  // serializes engine access across gateway handler threads
+  MatchingEngine<MatchingBook> eng;
+  FixSessionHost fixHost;
+
+  explicit Venue(DeliveryConfig dc = {})
+      : registry(dc, &counters),
+        eng(cfg(), [this](const OutboundEvent& e)
+            { registry.route(e); }),
+        fixHost(fixCfg())
+  {
+  }
+
+  static FixSessionConfig fixCfg()
+  {
+    FixSessionConfig c;
+    c.senderCompId = "VENUE";
+    c.targetCompId = "CLIENT";
+    return c;
+  }
+
+  static SessionRegistry::Encoder encoder(const FixSessionConfig& fc)
+  {
+    return [fc](const OutboundEvent& e, uint64_t seq, int64_t tsNs, std::vector<uint8_t>& out)
+    {
+      const std::string msg = FixCodec::encode(e, seq, fc.senderCompId, fc.targetCompId,
+                                               FixSession::sendingTime(tsNs));
+      if (msg.empty())
+      {
+        return false;
+      }
+      out.assign(msg.begin(), msg.end());
+      return true;
+    };
+  }
+
+  std::unique_ptr<TcpGateway> gateway(uint64_t account, bool cod = false)
+  {
+    auto gw = std::make_unique<TcpGateway>(
+        [](const uint8_t* p, size_t n)
+        { return FixCodec::decode(std::string(reinterpret_cast<const char*>(p), n)); },
+        account);
+    gw->setDelivery(&registry, encoder(fixHost.config()));
+    gw->setFixSession(&fixHost);
+    gw->setCounters(&counters);
+    gw->setCancelOnDisconnect(cod);
+    return gw;
+  }
+
+  std::unique_ptr<WsGateway> wsGateway(uint64_t account, bool cod = false)
+  {
+    auto gw = std::make_unique<WsGateway>(
+        [](const uint8_t* p, size_t n)
+        { return FixCodec::decode(std::string(reinterpret_cast<const char*>(p), n)); },
+        account);
+    gw->setDelivery(&registry, encoder(fixHost.config()));
+    gw->setFixSession(&fixHost);
+    gw->setCounters(&counters);
+    gw->setCancelOnDisconnect(cod);
+    return gw;
+  }
+
+  TcpGateway::Handler handler()
+  {
+    return [this](const InboundCommand& c, const TcpGateway::Responder&)
+    { submit(c); };
+  }
+
+  void submit(const InboundCommand& c)
+  {
+    std::lock_guard<std::mutex> lk(m);
+    eng.submit(c);
+  }
+
+  size_t openOrders(uint64_t account)
+  {
+    std::lock_guard<std::mutex> lk(m);
+    return eng.snapshotAccount(account).openOrders.size();
+  }
+};
+
+using Fields = std::unordered_map<int, std::string>;
+
+// Scripted FIX counterparty: full-header messages over the gateway's
+// length-prefixed transport framing, one FIX message per frame.
+struct FixClient
+{
+  int fd{-1};
+  uint64_t seq{1};
+
+  bool connectTo(int port, int rcvTimeoutSec = 4)
+  {
+    fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = htons(static_cast<uint16_t>(port));
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) != 0)
+    {
+      return false;
+    }
+    timeval tv{rcvTimeoutSec, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    return true;
+  }
+
+  void send(const std::string& m)
+  {
+    net::writeFrame(fd, reinterpret_cast<const uint8_t*>(m.data()), m.size());
+  }
+
+  // Admin message; seqOverride 0 = consume the next own seq.
+  void admin(const std::string& type, const std::vector<std::pair<int, std::string>>& fields = {},
+             uint64_t seqOverride = 0, bool possDup = false)
+  {
+    const uint64_t s = seqOverride != 0 ? seqOverride : seq++;
+    send(FixCodec::encodeAdmin(type, s, "CLIENT", "VENUE",
+                               FixSession::sendingTime(wallClockNs()), fields, possDup));
+  }
+
+  void order(uint64_t id, const char* side, const char* price, const char* quantity,
+             uint64_t seqOverride = 0, bool possDup = false)
+  {
+    const uint64_t s = seqOverride != 0 ? seqOverride : seq++;
+    std::string b;
+    auto add = [&](int t, const std::string& v)
+    { b += std::to_string(t) + "=" + v + std::string(1, FixCodec::SOH); };
+    add(35, "D");
+    add(34, std::to_string(s));
+    add(49, "CLIENT");
+    add(56, "VENUE");
+    add(52, FixSession::sendingTime(wallClockNs()));
+    if (possDup)
+    {
+      add(43, "Y");
+    }
+    add(11, std::to_string(id));
+    add(55, "1");
+    add(54, side);
+    add(38, quantity);
+    add(44, price);
+    add(40, "2");
+    send(FixCodec::frame(b));
+  }
+
+  bool read(Fields& f)
+  {
+    std::vector<uint8_t> frame;
+    if (!net::readFrame(fd, frame))
+    {
+      return false;
+    }
+    f = FixCodec::parseFields(std::string(frame.begin(), frame.end()));
+    return true;
+  }
+
+  // Read until a message of `type` arrives (or timeout / EOF).
+  bool readType(const std::string& type, Fields& f)
+  {
+    while (read(f))
+    {
+      if (f.count(35) != 0 && f[35] == type)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void close()
+  {
+    if (fd >= 0)
+    {
+      ::close(fd);
+      fd = -1;
+    }
+  }
+  ~FixClient() { close(); }
+};
+
+uint64_t u64f(Fields& f, int tag)
+{
+  return f.count(tag) != 0 ? std::strtoull(f[tag].c_str(), nullptr, 10) : 0;
+}
+
+// (1) Logon 141=Y, trading cycle, Heartbeat both ways, clean Logout.
+void test_logon_trade_heartbeat()
+{
+  std::printf("test_logon_trade_heartbeat\n");
+  Venue v;
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.admin("A", {{108, "1"}, {141, "Y"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+  CHECK(u64f(f, 34) == 1);   // fresh sequence space
+  CHECK(f[141] == "Y");      // reset confirmed
+  CHECK(u64f(f, 108) == 1);  // HeartBtInt adopted
+  CHECK(f.count(52) != 0);
+
+  c.order(1, "2", "100", "5");
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 34) == 2 && f[150] == "0" && u64f(f, 37) == 1);
+
+  // Idle past HeartBtInt: the venue heartbeats on its own timer.
+  CHECK(c.readType("0", f));
+  CHECK(u64f(f, 34) >= 3);
+
+  // Answer with our own Heartbeat (keeps the venue's liveness happy), then a
+  // clean Logout: the venue confirms with its own 35=5 and closes.
+  c.admin("0");
+  c.admin("5");
+  CHECK(c.readType("5", f));
+  CHECK(!c.read(f));  // venue closed the connection after the Logout exchange
+
+  c.close();
+  gw->stop();
+}
+
+// (2) Our resend: the client misses a fill while offline; after a reconnect
+// Logon WITHOUT 141 at the expected inbound seq, its ResendRequest gets the
+// fill as a PossDup replay (43=Y, 122 set, ORIGINAL 34) and GapFills over the
+// admin seqs (Heartbeat echo, Logon reply).
+void test_our_resend_possdup_and_gapfill()
+{
+  std::printf("test_our_resend_possdup_and_gapfill\n");
+  Venue v;
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  {
+    FixClient c;
+    CHECK(c.connectTo(port));
+    c.admin("A", {{108, "30"}});  // fresh session, no reset needed (34=1)
+    Fields f;
+    CHECK(c.readType("A", f));
+    CHECK(u64f(f, 34) == 1);
+
+    c.order(1, "2", "100", "5");  // maker rests
+    CHECK(c.readType("8", f));
+    CHECK(u64f(f, 34) == 2);
+
+    c.admin("1", {{112, "ping"}});  // venue Heartbeat echo consumes seq 3 (admin hole)
+    CHECK(c.readType("0", f));
+    CHECK(u64f(f, 34) == 3 && f[112] == "ping");
+    c.close();  // disconnect with the order resting; client has sent seqs 1..3
+  }
+
+  // A foreign aggressor fills the resting maker while account 1 is offline:
+  // the Executed report is sequenced (seq 4) into the event log.
+  v.submit(InboundCommand{mk(2, Side::BUY, 100, 5, /*acct*/ 2)});
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (v.registry.lastSeq(1) < 4 && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  CHECK(v.registry.lastSeq(1) == 4);
+
+  // Reconnect without 141 at the expected inbound seq (4). The Logon reply
+  // carries seq 5 -- the client sees the gap and requests 3..infinity.
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.seq = 4;
+  c.admin("A", {{108, "30"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+  CHECK(u64f(f, 34) == 5);
+
+  c.admin("2", {{7, "3"}, {16, "0"}});
+  // Strict replay order: GapFill over the Heartbeat (3 -> 4), the PossDup
+  // fill at its ORIGINAL seq 4, GapFill over the Logon reply (5 -> 6).
+  CHECK(c.read(f));
+  CHECK(f[35] == "4" && u64f(f, 34) == 3 && f[123] == "Y" && u64f(f, 36) == 4 && f[43] == "Y");
+  CHECK(c.read(f));
+  CHECK(f[35] == "8" && u64f(f, 34) == 4);
+  CHECK(f[43] == "Y");       // PossDupFlag
+  CHECK(f.count(122) != 0);  // OrigSendingTime from the first transmission
+  CHECK(f[150] == "F");      // ExecType Trade
+  CHECK(f[39] == "2");       // filled
+  CHECK(u64f(f, 37) == 1 && f[32] == "5");
+  CHECK(c.read(f));
+  CHECK(f[35] == "4" && u64f(f, 34) == 5 && u64f(f, 36) == 6);
+  CHECK(v.counters.resendServed.load() == 1);  // FIX resend bumps the shared counter
+
+  c.close();
+  gw->stop();
+}
+
+// (3) Their ResendRequest older than the retained log: GapFill up to the
+// first available seq, then the honest replay of what is retained.
+void test_their_resend_older_than_log()
+{
+  std::printf("test_their_resend_older_than_log\n");
+  Venue v(DeliveryConfig{/*queueCapacity*/ 64, /*resendLogCapacity*/ 1});
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.admin("A", {{108, "30"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+
+  c.order(1, "2", "100", "1");  // Accepted seq 2 -- trimmed (log holds 1 event)
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 34) == 2);
+  c.order(2, "2", "101", "1");  // Accepted seq 3 -- retained
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 34) == 3);
+
+  c.admin("2", {{7, "2"}, {16, "0"}});
+  CHECK(c.read(f));
+  CHECK(f[35] == "4" && u64f(f, 34) == 2 && f[123] == "Y" && u64f(f, 36) == 3);  // trimmed part
+  CHECK(c.read(f));
+  CHECK(f[35] == "8" && u64f(f, 34) == 3 && f[43] == "Y" && u64f(f, 37) == 2);
+
+  c.close();
+  gw->stop();
+}
+
+// (4) Our inbound gap: the venue sends its own 35=2, DROPS messages above the
+// hole, and applies them exactly once after the PossDup replay closes it.
+void test_inbound_gap_resend_and_recover()
+{
+  std::printf("test_inbound_gap_resend_and_recover\n");
+  Venue v;
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.admin("A", {{108, "30"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+
+  // Seq 2 "gets lost": the client jumps to 3. Both orders above the hole are
+  // dropped; the venue requests a resend from 2.
+  c.order(10, "2", "100", "1", /*seq*/ 3);
+  c.order(11, "2", "101", "1", /*seq*/ 4);
+  CHECK(c.readType("2", f));
+  CHECK(u64f(f, 7) == 2 && u64f(f, 16) == 0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  CHECK(v.openOrders(1) == 0);  // nothing above the hole was applied
+
+  // Close the hole: the "lost" seq 2 was a Heartbeat, then replay both orders
+  // with PossDup. Each applies exactly once, in order.
+  c.admin("0", {}, /*seq*/ 2);
+  c.order(10, "2", "100", "1", /*seq*/ 3, /*possDup*/ true);
+  c.order(11, "2", "101", "1", /*seq*/ 4, /*possDup*/ true);
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 37) == 10 && f[150] == "0");
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 37) == 11 && f[150] == "0");
+  CHECK(v.openOrders(1) == 2);
+
+  // A PossDup replay of an already-seen seq is silently dropped.
+  c.order(10, "2", "100", "1", /*seq*/ 3, /*possDup*/ true);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  CHECK(v.openOrders(1) == 2);
+
+  c.close();
+  gw->stop();
+}
+
+// (5) Liveness: no inbound traffic -> Heartbeat, then TestRequest, then
+// disconnect; cancel-on-disconnect sweeps the resting order.
+void test_testrequest_timeout_cod()
+{
+  std::printf("test_testrequest_timeout_cod\n");
+  Venue v;
+  auto gw = v.gateway(1, /*cod*/ true);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  FixClient c;
+  CHECK(c.connectTo(port, /*rcvTimeoutSec*/ 4));
+  c.admin("A", {{108, "1"}, {141, "Y"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+  c.order(20, "2", "100", "1");
+  CHECK(c.readType("8", f));
+  CHECK(v.openOrders(1) == 1);
+
+  // Go silent. Expected: venue Heartbeat at ~1s, TestRequest at ~1.2s, and a
+  // disconnect ~1.2 intervals later with no answer.
+  bool sawHeartbeat = false;
+  bool sawTestRequest = false;
+  while (c.read(f))
+  {
+    sawHeartbeat = sawHeartbeat || f[35] == "0";
+    sawTestRequest = sawTestRequest || f[35] == "1";
+  }
+  CHECK(sawHeartbeat);
+  CHECK(sawTestRequest);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (v.openOrders(1) != 0 && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  CHECK(v.openOrders(1) == 0);  // COD swept the resting order
+  CHECK(v.counters.idleDisconnects.load() >= 1);
+
+  c.close();
+  gw->stop();
+}
+
+// (6) Venue restart: session state is in-memory, so a Logon that continues an
+// old sequence space without 141=Y is answered with a Logout naming the
+// reason; a Logon with 141=Y starts clean.
+void test_restart_requires_reset()
+{
+  std::printf("test_restart_requires_reset\n");
+  Venue v;  // "restarted": no session has ever attached here
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  {
+    FixClient c;
+    CHECK(c.connectTo(port));
+    c.admin("A", {{108, "30"}}, /*seq*/ 7);  // stale pre-restart sequence space
+    Fields f;
+    CHECK(c.readType("5", f));
+    CHECK(f[58].find("141=Y") != std::string::npos);
+    CHECK(!c.read(f));  // disconnected
+  }
+
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.admin("A", {{108, "30"}, {141, "Y"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+  CHECK(u64f(f, 34) == 1 && f[141] == "Y");
+  c.order(30, "2", "100", "1");
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 37) == 30 && u64f(f, 34) == 2);
+
+  c.close();
+  gw->stop();
+}
+
+// (7) Venue restart WITH the session sidecar: seq counters survive, a Logon
+// without 141=Y at the correct 34 continues the old sequence space, trading
+// continues, and a resend into the pre-restart range answers GapFill (the
+// event log is deliberately not persisted).
+void test_restart_with_sidecar()
+{
+  std::printf("test_restart_with_sidecar\n");
+  const std::string sidecar = "/tmp/flox_test_fix_sidecar.fixsessions";
+  std::remove(sidecar.c_str());
+
+  auto v1 = std::make_unique<Venue>();
+  {
+    auto gw = v1->gateway(1);
+    const int port = gw->start(0, v1->handler());
+    CHECK(port > 0);
+
+    FixClient c;
+    CHECK(c.connectTo(port));
+    c.admin("A", {{108, "30"}});  // fresh session: seq 1, no reset needed
+    Fields f;
+    CHECK(c.readType("A", f));
+    CHECK(u64f(f, 34) == 1);
+    c.order(1, "2", "100", "1");
+    CHECK(c.readType("8", f));
+    CHECK(u64f(f, 34) == 2);  // client has sent 1..2, venue has sent 1..2
+    c.close();
+    gw->stop();
+  }
+  // The checkpoint boundary: sidecar written with the journal's discipline.
+  CHECK(FixSessionSidecar::write(sidecar, v1->fixHost, v1->registry));
+  v1.reset();  // the venue process dies
+
+  // "Restart": a fresh host + registry rebuilt from the sidecar.
+  Venue v2;
+  CHECK(FixSessionSidecar::load(sidecar, v2.fixHost, v2.registry));
+  auto gw = v2.gateway(1);
+  const int port = gw->start(0, v2.handler());
+  CHECK(port > 0);
+
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.seq = 3;                    // continuing the pre-restart sequence space
+  c.admin("A", {{108, "30"}});  // NO 141=Y -- works against restored state
+  Fields f;
+  CHECK(c.readType("A", f));
+  CHECK(u64f(f, 34) == 3);   // outbound seq continues (pre-restart lastSeq 2)
+  CHECK(f.count(141) == 0);  // no forced reset
+
+  c.order(2, "2", "101", "1");  // trading continues in the same space
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 37) == 2 && u64f(f, 34) == 4);
+
+  // Their 35=2 into the pre-restart range: the log did not survive, so the
+  // whole range collapses into SequenceReset-GapFill -- an explicit hole,
+  // never a silent one or a replay of invented history.
+  c.admin("2", {{7, "1"}, {16, "2"}});
+  CHECK(c.readType("4", f));
+  CHECK(u64f(f, 34) == 1 && f[123] == "Y" && u64f(f, 36) == 3 && f[43] == "Y");
+  CHECK(v2.counters.resendServed.load() >= 1);
+
+  c.close();
+  gw->stop();
+  std::remove(sidecar.c_str());
+}
+
+// (8) Unknown MsgType: consumed in sequence and answered with a session
+// Reject (35=3, 45=RefSeqNum, 372=RefMsgType); the session stays alive and
+// application flow continues.
+void test_session_reject_unknown_type()
+{
+  std::printf("test_session_reject_unknown_type\n");
+  Venue v;
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.admin("A", {{108, "30"}, {141, "Y"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+
+  c.admin("B", {{58, "hello"}});  // News: not in the supported set
+  CHECK(c.readType("3", f));
+  CHECK(u64f(f, 45) == 2);  // RefSeqNum of the offending message
+  CHECK(f[372] == "B");     // RefMsgType
+  CHECK(f.count(58) != 0);
+
+  c.order(40, "2", "100", "1");  // the session survived the reject
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 37) == 40 && f[150] == "0");
+
+  c.close();
+  gw->stop();
+}
+
+// (9) COD negotiation on the wire: Logon tag 20003 overrides the gateway
+// default in both directions.
+void test_cod_negotiation()
+{
+  std::printf("test_cod_negotiation\n");
+  Venue v;
+
+  // Gateway default OFF, Logon 20003=Y: disconnect sweeps the resting order.
+  {
+    auto gw = v.gateway(1, /*cod*/ false);
+    const int port = gw->start(0, v.handler());
+    CHECK(port > 0);
+    FixClient c;
+    CHECK(c.connectTo(port));
+    c.admin("A", {{108, "30"}, {141, "Y"}, {20003, "Y"}});
+    Fields f;
+    CHECK(c.readType("A", f));
+    c.order(50, "2", "100", "1");
+    CHECK(c.readType("8", f));
+    CHECK(v.openOrders(1) == 1);
+    c.close();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (v.openOrders(1) != 0 && std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    CHECK(v.openOrders(1) == 0);  // negotiated COD swept the order
+    gw->stop();
+  }
+
+  // Gateway default ON, Logon 20003=N: the resting order survives.
+  {
+    auto gw = v.gateway(2, /*cod*/ true);
+    const int port = gw->start(0, v.handler());
+    CHECK(port > 0);
+    FixClient c;
+    CHECK(c.connectTo(port));
+    c.admin("A", {{108, "30"}, {141, "Y"}, {20003, "N"}});
+    Fields f;
+    CHECK(c.readType("A", f));
+    c.order(51, "2", "100", "1");
+    CHECK(c.readType("8", f));
+    CHECK(v.openOrders(2) == 1);
+    c.close();
+    gw->stop();                   // joins the connection thread: any COD flush has run
+    CHECK(v.openOrders(2) == 1);  // negotiated OFF: nothing swept
+  }
+}
+
+// Scripted FIX-over-WebSocket counterparty: one FIX message per masked Text
+// frame; server frames parse through the shared ws:: helpers.
+struct WsFixClient
+{
+  int fd{-1};
+  uint64_t seq{1};
+  std::vector<uint8_t> buf;
+
+  bool connectTo(int port, int rcvTimeoutSec = 4)
+  {
+    fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = htons(static_cast<uint16_t>(port));
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) != 0)
+    {
+      return false;
+    }
+    timeval tv{rcvTimeoutSec, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    const std::string hs =
+        "GET /fix HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    if (::write(fd, hs.data(), hs.size()) != static_cast<ssize_t>(hs.size()))
+    {
+      return false;
+    }
+    std::string resp;
+    uint8_t tb[2048];
+    while (resp.find("\r\n\r\n") == std::string::npos)
+    {
+      const ssize_t r = ::read(fd, tb, sizeof tb);
+      if (r <= 0)
+      {
+        return false;
+      }
+      resp.append(reinterpret_cast<char*>(tb), static_cast<size_t>(r));
+    }
+    return resp.find("101 Switching Protocols") != std::string::npos;
+  }
+
+  void send(const std::string& m)
+  {
+    std::vector<uint8_t> f;
+    f.push_back(0x81);  // FIN + Text
+    const size_t n = m.size();
+    const uint8_t mask[4] = {0x11, 0x22, 0x33, 0x44};
+    if (n < 126)
+    {
+      f.push_back(static_cast<uint8_t>(0x80 | n));
+    }
+    else
+    {
+      f.push_back(0x80 | 126);
+      f.push_back(static_cast<uint8_t>(n >> 8));
+      f.push_back(static_cast<uint8_t>(n));
+    }
+    for (int i = 0; i < 4; ++i)
+    {
+      f.push_back(mask[i]);
+    }
+    for (size_t i = 0; i < n; ++i)
+    {
+      f.push_back(static_cast<uint8_t>(m[i] ^ mask[i & 3]));
+    }
+    ::write(fd, f.data(), f.size());
+  }
+
+  void admin(const std::string& type, const std::vector<std::pair<int, std::string>>& fields = {},
+             uint64_t seqOverride = 0, bool possDup = false)
+  {
+    const uint64_t s = seqOverride != 0 ? seqOverride : seq++;
+    send(FixCodec::encodeAdmin(type, s, "CLIENT", "VENUE",
+                               FixSession::sendingTime(wallClockNs()), fields, possDup));
+  }
+
+  void order(uint64_t id, const char* side, const char* price, const char* quantity)
+  {
+    const uint64_t s = seq++;
+    std::string b;
+    auto add = [&](int t, const std::string& v)
+    { b += std::to_string(t) + "=" + v + std::string(1, FixCodec::SOH); };
+    add(35, "D");
+    add(34, std::to_string(s));
+    add(49, "CLIENT");
+    add(56, "VENUE");
+    add(52, FixSession::sendingTime(wallClockNs()));
+    add(11, std::to_string(id));
+    add(55, "1");
+    add(54, side);
+    add(38, quantity);
+    add(44, price);
+    add(40, "2");
+    send(FixCodec::frame(b));
+  }
+
+  // One FIX message = one WS data frame (control frames are skipped).
+  bool read(Fields& f)
+  {
+    uint8_t tb[2048];
+    while (true)
+    {
+      ws::Opcode op{};
+      std::vector<uint8_t> payload;
+      const size_t consumed = ws::parseFrame(buf.data(), buf.size(), op, payload);
+      if (consumed == ws::kParseError)
+      {
+        return false;
+      }
+      if (consumed == 0)
+      {
+        const ssize_t r = ::read(fd, tb, sizeof tb);
+        if (r <= 0)
+        {
+          return false;
+        }
+        buf.insert(buf.end(), tb, tb + r);
+        continue;
+      }
+      buf.erase(buf.begin(), buf.begin() + static_cast<std::ptrdiff_t>(consumed));
+      if (op == ws::Opcode::Text || op == ws::Opcode::Binary)
+      {
+        f = FixCodec::parseFields(std::string(payload.begin(), payload.end()));
+        return true;
+      }
+      if (op == ws::Opcode::Close)
+      {
+        return false;
+      }
+      // Ping/Pong: skip (FIX heartbeats carry liveness on these sessions)
+    }
+  }
+
+  bool readType(const std::string& type, Fields& f)
+  {
+    while (read(f))
+    {
+      if (f.count(35) != 0 && f[35] == type)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void close()
+  {
+    if (fd >= 0)
+    {
+      ::close(fd);
+      fd = -1;
+    }
+  }
+  ~WsFixClient() { close(); }
+};
+
+// (10) The same FIX session layer over WebSocket: Logon 141=Y, a trading
+// cycle, the venue's own Heartbeat, and a short resend (PossDup replay with
+// the original seq) -- one FIX message per Text frame. The full recovery
+// matrix stays on the TCP tests; the session layer is transport-independent.
+void test_ws_fix_logon_trade_heartbeat_resend()
+{
+  std::printf("test_ws_fix_logon_trade_heartbeat_resend\n");
+  Venue v;
+  auto gw = v.wsGateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  WsFixClient c;
+  CHECK(c.connectTo(port));
+  c.admin("A", {{108, "1"}, {141, "Y"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+  CHECK(u64f(f, 34) == 1 && f[141] == "Y" && u64f(f, 108) == 1);
+
+  c.order(1, "2", "100", "5");
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 34) == 2 && f[150] == "0" && u64f(f, 37) == 1);
+
+  // Idle past HeartBtInt: the venue heartbeats on its own timer (over WS the
+  // FIX heartbeat replaces the Ping probe).
+  CHECK(c.readType("0", f));
+  CHECK(u64f(f, 34) >= 3);
+  c.admin("0");
+
+  // Short resend: request the Accepted (seq 2) again -- PossDup replay with
+  // the ORIGINAL seq, GapFill over the admin seqs, all in Text frames.
+  c.admin("2", {{7, "2"}, {16, "2"}});
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 34) == 2 && f[43] == "Y" && f.count(122) != 0 && u64f(f, 37) == 1);
+  CHECK(v.counters.resendServed.load() >= 1);
+
+  c.admin("5");
+  CHECK(c.readType("5", f));  // Logout confirmed
+
+  c.close();
+  gw->stop();
+}
+
+}  // namespace
+
+TEST(FixSessionLayer, EngineSuite)
+{
+  test_logon_trade_heartbeat();
+  test_our_resend_possdup_and_gapfill();
+  test_their_resend_older_than_log();
+  test_inbound_gap_resend_and_recover();
+  test_testrequest_timeout_cod();
+  test_restart_requires_reset();
+  test_restart_with_sidecar();
+  test_session_reject_unknown_type();
+  test_cod_negotiation();
+  test_ws_fix_logon_trade_heartbeat_resend();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_gateway.cpp
+++ b/venue/tests/test_venue_gateway.cpp
@@ -258,6 +258,67 @@ void test_fix_execreport()
                 "6=") != std::string::npos);  // AvgPx present
 }
 
+// FIX 4.4 session framing: every outbound message carries MsgSeqNum (34),
+// SenderCompID (49), TargetCompID (56) and SendingTime (52); inbound 34 is
+// validated (gap/duplicate/missing -> session error). Recovery itself
+// (ResendRequest 35=2 / GapFill) is intentionally NOT implemented -- see
+// docs/venue/perimeter.md: session-layer recovery is the SBE path.
+void test_fix_session()
+{
+  std::printf("test_fix_session\n");
+  FixSession fs("VENUE", "CLIENT");
+  const int64_t wallNs = 1'700'000'000'123'000'000;  // 2023-11-14 22:13:20.123 UTC
+
+  const std::string m1 = fs.encode(
+      OutboundEvent{OrderAccepted{7, SYM, Side::BUY, px(100), qty(5), true}}, wallNs);
+  CHECK(m1.rfind("8=FIX.4.4", 0) == 0);
+  CHECK(m1.find("\x01"
+                "34=1\x01") != std::string::npos);  // MsgSeqNum
+  CHECK(m1.find("\x01"
+                "49=VENUE\x01") != std::string::npos);  // SenderCompID
+  CHECK(m1.find("\x01"
+                "56=CLIENT\x01") != std::string::npos);  // TargetCompID
+  CHECK(m1.find("\x01"
+                "52=20231114-22:13:20.123\x01") != std::string::npos);  // SendingTime
+  // Frame integrity survives the re-frame: BodyLength + CheckSum are correct.
+  {
+    const size_t bodyStart = m1.find("35=");
+    const size_t csPos = m1.rfind(
+        "\x01"
+        "10=");
+    CHECK(bodyStart != std::string::npos && csPos != std::string::npos);
+    unsigned sum = 0;
+    for (size_t i = 0; i <= csPos; ++i)
+    {
+      sum += static_cast<unsigned char>(m1[i]);
+    }
+    CHECK(static_cast<unsigned>(std::atoi(m1.c_str() + csPos + 4)) == sum % 256);
+  }
+  // Seq is monotonic per message; a non-mapping event consumes no seq.
+  CHECK(fs.encode(OutboundEvent{MmpTriggered{1, SYM}}, wallNs).empty());
+  const std::string m2 = fs.encode(
+      OutboundEvent{OrderCanceled{7, SYM, CancelReason::UserRequested}}, wallNs);
+  CHECK(m2.find("\x01"
+                "34=2\x01") != std::string::npos);
+
+  // Inbound MsgSeqNum validation.
+  auto inbound = [](uint64_t seq)
+  {
+    return fixJoin({{35, "D"}, {34, std::to_string(seq)}, {11, "1"}, {55, "1"}, {54, "1"}, {38, "5"}});
+  };
+  CHECK(fs.acceptInbound(inbound(1)) == FixSession::InSeq::Ok);
+  CHECK(fs.acceptInbound(inbound(2)) == FixSession::InSeq::Ok);
+  CHECK(fs.acceptInbound(inbound(5)) == FixSession::InSeq::Gap);        // 3,4 lost -> reject session
+  CHECK(fs.expectedInboundSeq() == 3);                                  // a gap does not advance
+  CHECK(fs.acceptInbound(inbound(2)) == FixSession::InSeq::Duplicate);  // replayed old message
+  CHECK(fs.acceptInbound(fixJoin({{35, "D"}, {11, "1"}, {55, "1"}, {54, "1"}, {38, "5"}})) ==
+        FixSession::InSeq::Missing);  // no 34: structurally invalid FIX 4.4
+
+  // msgSeqNum must match tag 34 at a field boundary only (134= is not 34=).
+  CHECK(FixCodec::msgSeqNum(fixJoin({{35, "D"}, {134, "9"}, {34, "6"}})) == 6);
+  CHECK(FixCodec::msgSeqNum(fixJoin({{35, "D"}, {134, "9"}})) == 0);
+}
+
 void test_rest_json()
 {
   std::printf("test_rest_json\n");

--- a/venue/tests/test_venue_ha.cpp
+++ b/venue/tests/test_venue_ha.cpp
@@ -57,7 +57,9 @@ constexpr uint64_t VENUE = 1000;
 constexpr int NACCT = 64;  // matches the workload's account spread
 
 // Ledger-backed engine: settlement runs, so replicas must reconstruct not just
-// the event stream but the exact per-account balances.
+// the event stream but the exact per-account balances. The ledger starts EMPTY
+// -- deposits arrive as journaled commands (genesis in the WAL), so recovery
+// needs no out-of-band seeding.
 struct HashEng
 {
   uint64_t h = 1469598103934665603ULL;
@@ -67,15 +69,25 @@ struct HashEng
       : eng(cfg(), [this](const OutboundEvent& e)
             { h = hashEvent(h, e); }, LadderBook{lc()})
   {
-    for (int a = 1; a <= NACCT; ++a)
-    {
-      led.deposit(a, BASE, amountOf(Quantity::fromDouble(10000)));
-      led.deposit(a, QUOTE, amountOf(Volume::fromDouble(1000000)));
-    }
     eng.setLedger(&led, VENUE);
   }
   void submit(const InboundCommand& c) { eng.submit(c); }
 };
+
+// Balance genesis as commands: the same stream every replica and every
+// recovery replays, so balances are reproducible from an empty ledger.
+std::vector<InboundCommand> genesisDeposits()
+{
+  std::vector<InboundCommand> g;
+  for (int a = 1; a <= NACCT; ++a)
+  {
+    g.emplace_back(Deposit{static_cast<uint64_t>(a), BASE,
+                           static_cast<int64_t>(amountOf(Quantity::fromDouble(10000))), SYM});
+    g.emplace_back(Deposit{static_cast<uint64_t>(a), QUOTE,
+                           static_cast<int64_t>(amountOf(Volume::fromDouble(1000000))), SYM});
+  }
+  return g;
+}
 
 // Every balance (per account + venue, base + quote, available + reserved) equal.
 bool ledgersEqual(const Ledger& a, const Ledger& b)
@@ -110,7 +122,11 @@ TEST(Ha, EngineSuite)
   workload::Params p;
   p.symbol = SYM;
   p.count = 200'000;
-  const auto cmds = workload::symmetricLimits(p);
+  auto cmds = genesisDeposits();  // genesis first: balances come from the stream
+  {
+    const auto orders = workload::symmetricLimits(p);
+    cmds.insert(cmds.end(), orders.begin(), orders.end());
+  }
 
   const std::string path = "/tmp/flox_test_venue_ha_ha_journal.bin";
 
@@ -131,10 +147,13 @@ TEST(Ha, EngineSuite)
   CHECK(primary.eng.book().bestAsk() == standby.eng.book().bestAsk());
   CHECK(ledgersEqual(primary.led, standby.led));  // standby balances match primary exactly
 
-  // 3: journal recovery -- a fresh replica rebuilt from the WAL.
+  // 3: journal recovery -- a fresh replica rebuilt from the WAL. Its ledger
+  // starts EMPTY: the deposits are in the journal, so the replay alone must
+  // reproduce every balance (no manual seeding).
   const auto replayed = Journal::load(path);
   CHECK(replayed.size() == cmds.size());
   HashEng recovered;
+  CHECK(recovered.led.available(1, BASE) == 0);  // truly empty before replay
   for (const auto& c : replayed)
   {
     recovered.submit(c);

--- a/venue/tests/test_venue_lastlook.cpp
+++ b/venue/tests/test_venue_lastlook.cpp
@@ -1,0 +1,773 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Last-look lifecycle (T016) and clientOrderId dedup (T020).
+ *
+ * Last look: a reject/timeout must RESTORE liquidity -- the maker's displayed
+ * qty back onto its price level (tail, as-if re-entered), the taker residual
+ * routed by its TIF (GTC/GTD rest, IOC/FOK/MARKET cancel). The public feed
+ * must equal the matching book after any hold/accept/reject sequence. Holds
+ * are owned by the maker account, expire on idle via tick()/TimeTick, resolve
+ * deterministically on cancel-while-held, and never count as firm liquidity
+ * for a FOK. lastLookWindowNs == 0 disables the feature entirely.
+ *
+ * clOrdId dedup: per-account, session-window; a resend of a used clientOrderId
+ * rejects (DuplicateClientOrderId) whether the original is resting, filled or
+ * canceled; accounts do not collide; replay rebuilds the index.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/sequenced_shard.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+venue::SymbolConfig cfg(int64_t llWindow = 1000, bool acceptOnTimeout = false)
+{
+  venue::SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  c.lastLookWindowNs = llWindow;
+  c.lastLookAcceptOnTimeout = acceptOnTimeout;
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+struct Cap
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+  template <class T>
+  int count() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<T>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  int trades() const { return count<venue::Trade>(); }
+  const FillHeld* lastHeld() const
+  {
+    const FillHeld* out = nullptr;
+    for (auto& e : ev)
+    {
+      if (auto* h = std::get_if<FillHeld>(&e))
+      {
+        out = h;
+      }
+    }
+    return out;
+  }
+  const FillRejected* lastFillRejected() const
+  {
+    const FillRejected* out = nullptr;
+    for (auto& e : ev)
+    {
+      if (auto* h = std::get_if<FillRejected>(&e))
+      {
+        out = h;
+      }
+    }
+    return out;
+  }
+  bool sawReject(RejectReason r) const
+  {
+    for (auto& e : ev)
+    {
+      if (auto* j = std::get_if<OrderRejected>(&e); j != nullptr && j->reason == r)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+  bool sawCancel(CancelReason r) const
+  {
+    for (auto& e : ev)
+    {
+      if (auto* c = std::get_if<OrderCanceled>(&e); c != nullptr && c->reason == r)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+// Displayed qty resting at a price on one side of the matching book.
+Quantity bookAt(const MatchingBook& b, Side s, double p)
+{
+  std::vector<std::pair<Price, Quantity>> lv;
+  b.levels(s, lv);
+  for (const auto& [price, q] : lv)
+  {
+    if (price == px(p))
+    {
+      return q;
+    }
+  }
+  return Quantity{};
+}
+
+// ---- pro-rata guard: lastLook orders are refused at admission ---------------
+
+void test_prorata_lastlook_rejected()
+{
+  std::printf("test_prorata_lastlook_rejected\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink(), MatchingBook{}, MatchPolicy::ProRata);
+  NewOrder ll = limit(1, Side::SELL, 100, 5, 1);
+  ll.lastLook = true;
+  eng.submit(InboundCommand{ll}, 1);
+  CHECK(cap.sawReject(RejectReason::LastLookUnsupported));
+  CHECK(bookAt(eng.book(), Side::SELL, 100).isZero());
+
+  // Firm order on the same pro-rata instrument is fine.
+  NewOrder firm = limit(2, Side::SELL, 100, 5, 1);
+  eng.submit(InboundCommand{firm}, 2);
+  CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(5));
+
+  // Same lastLook order on a price-time instrument is fine.
+  Cap cap2;
+  MatchingEngine<MatchingBook> ptEng(cfg(), cap2.sink());
+  NewOrder ok = limit(3, Side::SELL, 100, 5, 1);
+  ok.lastLook = true;
+  ptEng.submit(InboundCommand{ok}, 1);
+  CHECK(bookAt(ptEng.book(), Side::SELL, 100) == qty(5));
+}
+
+// ---- T016: reject restores the book ----------------------------------------
+
+void test_reject_restores_book()
+{
+  std::printf("test_reject_restores_book\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+  CHECK(cap.trades() == 0);
+  CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(2));  // 3 held out of the book
+  const auto* h = cap.lastHeld();
+  CHECK(h != nullptr && h->qty == qty(3) && h->makerDisplayAfter == qty(2));
+  eng.submit(InboundCommand{LastLookDecision{h->heldId, SYM, false, 1}}, 2);
+  CHECK(cap.trades() == 0);
+  // Maker's 3 are back on its level (tail); the GTC taker residual rests too.
+  CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(5));
+  CHECK(bookAt(eng.book(), Side::BUY, 100) == qty(3));
+  const auto* fr = cap.lastFillRejected();
+  CHECK(fr != nullptr && fr->qty == qty(3) && fr->makerId == 1 && fr->takerId == 2 &&
+        fr->price == px(100));
+  // The taker fully exited with zero fills before the reject; the restore is
+  // what made it whole -- resend of either id must be a duplicate while resting.
+  eng.submit(InboundCommand{limit(1, Side::SELL, 101, 1, 1)}, 3);
+  CHECK(cap.sawReject(RejectReason::DuplicateOrderId));
+}
+
+void test_partial_hold_reject()
+{
+  std::printf("test_partial_hold_reject\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 2, 3)}, 0);  // firm maker, acct 3
+  NewOrder mk = limit(2, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 1);
+  // Taker 6: fills 2 firm (trade), holds 4 from the last-look maker, leaves 0.
+  eng.submit(InboundCommand{limit(3, Side::BUY, 100, 6, 2)}, 2);
+  CHECK(cap.trades() == 1);
+  const auto* h = cap.lastHeld();
+  CHECK(h != nullptr && h->qty == qty(4));
+  eng.submit(InboundCommand{LastLookDecision{h->heldId, SYM, false, 1}}, 3);
+  CHECK(cap.trades() == 1);                              // no new prints
+  CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(5));  // maker fully restored
+  CHECK(bookAt(eng.book(), Side::BUY, 100) == qty(4));   // held taker slice rests
+}
+
+// ---- T016: taker residual per TIF -------------------------------------------
+
+void test_taker_residual_tifs()
+{
+  std::printf("test_taker_residual_tifs\n");
+  {  // GTC: residual rests (covered above too; assert no cancel event)
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+    eng.submit(InboundCommand{LastLookDecision{cap.lastHeld()->heldId, SYM, false, 1}}, 2);
+    CHECK(bookAt(eng.book(), Side::BUY, 100) == qty(3));
+    CHECK(cap.count<OrderCanceled>() == 0);
+  }
+  {  // IOC: residual canceled with the IOC reason, nothing rests
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    NewOrder tk = limit(2, Side::BUY, 100, 3, 2);
+    tk.tif = TimeInForce::IOC;
+    eng.submit(InboundCommand{tk}, 1);
+    eng.submit(InboundCommand{LastLookDecision{cap.lastHeld()->heldId, SYM, false, 1}}, 2);
+    CHECK(cap.sawCancel(CancelReason::ImmediateOrCancelResidual));
+    CHECK(bookAt(eng.book(), Side::BUY, 100).isZero());
+    CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(5));  // maker still restored
+  }
+  {  // MARKET: residual canceled with the market reason
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    NewOrder tk;
+    tk.id = 2;
+    tk.symbol = SYM;
+    tk.side = Side::BUY;
+    tk.type = OrderType::MARKET;
+    tk.quantity = qty(3);
+    tk.accountId = 2;
+    eng.submit(InboundCommand{tk}, 1);
+    const auto* h = cap.lastHeld();
+    CHECK(h != nullptr && h->qty == qty(3));
+    eng.submit(InboundCommand{LastLookDecision{h->heldId, SYM, false, 1}}, 2);
+    CHECK(cap.sawCancel(CancelReason::MarketResidual));
+    CHECK(bookAt(eng.book(), Side::BUY, 100).isZero());
+  }
+}
+
+// ---- T016: public feed == matching book -------------------------------------
+
+void test_md_equals_book()
+{
+  std::printf("test_md_equals_book\n");
+  std::vector<MdMessage> md;
+  MarketDataPublisher<1 << 16> pub([&](const MdMessage& m)
+                                   { md.push_back(m); }, px(0.01), SYM);
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   {
+                                     cap.ev.push_back(e);
+                                     pub.onEvent(e); });
+
+  auto feedMatchesBook = [&](std::vector<double> prices)
+  {
+    for (double p : prices)
+    {
+      if (pub.book().bidAtPrice(px(p)).raw() != bookAt(eng.book(), Side::BUY, p).raw())
+      {
+        return false;
+      }
+      if (pub.book().askAtPrice(px(p)).raw() != bookAt(eng.book(), Side::SELL, p).raw())
+      {
+        return false;
+      }
+    }
+    return true;
+  };
+  const std::vector<double> prices{99.0, 100.0, 101.0};
+
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);
+  CHECK(feedMatchesBook(prices));
+
+  // Hold: the feed must drop the held size immediately (no phantom liquidity).
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+  CHECK(pub.book().askAtPrice(px(100)) == qty(2));
+  CHECK(feedMatchesBook(prices));
+
+  // Reject: maker restored, taker residual rests -- feed follows both.
+  eng.submit(InboundCommand{LastLookDecision{cap.lastHeld()->heldId, SYM, false, 1}}, 2);
+  CHECK(pub.book().askAtPrice(px(100)) == qty(5));
+  CHECK(pub.book().bidAtPrice(px(100)) == qty(3));
+  CHECK(feedMatchesBook(prices));
+
+  // Hold + accept: depth already left at hold time; the print must not change it.
+  NewOrder tk = limit(3, Side::BUY, 100, 2, 3);
+  tk.tif = TimeInForce::IOC;
+  eng.submit(InboundCommand{tk}, 3);
+  CHECK(feedMatchesBook(prices));
+  eng.submit(InboundCommand{LastLookDecision{cap.lastHeld()->heldId, SYM, true, 1}}, 4);
+  CHECK(cap.trades() == 1);
+  CHECK(pub.book().askAtPrice(px(100)) == qty(3));
+  CHECK(feedMatchesBook(prices));
+
+  // Cancel-while-held: resolve + cancel must drain both feed and book.
+  eng.submit(InboundCommand{limit(4, Side::BUY, 100, 1, 3)}, 5);  // new hold (1 of maker's 3)
+  CHECK(cap.count<FillHeld>() == 3);
+  eng.submit(InboundCommand{CancelOrder{1, SYM, 1}}, 6);  // maker cancels with a live hold
+  eng.submit(InboundCommand{CancelOrder{2, SYM, 2}}, 7);
+  eng.submit(InboundCommand{CancelOrder{4, SYM, 3}}, 8);
+  CHECK(eng.book().empty());
+  CHECK(feedMatchesBook(prices));
+}
+
+// ---- T016: ownership --------------------------------------------------------
+
+void test_ownership()
+{
+  std::printf("test_ownership\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+  const auto* h = cap.lastHeld();
+  CHECK(h != nullptr);
+  const uint64_t heldId = h->heldId;  // copy: cap.ev may reallocate below
+  // The taker (or anyone but the maker) must not be able to accept its own fill.
+  eng.submit(InboundCommand{LastLookDecision{heldId, SYM, true, 2}}, 2);
+  CHECK(cap.sawReject(RejectReason::NotOrderOwner));
+  CHECK(cap.trades() == 0);  // the hold is untouched
+  // The real maker still can.
+  eng.submit(InboundCommand{LastLookDecision{heldId, SYM, true, 1}}, 3);
+  CHECK(cap.trades() == 1);
+}
+
+// ---- T016: timeout accept, idle expiry, window=0 ----------------------------
+
+void test_timeout_accept()
+{
+  std::printf("test_timeout_accept\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(1000, /*acceptOnTimeout*/ true), cap.sink());
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // deadline 1001
+  CHECK(cap.trades() == 0);
+  eng.submit(InboundCommand{CancelOrder{999, SYM, 9}}, 5000);  // time passes -> accept
+  CHECK(cap.trades() == 1);
+  CHECK(cap.count<FillRejected>() == 0);
+  CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(2));
+}
+
+void test_idle_expiry_via_tick()
+{
+  std::printf("test_idle_expiry_via_tick\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // deadline 1001
+  CHECK(eng.openHolds() == 1);
+  eng.tick(500);  // before the deadline: nothing happens
+  CHECK(eng.openHolds() == 1);
+  eng.tick(5000);  // NO traffic -- the sweep alone expires the hold (reject)
+  CHECK(eng.openHolds() == 0);
+  CHECK(cap.count<FillRejected>() == 1);
+  CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(5));
+  CHECK(bookAt(eng.book(), Side::BUY, 100) == qty(3));
+  eng.tick(6000);  // idempotent
+  CHECK(cap.count<FillRejected>() == 1);
+}
+
+void test_window_zero_disables()
+{
+  std::printf("test_window_zero_disables\n");
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(cfg(/*window*/ 0), cap.sink());
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;  // flag set, but the venue has last look OFF
+  eng.submit(InboundCommand{mk}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+  CHECK(cap.count<FillHeld>() == 0);
+  CHECK(cap.trades() == 1);  // fills like a normal maker
+}
+
+// ---- T016: cancel-while-held + conservation ---------------------------------
+
+void test_cancel_while_held_conservation()
+{
+  std::printf("test_cancel_while_held_conservation\n");
+  constexpr AssetId BASE = 0, QUOTE = 1;
+  constexpr uint64_t VENUE = 999;
+  const Amount base5 = amountOf(qty(5));
+  const Amount usd300 = amountOf(Volume::fromDouble(300));
+  Ledger led;
+  led.deposit(1, BASE, base5);
+  led.deposit(2, QUOTE, usd300);
+  auto c = cfg();
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(c, cap.sink());
+  eng.setLedger(&led, VENUE);
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+  const auto* h = cap.lastHeld();
+  CHECK(h != nullptr);
+  const uint64_t heldId = h->heldId;
+
+  // Maker cancels its order while the hold is live: the hold resolves (reject)
+  // FIRST, deterministically, then the whole order cancels.
+  eng.submit(InboundCommand{CancelOrder{1, SYM, 1}}, 2);
+  CHECK(cap.count<FillRejected>() == 1);
+  CHECK(cap.sawCancel(CancelReason::UserRequested));
+  CHECK(bookAt(eng.book(), Side::SELL, 100).isZero());
+  // Maker made whole immediately; taker's restored GTC residual rests, backed
+  // by its reservation.
+  CHECK(led.available(1, BASE) == base5 && led.reserved(1, BASE) == 0);
+  CHECK(bookAt(eng.book(), Side::BUY, 100) == qty(3));
+  CHECK(led.reserved(2, QUOTE) == usd300);
+
+  // Accept-after-cancel must be impossible.
+  eng.submit(InboundCommand{LastLookDecision{heldId, SYM, true, 1}}, 3);
+  CHECK(cap.trades() == 0);
+  CHECK(cap.sawReject(RejectReason::UnknownOrder));
+
+  // Conservation, then a full drain returns every reserved unit.
+  CHECK(led.total(1, BASE) == base5 && led.total(2, QUOTE) == usd300);
+  eng.submit(InboundCommand{CancelOrder{2, SYM, 2}}, 4);
+  CHECK(led.available(2, QUOTE) == usd300 && led.reserved(2, QUOTE) == 0);
+}
+
+// ---- T016: FOK vs last-look -------------------------------------------------
+
+void test_fok_vs_lastlook()
+{
+  std::printf("test_fok_vs_lastlook\n");
+  {  // crossable liquidity is last-look only -> FOK rejected, book untouched
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    NewOrder tk = limit(2, Side::BUY, 100, 3, 2);
+    tk.tif = TimeInForce::FOK;
+    eng.submit(InboundCommand{tk}, 1);
+    CHECK(cap.sawReject(RejectReason::FillOrKillUnfulfillable));
+    CHECK(cap.count<FillHeld>() == 0);
+    CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(5));
+  }
+  {  // enough firm size, but a last-look maker inside the crossing range -> reject
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+    NewOrder ll = limit(1, Side::SELL, 100, 5, 1);
+    ll.lastLook = true;
+    eng.submit(InboundCommand{ll}, 0);
+    eng.submit(InboundCommand{limit(2, Side::SELL, 101, 5, 3)}, 1);  // firm
+    NewOrder tk = limit(3, Side::BUY, 101, 5, 2);
+    tk.tif = TimeInForce::FOK;
+    eng.submit(InboundCommand{tk}, 2);
+    CHECK(cap.sawReject(RejectReason::FillOrKillUnfulfillable));
+    CHECK(cap.trades() == 0 && cap.count<FillHeld>() == 0);
+  }
+  {  // last-look maker OUTSIDE the crossing range: FOK executes normally
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
+    NewOrder ll = limit(1, Side::SELL, 102, 5, 1);
+    ll.lastLook = true;
+    eng.submit(InboundCommand{ll}, 0);
+    eng.submit(InboundCommand{limit(2, Side::SELL, 101, 5, 3)}, 1);  // firm
+    NewOrder tk = limit(3, Side::BUY, 101, 5, 2);
+    tk.tif = TimeInForce::FOK;
+    eng.submit(InboundCommand{tk}, 2);
+    CHECK(cap.trades() == 1);
+    CHECK(cap.count<FillHeld>() == 0);
+  }
+}
+
+// ---- T016: idle sweeper on the sequenced shard (journaled TimeTick) ---------
+
+void test_shard_idle_sweeper()
+{
+  std::printf("test_shard_idle_sweeper\n");
+  const std::string path = "/tmp/flox_test_venue_lastlook_sweeper.bin";
+  std::remove(path.c_str());
+
+  auto now = std::make_shared<std::atomic<int64_t>>(1000);
+  SequencedShard<>::TimeSource clk = [now]
+  { return now->load(); };
+
+  std::atomic<int> fillHeld{0};
+  std::atomic<int> fillRejected{0};
+  struct Sink : IEngineEventListener
+  {
+    std::atomic<int>* held{nullptr};
+    std::atomic<int>* rejected{nullptr};
+    void onEngineEvent(const EngineEventMsg& e) override
+    {
+      if (std::get_if<FillHeld>(&e.event))
+      {
+        held->fetch_add(1);
+      }
+      if (std::get_if<FillRejected>(&e.event))
+      {
+        rejected->fetch_add(1);
+      }
+    }
+  } sink;
+  sink.held = &fillHeld;
+  sink.rejected = &fillRejected;
+
+  {
+    auto shard = std::make_unique<SequencedShard<>>(cfg(/*window*/ 5000), path, MatchingBook{},
+                                                    Journal::Sync::Off, clk,
+                                                    /*idleSweepIntervalNs*/ 1000);
+    shard->subscribeOutbound(&sink);
+    shard->start();
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    shard->submit(InboundCommand{mk});
+    shard->submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)});
+    shard->flush();
+    CHECK(fillHeld.load() == 1);
+    CHECK(fillRejected.load() == 0);
+
+    // NO further traffic. Advance the injected clock past the window; the idle
+    // sweeper must inject a TimeTick that expires the hold.
+    now->store(1'000'000);
+    for (int i = 0; i < 2000 && fillRejected.load() == 0; ++i)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    CHECK(fillRejected.load() == 1);
+    shard->stop();
+  }
+
+  // The sweep went through the journal: replaying it reproduces the timeout.
+  const auto records = Journal::loadTimed(path);
+  int ticks = 0;
+  for (const auto& [ts, cmd] : records)
+  {
+    (void)ts;
+    if (std::get_if<TimeTick>(&cmd))
+    {
+      ++ticks;
+    }
+  }
+  CHECK(ticks >= 1);
+  int replayRejected = 0;
+  MatchingEngine<MatchingBook> rec(cfg(5000), [&](const OutboundEvent& e)
+                                   {
+                                     if (std::get_if<FillRejected>(&e))
+                                     {
+                                       ++replayRejected;
+                                     } });
+  for (const auto& [ts, cmd] : records)
+  {
+    rec.submit(cmd, ts);
+  }
+  CHECK(replayRejected == 1);
+  std::remove(path.c_str());
+}
+
+// ---- T020: clientOrderId dedup ----------------------------------------------
+
+void test_clordid_dedup()
+{
+  std::printf("test_clordid_dedup\n");
+  {  // resend after the original FILLED -> reject, no second execution
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(0), cap.sink());
+    eng.submit(InboundCommand{limit(1, Side::SELL, 100, 3, 1)}, 0);
+    NewOrder tk = limit(2, Side::BUY, 100, 3, 2);
+    tk.clientOrderId = 77;
+    eng.submit(InboundCommand{tk}, 1);
+    CHECK(cap.trades() == 1);
+    NewOrder resend = limit(3, Side::BUY, 100, 3, 2);  // fresh venue id, same clOrdId
+    resend.clientOrderId = 77;
+    eng.submit(InboundCommand{resend}, 2);
+    CHECK(cap.trades() == 1);  // did NOT execute twice
+    CHECK(cap.sawReject(RejectReason::DuplicateClientOrderId));
+    CHECK(eng.book().empty());  // book untouched by the resend
+  }
+  {  // resend while the original still RESTS -> reject, original unharmed
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(0), cap.sink());
+    NewOrder o = limit(10, Side::SELL, 100, 3, 1);
+    o.clientOrderId = 88;
+    eng.submit(InboundCommand{o}, 0);
+    NewOrder resend = limit(11, Side::SELL, 100, 3, 1);
+    resend.clientOrderId = 88;
+    eng.submit(InboundCommand{resend}, 1);
+    CHECK(cap.sawReject(RejectReason::DuplicateClientOrderId));
+    CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(3));  // only the original
+  }
+  {  // resend after cancel -> still a duplicate (session window)
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(0), cap.sink());
+    NewOrder o = limit(10, Side::SELL, 100, 3, 1);
+    o.clientOrderId = 88;
+    eng.submit(InboundCommand{o}, 0);
+    eng.submit(InboundCommand{CancelOrder{10, SYM, 1}}, 1);
+    NewOrder resend = limit(11, Side::SELL, 100, 3, 1);
+    resend.clientOrderId = 88;
+    eng.submit(InboundCommand{resend}, 2);
+    CHECK(cap.sawReject(RejectReason::DuplicateClientOrderId));
+  }
+  {  // dedup is per account: two accounts may use the same clientOrderId
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(0), cap.sink());
+    NewOrder a = limit(20, Side::SELL, 101, 1, 1);
+    a.clientOrderId = 99;
+    NewOrder b = limit(21, Side::SELL, 102, 1, 2);
+    b.clientOrderId = 99;
+    eng.submit(InboundCommand{a}, 0);
+    eng.submit(InboundCommand{b}, 1);
+    CHECK(cap.count<OrderAccepted>() == 2);
+    CHECK(cap.count<OrderRejected>() == 0);
+  }
+  {  // clientOrderId 0 = unset: never deduplicated
+    Cap cap;
+    MatchingEngine<MatchingBook> eng(cfg(0), cap.sink());
+    eng.submit(InboundCommand{limit(30, Side::SELL, 101, 1, 1)}, 0);
+    eng.submit(InboundCommand{limit(31, Side::SELL, 102, 1, 1)}, 1);
+    CHECK(cap.count<OrderAccepted>() == 2);
+  }
+}
+
+// Replay safety: the dedup index is rebuilt by the same submits during journal
+// replay, so a post-restart resend behaves exactly like a live one.
+void test_clordid_dedup_survives_replay()
+{
+  std::printf("test_clordid_dedup_survives_replay\n");
+  const std::string path = "/tmp/flox_test_venue_lastlook_clordid.bin";
+  std::remove(path.c_str());
+
+  struct Sink : IEngineEventListener
+  {
+    std::atomic<int> trades{0};
+    std::atomic<int> dupRejects{0};
+    void onEngineEvent(const EngineEventMsg& e) override
+    {
+      if (std::get_if<venue::Trade>(&e.event))
+      {
+        trades.fetch_add(1);
+      }
+      if (auto* j = std::get_if<OrderRejected>(&e.event);
+          j != nullptr && j->reason == RejectReason::DuplicateClientOrderId)
+      {
+        dupRejects.fetch_add(1);
+      }
+    }
+  };
+
+  {  // live session: submit + fill with clOrdId 55
+    Sink sink;
+    auto shard = std::make_unique<SequencedShard<>>(cfg(0), path, MatchingBook{},
+                                                    Journal::Sync::Off);
+    shard->subscribeOutbound(&sink);
+    shard->start();
+    shard->submit(InboundCommand{limit(1, Side::SELL, 100, 3, 1)});
+    NewOrder tk = limit(2, Side::BUY, 100, 3, 2);
+    tk.clientOrderId = 55;
+    shard->submit(InboundCommand{tk});
+    shard->flush();
+    shard->stop();
+    CHECK(sink.trades.load() == 1);
+  }
+  {  // restart: recovery replays the journal, then the resend must reject
+    Sink sink;
+    auto shard = std::make_unique<SequencedShard<>>(cfg(0), path, MatchingBook{},
+                                                    Journal::Sync::Off);
+    shard->subscribeOutbound(&sink);
+    shard->start();
+    CHECK(shard->recoveredCommands() == 2u);
+    NewOrder resend = limit(3, Side::BUY, 100, 3, 2);
+    resend.clientOrderId = 55;
+    shard->submit(InboundCommand{resend});
+    shard->flush();
+    shard->stop();
+    CHECK(sink.trades.load() == 0);  // recovery does not re-broadcast, resend did not trade
+    CHECK(sink.dupRejects.load() == 1);
+  }
+  std::remove(path.c_str());
+}
+
+}  // namespace
+
+TEST(VenueLastLook, LifecycleSuite)
+{
+  test_prorata_lastlook_rejected();
+  test_reject_restores_book();
+  test_partial_hold_reject();
+  test_taker_residual_tifs();
+  test_md_equals_book();
+  test_ownership();
+  test_timeout_accept();
+  test_idle_expiry_via_tick();
+  test_window_zero_disables();
+  test_cancel_while_held_conservation();
+  test_fok_vs_lastlook();
+  test_shard_idle_sweeper();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}
+
+TEST(VenueClientOrderId, DedupSuite)
+{
+  const int before = g_failures;
+  test_clordid_dedup();
+  test_clordid_dedup_survives_replay();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, before);
+}

--- a/venue/tests/test_venue_liveness.cpp
+++ b/venue/tests/test_venue_liveness.cpp
@@ -1,0 +1,323 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Liveness and cancel-on-disconnect:
+ *  - a black-holed peer (connect, order, silence) is disconnected on the idle
+ *    timeout and COD sweeps its orders -- previously a half-open peer held its
+ *    orders and a gateway thread forever;
+ *  - stop() completes promptly with a silent client attached (the acceptor
+ *    shuts every connection fd down before joining);
+ *  - the WebSocket path pings at half the idle window and drops a peer that
+ *    never answers;
+ *  - DisconnectCanceller prunes terminally-resolved orders, so a disconnect
+ *    flush never cancels an order that already filled.
+ */
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/rest_json.h"
+#include "flox-venue/sbe_order_entry_codec.h"
+#include "flox-venue/session_registry.h"
+#include "flox-venue/tcp_gateway.h"
+#include "flox-venue/ws_gateway.h"
+#include "flox/util/transport.h"
+#include "flox/util/websocket.h"
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+NewOrder mk(OrderId id, Side s, double p, double q, uint64_t acct = 0)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+int tcpConnect(int port)
+{
+  const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  if (::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) != 0)
+  {
+    ::close(fd);
+    return -1;
+  }
+  timeval tv{2, 0};
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+  return fd;
+}
+
+bool waitUntil(const std::function<bool()>& pred, int ms = 3000)
+{
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(ms);
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    if (pred())
+    {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  return pred();
+}
+
+// Black-holed peer: connect, place an order, go silent. The idle timeout must
+// close the session and COD must pull the resting order.
+void test_idle_disconnect_cod()
+{
+  std::printf("test_idle_disconnect_cod\n");
+  GatewayCounters counters;
+  SessionRegistry registry({}, &counters);
+  std::mutex m;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { registry.route(e); });
+
+  TcpGateway gw([](const uint8_t* p, size_t n)
+                { return SbeOrderEntryCodec::decode(p, n); },
+                /*account*/ 1);
+  gw.setDelivery(&registry, [](const OutboundEvent& e, uint64_t seq, int64_t, std::vector<uint8_t>& out)
+                 {
+                   SbeOrderEntryCodec::encode(e, out, seq);
+                   return !out.empty(); });
+  gw.setCounters(&counters);
+  gw.setCancelOnDisconnect(true);
+  gw.setIdleTimeout(std::chrono::milliseconds(300));
+  const int port = gw.start(0, [&](const InboundCommand& c, const TcpGateway::Responder&)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              eng.submit(c); });
+  CHECK(port > 0);
+
+  const int c = tcpConnect(port);
+  CHECK(c >= 0);
+  std::vector<uint8_t> b;
+  SbeOrderEntryCodec::encode(InboundCommand{mk(1, Side::SELL, 100, 5)}, b);
+  net::writeFrame(c, b.data(), b.size());
+  std::vector<uint8_t> frame;
+  CHECK(net::readFrame(c, frame));  // Accepted: the order is resting
+
+  // Silence. The idle window (300ms) elapses -> the venue closes the session
+  // and cancel-on-disconnect sweeps the book.
+  CHECK(waitUntil([&]
+                  {
+                    std::lock_guard<std::mutex> lk(m);
+                    return eng.book().empty(); }));
+  CHECK(counters.idleDisconnects.load() >= 1);
+  CHECK(!net::readFrame(c, frame) || true);  // drain; the peer socket is dead either way
+  ::close(c);
+  gw.stop();
+}
+
+// stop() must complete promptly while a silent client is connected: the
+// acceptor's shutdown sweep unblocks the parked read.
+void test_stop_with_silent_client()
+{
+  std::printf("test_stop_with_silent_client\n");
+  TcpGateway gw([](const uint8_t* p, size_t n)
+                { return SbeOrderEntryCodec::decode(p, n); });
+  const int port = gw.start(0, [](const InboundCommand&, const TcpGateway::Responder&) {});
+  CHECK(port > 0);
+  const int c = tcpConnect(port);
+  CHECK(c >= 0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));  // let the conn thread park in read
+
+  const auto t0 = std::chrono::steady_clock::now();
+  gw.stop();  // idle timeout is 30s: without the sweep this would hang that long
+  const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now() - t0)
+                      .count();
+  std::printf("  stop() with silent client took %lldms\n", static_cast<long long>(ms));
+  CHECK(ms < 2000);
+  ::close(c);
+}
+
+// WebSocket liveness: the server pings at half the idle window; a peer that
+// answers nothing is dropped after the full window.
+void test_ws_idle_disconnect()
+{
+  std::printf("test_ws_idle_disconnect\n");
+  GatewayCounters counters;
+  WsGateway gw([](const uint8_t* p, size_t n)
+               { return RestJson::decode(std::string(reinterpret_cast<const char*>(p), n)); });
+  gw.setCounters(&counters);
+  gw.setIdleTimeout(std::chrono::milliseconds(400));
+  const int port = gw.start(0, [](const InboundCommand&, const WsGateway::Responder&) {});
+  CHECK(port > 0);
+
+  const int c = tcpConnect(port);
+  CHECK(c >= 0);
+  const std::string hs =
+      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+  ::write(c, hs.data(), hs.size());
+  std::string resp;
+  uint8_t tb[2048];
+  while (resp.find("\r\n\r\n") == std::string::npos)
+  {
+    const ssize_t r = ::read(c, tb, sizeof tb);
+    if (r <= 0)
+    {
+      break;
+    }
+    resp.append(reinterpret_cast<char*>(tb), static_cast<size_t>(r));
+  }
+  CHECK(resp.find("101 Switching Protocols") != std::string::npos);
+
+  // Read whatever the server sends (Pings) without ever answering; the server
+  // must close the connection once the idle window passes.
+  bool sawPing = false;
+  bool closed = false;
+  std::vector<uint8_t> buf;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    const ssize_t r = ::read(c, tb, sizeof tb);
+    if (r == 0)
+    {
+      closed = true;
+      break;
+    }
+    if (r < 0)
+    {
+      continue;  // client-side read timeout tick
+    }
+    buf.insert(buf.end(), tb, tb + r);
+    ws::Opcode op{};
+    std::vector<uint8_t> pl;
+    size_t cons;
+    while ((cons = ws::parseFrame(buf.data(), buf.size(), op, pl)) > 0 && cons != ws::kParseError)
+    {
+      buf.erase(buf.begin(), buf.begin() + static_cast<std::ptrdiff_t>(cons));
+      sawPing |= (op == ws::Opcode::Ping);
+    }
+  }
+  CHECK(sawPing);  // keepalive probe went out at half the window
+  CHECK(closed);   // and the unresponsive peer was dropped
+  CHECK(counters.idleDisconnects.load() >= 1);
+  ::close(c);
+  gw.stop();
+}
+
+// COD pruning: an order that terminally resolved (full fill) while the session
+// was up must NOT be canceled by the disconnect flush.
+void test_cod_prunes_filled_orders()
+{
+  std::printf("test_cod_prunes_filled_orders\n");
+  GatewayCounters counters;
+  SessionRegistry registry({}, &counters);
+  std::mutex m;
+  int cancelCmds = 0;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { registry.route(e); });
+
+  TcpGateway gw([](const uint8_t* p, size_t n)
+                { return SbeOrderEntryCodec::decode(p, n); },
+                /*account*/ 1);
+  gw.setDelivery(&registry, [](const OutboundEvent& e, uint64_t seq, int64_t, std::vector<uint8_t>& out)
+                 {
+                   SbeOrderEntryCodec::encode(e, out, seq);
+                   return !out.empty(); });
+  gw.setCancelOnDisconnect(true);
+  const int port = gw.start(0, [&](const InboundCommand& c, const TcpGateway::Responder&)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              if (std::get_if<CancelOrder>(&c) != nullptr)
+                              {
+                                ++cancelCmds;
+                              }
+                              eng.submit(c); });
+  CHECK(port > 0);
+
+  const int c = tcpConnect(port);
+  CHECK(c >= 0);
+  std::vector<uint8_t> b;
+  SbeOrderEntryCodec::encode(InboundCommand{mk(1, Side::SELL, 100, 5)}, b);
+  net::writeFrame(c, b.data(), b.size());
+  std::vector<uint8_t> frame;
+  CHECK(net::readFrame(c, frame));  // Accepted
+
+  // A foreign aggressor fills the whole order: terminal -> COD must untrack it.
+  {
+    std::lock_guard<std::mutex> lk(m);
+    eng.submit(InboundCommand{mk(2, Side::BUY, 100, 5, /*acct*/ 2)});
+  }
+  // Wait until the terminal report was routed (the observer pruned on route).
+  CHECK(waitUntil([&]
+                  { return registry.lastSeq(1) >= 3; }));  // Accepted, Trade, Executed
+
+  ::close(c);  // disconnect
+  gw.stop();
+
+  std::lock_guard<std::mutex> lk(m);
+  CHECK(cancelCmds == 0);  // no cancel for the long-gone order
+  CHECK(eng.book().empty());
+}
+
+}  // namespace
+
+TEST(Liveness, EngineSuite)
+{
+  test_idle_disconnect_cod();
+  test_stop_with_silent_client();
+  test_ws_idle_disconnect();
+  test_cod_prunes_filled_orders();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_marketdata.cpp
+++ b/venue/tests/test_venue_marketdata.cpp
@@ -9,6 +9,7 @@
 #include "flox-venue/market_data.h"
 #include "flox-venue/matching_book.h"
 #include "flox-venue/matching_engine.h"
+#include "flox-venue/resend_buffer.h"
 #include "flox-venue/sbe_md_codec.h"
 #include "flox-venue/workload.h"
 #include "flox/book/ladder_book.h"
@@ -71,7 +72,8 @@ NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
 bool sameMd(const MdMessage& a, const MdMessage& b)
 {
   return a.type == b.type && a.seq == b.seq && a.symbol == b.symbol && a.id == b.id &&
-         a.side == b.side && a.price == b.price && a.qty == b.qty && a.makerId == b.makerId;
+         a.side == b.side && a.price == b.price && a.qty == b.qty && a.makerId == b.makerId &&
+         a.epoch == b.epoch;
 }
 
 void test_l2_and_codec()
@@ -102,6 +104,16 @@ void test_l2_and_codec()
   CHECK(md.book().askAtPrice(px(100)) == qty(0));
   CHECK(md.book().bestAsk() == px(102));
   CHECK(md.book().askAtPrice(px(102)) == qty(3));
+
+  // The wire stream is sequenced from 1 (contiguous) and every message carries
+  // the publisher's non-zero epoch -- the demux/recovery key on the wire.
+  CHECK(md.epoch() != 0);
+  for (size_t i = 0; i < feed.size(); ++i)
+  {
+    CHECK(feed[i].seq == i + 1);
+    CHECK(feed[i].epoch == md.epoch());
+  }
+  CHECK(md.seq() == feed.size());
 
   // SBE round-trip on the whole feed
   std::vector<uint8_t> buf;
@@ -261,6 +273,133 @@ void test_iceberg_hidden_from_md()
   CHECK(sawMakerExec);
 }
 
+// Harness around GapDetector: feeds synthetic seq/epoch messages and records
+// deliveries, gap reports and epoch changes.
+struct GdHarness
+{
+  GapDetector gd;
+  std::vector<uint64_t> delivered;                    // seqs, in delivery order
+  std::vector<uint64_t> gaps;                         // fromSeq per gap report
+  std::vector<std::pair<uint64_t, uint64_t>> epochs;  // (old, new)
+
+  explicit GdHarness(GapDetector::Config cfg = {16, 1024}) : gd(cfg) {}
+
+  void feed(uint64_t seq, uint64_t epoch = 1, SymbolId sym = SYM)
+  {
+    MdMessage m;
+    m.type = MdType::Trade;
+    m.seq = seq;
+    m.symbol = sym;
+    m.epoch = epoch;
+    gd.observe(m, [&](const MdMessage& d)
+               { delivered.push_back(d.seq); }, [&](SymbolId, uint64_t, uint64_t from)
+               { gaps.push_back(from); }, [&](SymbolId, uint64_t o, uint64_t n)
+               { epochs.emplace_back(o, n); });
+  }
+};
+
+void test_gap_detector_reordering()
+{
+  std::printf("test_gap_detector_reordering\n");
+  // Reordered datagrams: everything delivers exactly once, in seq order, with
+  // no false duplicates -- the old detector returned a late 3 as "duplicate".
+  GdHarness h;
+  h.feed(1);
+  h.feed(2);
+  h.feed(5);  // gap: 3,4 missing; 5 held
+  h.feed(4);  // still held
+  CHECK(h.delivered.size() == 2);
+  CHECK(h.gaps.size() == 1 && h.gaps[0] == 3);
+  h.feed(3);  // fills the gap: 3,4,5 drain in order
+  CHECK((h.delivered == std::vector<uint64_t>{1, 2, 3, 4, 5}));
+  h.feed(6);
+  CHECK(h.delivered.back() == 6);
+  CHECK(h.gaps.size() == 1);  // closed gap is not re-reported
+
+  // A true duplicate (below the watermark or of a held message) is dropped.
+  h.feed(2);
+  h.feed(6);
+  CHECK(h.delivered.size() == 6);
+}
+
+void test_gap_detector_reraise()
+{
+  std::printf("test_gap_detector_reraise\n");
+  // An unfilled gap is re-reported every reraiseAfter received messages, so a
+  // lost resend request does not strand the consumer.
+  GdHarness h(GapDetector::Config{3, 1024});
+  h.feed(1);
+  h.feed(5);  // gap from 2 -> first report
+  CHECK(h.gaps.size() == 1 && h.gaps[0] == 2);
+  h.feed(6);
+  h.feed(7);
+  h.feed(8);  // 3rd message with the gap open -> re-raise
+  CHECK(h.gaps.size() == 2 && h.gaps[1] == 2);
+  h.feed(9);
+  h.feed(10);
+  h.feed(11);  // re-raise again
+  CHECK(h.gaps.size() == 3 && h.gaps[2] == 2);
+  h.feed(2);
+  h.feed(3);
+  h.feed(4);  // gap closes; 2..11 all delivered
+  CHECK(h.delivered.size() == 11);
+  for (size_t i = 0; i < h.delivered.size(); ++i)
+  {
+    CHECK(h.delivered[i] == i + 1);
+  }
+}
+
+void test_gap_detector_epoch_change()
+{
+  std::printf("test_gap_detector_epoch_change\n");
+  // A new epoch = publisher restart: the stream resets to seq 1 and the epoch
+  // callback fires -- a surviving consumer re-snapshots instead of treating
+  // the restarted feed as duplicates (the silent-stall defect).
+  GdHarness h;
+  h.feed(1, /*epoch*/ 7);
+  h.feed(2, 7);
+  h.feed(1, 9);  // restart: new epoch, seq starts over
+  h.feed(2, 9);
+  CHECK((h.delivered == std::vector<uint64_t>{1, 2, 1, 2}));
+  CHECK(h.epochs.size() == 1 && h.epochs[0].first == 7 && h.epochs[0].second == 9);
+  CHECK(h.gaps.empty());
+}
+
+void test_gap_detector_per_symbol()
+{
+  std::printf("test_gap_detector_per_symbol\n");
+  // Streams are keyed by symbol: a gap on one symbol does not disturb the
+  // other's sequencing (several per-symbol publishers can share one group).
+  GdHarness h;
+  h.feed(1, 1, /*sym*/ 1);
+  h.feed(1, 1, /*sym*/ 2);
+  h.feed(3, 1, /*sym*/ 1);  // gap on symbol 1 only
+  h.feed(2, 1, /*sym*/ 2);
+  CHECK(h.gaps.size() == 1 && h.gaps[0] == 2);
+  CHECK(h.delivered.size() == 3);  // 1@1, 1@2, 2@2; 3@1 held
+  h.feed(2, 1, /*sym*/ 1);
+  CHECK(h.delivered.size() == 5);
+  CHECK(h.gd.expected(1) == 4 && h.gd.expected(2) == 3);
+}
+
+void test_gap_detector_held_overflow()
+{
+  std::printf("test_gap_detector_held_overflow\n");
+  // maxHeld overflow abandons the gap: everything held is delivered in seq
+  // order (with the hole) rather than buffered forever -- held-out datagrams
+  // are never lost.
+  GdHarness h(GapDetector::Config{100, 4});
+  h.feed(1);
+  for (uint64_t s = 3; s <= 7; ++s)  // 2 never arrives; 5 held > maxHeld=4 -> flush
+  {
+    h.feed(s);
+  }
+  CHECK((h.delivered == std::vector<uint64_t>{1, 3, 4, 5, 6, 7}));
+  CHECK(!h.gaps.empty() && h.gaps[0] == 2);
+  h.feed(8);  // stream continues normally after the flush
+  CHECK(h.delivered.back() == 8);
+}
+
 }  // namespace
 
 TEST(Marketdata, EngineSuite)
@@ -268,6 +407,11 @@ TEST(Marketdata, EngineSuite)
   test_l2_and_codec();
   test_book_agreement();
   test_iceberg_hidden_from_md();
+  test_gap_detector_reordering();
+  test_gap_detector_reraise();
+  test_gap_detector_epoch_change();
+  test_gap_detector_per_symbol();
+  test_gap_detector_held_overflow();
   std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
   EXPECT_EQ(g_failures, 0);
 }

--- a/venue/tests/test_venue_md_recovery.cpp
+++ b/venue/tests/test_venue_md_recovery.cpp
@@ -1,0 +1,649 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Market-data snapshot + recovery, end to end over real sockets: a late joiner
+ * detects the gap, fetches a snapshot through MdRecoveryClient (the consumer
+ * round-trip: request -> classified reply -> GapDetector reset) and converges
+ * on the reference book; a publisher restart surfaces as an epoch change and
+ * the consumer re-snapshots instead of stalling; the resend ring replays a
+ * tail; sendto failures are counted, never blocking.
+ */
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/md_recovery.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/resend_buffer.h"
+#include "flox-venue/udp_multicast.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdio>
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// Minimal MD consumer book: per-order state driven by the public feed, folded
+// to (side, price) -> aggregate qty for comparisons.
+struct ConsumerBook
+{
+  struct O
+  {
+    Side side{};
+    Price price{};
+    Quantity qty{};
+  };
+  std::unordered_map<OrderId, O> orders;
+
+  void clear() { orders.clear(); }
+
+  void apply(const MdMessage& m)
+  {
+    switch (m.type)
+    {
+      case MdType::AddOrder:
+        orders[m.id] = O{m.side, m.price, m.qty};
+        break;
+      case MdType::Executed:
+      {
+        auto it = orders.find(m.id);
+        if (it != orders.end())
+        {
+          it->second.qty = m.qty;
+          if (m.qty.raw() == 0)
+          {
+            orders.erase(it);
+          }
+        }
+        break;
+      }
+      case MdType::Cancel:
+        orders.erase(m.id);
+        break;
+      case MdType::Replace:
+        orders[m.id] = O{m.side, m.price, m.qty};
+        break;
+      case MdType::Trade:
+      case MdType::Triggered:
+        break;  // no direct depth impact (depth moves via Executed)
+    }
+  }
+
+  std::map<std::pair<int, int64_t>, int64_t> levels() const
+  {
+    std::map<std::pair<int, int64_t>, int64_t> lv;
+    for (const auto& [id, o] : orders)
+    {
+      if (o.qty.raw() > 0)
+      {
+        lv[{static_cast<int>(o.side), o.price.raw()}] += o.qty.raw();
+      }
+    }
+    return lv;
+  }
+};
+
+bool sameBook(const ConsumerBook& a, const ConsumerBook& b) { return a.levels() == b.levels(); }
+
+// All recovery round-trips below go through MdRecoveryClient -- the test IS
+// the documentation of the consumer protocol the client packages.
+MdRecoveryClient client(int port)
+{
+  return MdRecoveryClient("127.0.0.1", static_cast<uint16_t>(port));
+}
+
+// Probe whether same-host multicast works (CI containers often block it);
+// fall back to loopback unicast exactly like the existing UDP MD test.
+bool probeMulticast()
+{
+  const char* group = "239.7.7.9";
+  const char* iface = "127.0.0.1";
+  UdpMdSubscriber sub;
+  if (!sub.join(group, 0, true, iface))
+  {
+    return false;
+  }
+  sub.setTimeout(200);
+  UdpMdPublisher pub;
+  if (!pub.open(group, static_cast<uint16_t>(sub.port()), true, iface))
+  {
+    return false;
+  }
+  pub.publish(MdMessage{MdType::Trade, 1, SYM, 1, Side::BUY, px(100), qty(1), 0, 1});
+  MdMessage m;
+  return sub.recv(m);
+}
+
+bool g_multicast = false;
+
+bool setupUdp(UdpMdPublisher& pub, UdpMdSubscriber& sub, const char* group)
+{
+  const char* iface = "127.0.0.1";
+  if (!sub.join(group, 0, g_multicast, iface))
+  {
+    return false;
+  }
+  sub.setTimeout(300);
+  return pub.open(g_multicast ? group : "127.0.0.1", static_cast<uint16_t>(sub.port()),
+                  g_multicast, iface);
+}
+
+// Late joiner: misses the start of the stream. RecoveringMdSubscriber (the
+// packaged consumer protocol: gap accounting + TCP round-trip + sequencer
+// fast-forward) detects the gap, fetches the snapshot (fromSeq older than the
+// ring -> SnapshotRequired path), hands the body to the onSnapshot callback,
+// resumes the incremental feed and converges on the reference consumer's
+// book. The low-level protocol cases stay in test_resend_served -- this test
+// covers the composed consumer.
+void test_late_joiner_snapshot()
+{
+  std::printf("test_late_joiner_snapshot\n");
+  MdCounters counters;
+  ConsumerBook refBook;  // reference consumer: sees the stream from seq 1
+  UdpMdPublisher udpPub;
+  UdpMdSubscriber sub;
+  CHECK(setupUdp(udpPub, sub, "239.7.8.1"));
+  udpPub.setCounters(&counters);
+
+  // Small ring so a from-genesis resend is impossible: the late joiner MUST be
+  // routed through the snapshot path.
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           {
+                             refBook.apply(m);
+                             udpPub.publish(m); },
+                           px(0.01), SYM, /*epoch*/ 0, /*resendCapacity*/ 8);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e); });
+  MdRecoveryServer rec(&counters);
+  rec.addPublisher(md);
+  CHECK(rec.start(0) > 0);
+
+  // Phase A (missed by the late joiner): resting depth + a partial fill.
+  for (int i = 1; i <= 5; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i, i));
+  }
+  for (int i = 1; i <= 5; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(5 + i), Side::BUY, 100 - i, i));
+  }
+  eng.submit(limit(11, Side::BUY, 101, 0.5, 2));  // trades 0.5 against id1
+  CHECK(md.seq() > 8);                            // more than the ring retains
+
+  // The late joiner was not listening: drop everything received so far.
+  {
+    MdMessage m;
+    while (sub.recv(m))
+    {
+    }
+  }
+
+  // Attach the recovering consumer over the raw subscriber.
+  RecoveringMdSubscriber::Config rc;
+  rc.host = "127.0.0.1";
+  rc.port = static_cast<uint16_t>(rec.port());
+  RecoveringMdSubscriber rsub(sub, rc);
+  ConsumerBook lateBook;
+  uint64_t snapshotLastSeq = 0;
+  rsub.onSnapshot([&](SymbolId sym, const MdSnapshotBegin& b, const std::vector<MdMessage>& orders)
+                  {
+                    CHECK(sym == SYM);
+                    CHECK(b.epoch == md.epoch());
+                    CHECK(b.orderCount == orders.size());
+                    snapshotLastSeq = b.lastSeq;
+                    lateBook.clear();
+                    for (const auto& m : orders)
+                    {
+                      CHECK(m.type == MdType::AddOrder);
+                      CHECK(m.epoch == b.epoch);
+                      lateBook.apply(m);
+                    } });
+
+  // Phase B: live traffic the late joiner receives but cannot deliver until
+  // the snapshot recovery has run (everything is ahead of the missing prefix).
+  eng.submit(CancelOrder{2, SYM, 1});
+  eng.submit(ModifyOrder{3, SYM, px(106), qty(2), 1});
+  eng.submit(limit(12, Side::SELL, 107, 3));
+  const uint64_t targetB = md.seq();
+
+  // Position = the later of the snapshot resume point and the last delivered
+  // increment (the snapshot may already cover everything published so far).
+  uint64_t appliedSeq = 0;
+  const auto position = [&]
+  { return appliedSeq > snapshotLastSeq ? appliedSeq : snapshotLastSeq; };
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (position() < targetB && std::chrono::steady_clock::now() < deadline)
+    {
+      MdMessage m;
+      if (!rsub.recv(m))
+      {
+        continue;
+      }
+      CHECK(m.seq == appliedSeq + 1 || appliedSeq == 0);  // strictly in order
+      lateBook.apply(m);
+      appliedSeq = m.seq;
+    }
+  }
+  CHECK(rsub.gapsDetected() >= 1);        // the missing prefix surfaced as a gap
+  CHECK(rsub.snapshotsRecovered() == 1);  // resolved through the snapshot path
+  CHECK(snapshotLastSeq >= 8);            // the snapshot really covered the prefix
+  CHECK(counters.snapshotsServed.load() == 1);
+  CHECK(position() == targetB);
+  CHECK(rsub.expected(SYM) == targetB + 1);
+  CHECK(sameBook(lateBook, refBook));  // snapshot + resumed increments == reference
+
+  // Phase C: the incremental feed keeps both books in step with no further
+  // recovery round-trips.
+  eng.submit(limit(13, Side::BUY, 94, 2));
+  eng.submit(CancelOrder{6, SYM, 1});
+  eng.submit(limit(14, Side::BUY, 103, 10, 2));  // sweeps the 101 remainder, rests at 103
+  const uint64_t target = md.seq();
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (position() < target && std::chrono::steady_clock::now() < deadline)
+  {
+    MdMessage m;
+    if (!rsub.recv(m))
+    {
+      continue;
+    }
+    lateBook.apply(m);
+    appliedSeq = m.seq;
+  }
+  CHECK(position() == target);
+  CHECK(appliedSeq == target);            // phase C really flowed as increments
+  CHECK(rsub.snapshotsRecovered() == 1);  // no extra recovery was needed
+  CHECK(sameBook(lateBook, refBook));
+  rec.stop();
+}
+
+// Resend ring: a gap inside the retained tail is replayed byte-for-byte; a
+// fromSeq past the head is an empty replay, not a snapshot.
+void test_resend_served()
+{
+  std::printf("test_resend_served\n");
+  MdCounters counters;
+  std::vector<MdMessage> sent;
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { sent.push_back(m); }, px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e); });
+  MdRecoveryServer rec(&counters);
+  rec.addPublisher(md);
+  CHECK(rec.start(0) > 0);
+
+  for (int i = 1; i <= 10; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(i), i % 2 ? Side::SELL : Side::BUY,
+                     i % 2 ? 100 + i : 100 - i, i));
+  }
+  const uint64_t last = md.seq();
+  CHECK(last == sent.size());
+
+  MdRecoveryClient::Result mid;
+  CHECK(client(rec.port()).recover(SYM, 5, mid) == MdRecoveryClient::Status::Ok);
+  CHECK(!mid.snapshot);
+  CHECK(mid.messages.size() == last - 4);
+  for (size_t i = 0; i < mid.messages.size(); ++i)
+  {
+    CHECK(mid.messages[i].seq == 5 + i);
+    CHECK(mid.messages[i].epoch == md.epoch());
+    CHECK(mid.messages[i].id == sent[4 + i].id);
+    CHECK(mid.messages[i].qty == sent[4 + i].qty);
+  }
+  CHECK(mid.lastSeq == last && mid.epoch == md.epoch());
+  CHECK(counters.resendServed.load() == 1);
+
+  MdRecoveryClient::Result all;
+  CHECK(client(rec.port()).recover(SYM, 1, all) == MdRecoveryClient::Status::Ok);
+  CHECK(!all.snapshot && all.messages.size() == last);
+
+  MdRecoveryClient::Result ahead;  // nothing published past `last` yet
+  CHECK(client(rec.port()).recover(SYM, last + 1, ahead) == MdRecoveryClient::Status::Ok);
+  CHECK(!ahead.snapshot && ahead.messages.empty());
+  CHECK(ahead.lastSeq == last);  // empty replay keeps the consumer's position
+  CHECK(counters.snapshotsServed.load() == 0);
+
+  // A trimmed-out fromSeq flips to the snapshot path (small ring).
+  MdCounters counters2;
+  MarketDataPublisher<> md2([](const MdMessage&) {}, px(0.01), SYM, 0, /*resendCapacity*/ 4);
+  MatchingEngine<MatchingBook> eng2(cfg(), [&](const OutboundEvent& e)
+                                    { md2.onEvent(e); });
+  MdRecoveryServer rec2(&counters2);
+  rec2.addPublisher(md2);
+  CHECK(rec2.start(0) > 0);
+  for (int i = 1; i <= 10; ++i)
+  {
+    eng2.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i, i));
+  }
+  MdRecoveryClient::Result old;
+  CHECK(client(rec2.port()).recover(SYM, 2, old) == MdRecoveryClient::Status::Ok);
+  CHECK(old.snapshot);
+  CHECK(old.messages.size() == 10);  // all ten still resting
+  CHECK(counters2.snapshotsServed.load() == 1 && counters2.resendServed.load() == 0);
+
+  // A dead server is an honest ConnectError, not an exception or a hang.
+  const int deadPort = rec2.port();
+  rec2.stop();
+  MdRecoveryClient::Result none;
+  CHECK(client(deadPort).recover(SYM, 1, none) == MdRecoveryClient::Status::ConnectError);
+  rec.stop();
+}
+
+// Publisher restart: the surviving RecoveringMdSubscriber sees the epoch
+// change, drops its stale book through the onSnapshot callback (fromSeq=0
+// snapshot recovery) and keeps consuming -- never a silent stall where every
+// message of the restarted feed counts as a duplicate.
+void test_publisher_restart_epoch()
+{
+  std::printf("test_publisher_restart_epoch\n");
+  MdCounters counters;
+  UdpMdPublisher udpPub;
+  UdpMdSubscriber sub;
+  CHECK(setupUdp(udpPub, sub, "239.7.8.2"));
+  MdRecoveryServer rec(&counters);
+  CHECK(rec.start(0) > 0);
+
+  ConsumerBook consumer;
+  ConsumerBook ref2;  // reference for the second publisher lifetime
+
+  RecoveringMdSubscriber::Config rc;
+  rc.host = "127.0.0.1";
+  rc.port = static_cast<uint16_t>(rec.port());
+  RecoveringMdSubscriber rsub(sub, rc);
+  uint64_t snapshotEpoch = 0;
+  rsub.onSnapshot([&](SymbolId sym, const MdSnapshotBegin& b, const std::vector<MdMessage>& orders)
+                  {
+                    CHECK(sym == SYM);
+                    snapshotEpoch = b.epoch;
+                    consumer.clear();  // the pre-restart book is void
+                    for (const auto& m : orders)
+                    {
+                      consumer.apply(m);
+                    } });
+
+  auto md1 = std::make_unique<MarketDataPublisher<>>([&](const MdMessage& m)
+                                                     { udpPub.publish(m); }, px(0.01), SYM);
+  rec.addPublisher(*md1);
+  const uint64_t epoch1 = md1->epoch();
+  {
+    MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                     { md1->onEvent(e); });
+    eng.submit(limit(1, Side::SELL, 101, 1));
+    eng.submit(limit(2, Side::BUY, 99, 2));
+    const uint64_t t1 = md1->seq();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    uint64_t applied = 0;
+    while (applied < t1 && std::chrono::steady_clock::now() < deadline)
+    {
+      MdMessage m;
+      if (rsub.recv(m))
+      {
+        consumer.apply(m);
+        applied = m.seq;
+      }
+    }
+    CHECK(applied == t1);
+    CHECK(rsub.epochChanges() == 0);  // first lifetime: nothing to recover
+  }
+
+  // Restart: a fresh publisher for the same symbol -- new epoch, seq back to 1.
+  auto md2 = std::make_unique<MarketDataPublisher<>>([&](const MdMessage& m)
+                                                     {
+                                                       ref2.apply(m);
+                                                       udpPub.publish(m); },
+                                                     px(0.01), SYM);
+  rec.addPublisher(*md2);  // replaces the source for SYM
+  md1.reset();
+  CHECK(md2->epoch() != epoch1);
+  MatchingEngine<MatchingBook> eng2(cfg(), [&](const OutboundEvent& e)
+                                    { md2->onEvent(e); });
+  eng2.submit(limit(1, Side::SELL, 105, 3));  // ids restart too: a different book
+  eng2.submit(limit(2, Side::BUY, 95, 4));
+  eng2.submit(limit(3, Side::SELL, 106, 1));
+  const uint64_t t2 = md2->seq();
+
+  // The wrapper handles the whole restart protocol inside recv(): epoch
+  // change -> snapshot recovery -> fast-forward -> continue the new stream.
+  // The snapshot may already cover everything published in the new lifetime,
+  // so the position is the later of the resume point and delivered seqs.
+  uint64_t applied = 0;
+  uint64_t snapLastSeq = 0;
+  rsub.onSnapshot([&](SymbolId sym, const MdSnapshotBegin& b, const std::vector<MdMessage>& orders)
+                  {
+                    CHECK(sym == SYM);
+                    snapshotEpoch = b.epoch;
+                    snapLastSeq = b.lastSeq;
+                    consumer.clear();  // the pre-restart book is void
+                    for (const auto& m : orders)
+                    {
+                      consumer.apply(m);
+                    } });
+  const auto position = [&]
+  { return applied > snapLastSeq ? applied : snapLastSeq; };
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (position() < t2 && std::chrono::steady_clock::now() < deadline)
+  {
+    MdMessage m;
+    if (!rsub.recv(m))
+    {
+      continue;
+    }
+    CHECK(m.epoch == md2->epoch());  // stale-epoch datagrams never surface
+    consumer.apply(m);
+    applied = m.seq;
+  }
+  CHECK(rsub.epochChanges() == 1);
+  CHECK(rsub.snapshotsRecovered() >= 1);
+  CHECK(snapshotEpoch == md2->epoch());
+  CHECK(position() == t2);  // the feed kept flowing after the restart
+  CHECK(rsub.expected(SYM) == t2 + 1);
+  CHECK(sameBook(consumer, ref2));
+  CHECK(counters.snapshotsServed.load() >= 1);
+  rec.stop();
+}
+
+// Recovery-channel failure: attempts are bounded with doubling backoff, the
+// failure is counted, recv() degrades to a timeout instead of hanging -- and
+// once the resend server is back, the SAME gap (re-raised by the detector)
+// recovers through the ring replay path.
+void test_recovery_backoff_bounded()
+{
+  std::printf("test_recovery_backoff_bounded\n");
+  UdpMdPublisher pub;
+  UdpMdSubscriber sub;
+  CHECK(setupUdp(pub, sub, "239.7.8.4"));
+  sub.setTimeout(100);
+
+  MdCounters counters;
+  // Lossy wire: seq 2 never reaches the subscriber (it stays on the resend
+  // ring) -- the manufactured gap this test recovers.
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           {
+                             if (m.seq != 2)
+                             {
+                               pub.publish(m);
+                             } },
+                           px(0.01), SYM, /*epoch*/ 7);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e); });
+  MdRecoveryServer rec(&counters);
+  rec.addPublisher(md);
+  const int port = rec.start(0);
+  CHECK(port > 0);
+  rec.stop();  // server down: every recovery round-trip is a ConnectError
+
+  RecoveringMdSubscriber::Config rc;
+  rc.host = "127.0.0.1";
+  rc.port = static_cast<uint16_t>(port);
+  rc.maxAttempts = 2;
+  rc.initialBackoff = std::chrono::milliseconds(5);
+  // reraiseAfter=2: the still-open gap re-raises quickly once traffic flows.
+  RecoveringMdSubscriber rsub(sub, rc, GapDetector::Config{2, 1024});
+
+  eng.submit(limit(1, Side::SELL, 101, 1));  // seq 1: delivered normally
+  {
+    MdMessage m;
+    CHECK(rsub.recv(m));
+    CHECK(m.seq == 1);
+  }
+  eng.submit(limit(2, Side::BUY, 99, 1));    // seq 2: dropped by the lossy wire
+  eng.submit(limit(3, Side::SELL, 102, 1));  // seq 3: opens the gap at 2
+  // recv: gap at 2 -> recovery attempts (server down) -> bounded failure ->
+  // timeout, not a hang.
+  {
+    MdMessage m;
+    const bool got = rsub.recv(m);
+    CHECK(!got);  // nothing deliverable, recovery failed, clean timeout
+  }
+  CHECK(rsub.gapsDetected() >= 1);
+  CHECK(rsub.recoveriesFailed() == 1);
+  CHECK(rsub.resendsRecovered() == 0);
+
+  // Server returns; further traffic re-raises the gap; the ring replays 2..
+  CHECK(rec.start(static_cast<uint16_t>(port)) == port);
+  eng.submit(limit(4, Side::BUY, 98, 1));    // seq 4
+  eng.submit(limit(5, Side::SELL, 103, 1));  // seq 5 (re-raise threshold)
+  std::vector<uint64_t> seqs;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (seqs.size() < 4 && std::chrono::steady_clock::now() < deadline)
+  {
+    MdMessage m;
+    if (rsub.recv(m))
+    {
+      seqs.push_back(m.seq);
+    }
+  }
+  CHECK(seqs.size() == 4);  // 2, 3, 4, 5 -- the hole filled, strictly in order
+  for (size_t i = 0; i < seqs.size(); ++i)
+  {
+    CHECK(seqs[i] == 2 + i);
+  }
+  CHECK(rsub.resendsRecovered() >= 1);
+  rec.stop();
+}
+
+// MdRecoveryServer beyond loopback: an explicit bind address ("0.0.0.0")
+// exposes the channel on all interfaces (hardening contract documented in
+// market-data.md: TLS termination / firewall in front); the loopback client
+// still reaches it, and the default remains loopback-only.
+void test_recovery_server_bind_address()
+{
+  std::printf("test_recovery_server_bind_address\n");
+  MdCounters counters;
+  MarketDataPublisher<> md([](const MdMessage&) {}, px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e); });
+  for (int i = 1; i <= 3; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i, i));
+  }
+
+  MdRecoveryServer rec(&counters);
+  rec.addPublisher(md);
+  const int port = rec.start(0, "0.0.0.0");  // all interfaces (safe in CI: connect via loopback)
+  CHECK(port > 0);
+  MdRecoveryClient::Result all;
+  CHECK(client(port).recover(SYM, 1, all) == MdRecoveryClient::Status::Ok);
+  CHECK(!all.snapshot && all.messages.size() == 3);
+  rec.stop();
+
+  // A garbage bind address fails loudly instead of silently binding loopback.
+  MdRecoveryServer bad(&counters);
+  bad.addPublisher(md);
+  CHECK(bad.start(0, "not-an-address") == -1);
+}
+
+// sendto failures are counted as drops and never block or throw.
+void test_send_drop_counted()
+{
+  std::printf("test_send_drop_counted\n");
+  MdCounters counters;
+  UdpMdPublisher pub;
+  pub.setCounters(&counters);
+  // Closed socket: the datagram cannot leave -- a counted drop, not a wait.
+  const MdMessage m{MdType::Trade, 1, SYM, 1, Side::BUY, px(100), qty(1), 0, 1};
+  CHECK(!pub.publish(m));
+  CHECK(counters.sendDrops.load() == 1);
+
+  // A healthy socket publishes without touching the counter.
+  UdpMdSubscriber sub;
+  CHECK(sub.join("239.7.8.3", 0, false, "127.0.0.1"));
+  sub.setTimeout(300);
+  CHECK(pub.open("127.0.0.1", static_cast<uint16_t>(sub.port()), false));
+  CHECK(pub.publish(m));
+  CHECK(counters.sendDrops.load() == 1);
+  MdMessage got;
+  CHECK(sub.recv(got));
+  CHECK(got.seq == 1 && got.epoch == 1);
+}
+
+}  // namespace
+
+TEST(MdRecovery, EngineSuite)
+{
+  g_multicast = probeMulticast();
+  std::printf("  UDP path: %s\n", g_multicast ? "multicast" : "unicast fallback");
+  test_late_joiner_snapshot();
+  test_resend_served();
+  test_publisher_restart_epoch();
+  test_recovery_backoff_bounded();
+  test_recovery_server_bind_address();
+  test_send_drop_counted();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_mm.cpp
+++ b/venue/tests/test_venue_mm.cpp
@@ -152,9 +152,10 @@ void test_last_look()
   }
 }
 
-// Last-look reject/timeout must return BOTH parties' held buying power to
-// available -- otherwise it is stranded in `reserved` forever and the taker is
-// never made whole for a fill that never happened.
+// Last-look reject/timeout restores both legs to the book (the maker's
+// displayed qty back at its level, the GTC taker residual rests), so the
+// reservations KEEP backing the restored resting orders -- nothing stranded,
+// nothing double-released -- and canceling the restored orders frees it all.
 void test_last_look_reject_releases_reservation()
 {
   std::printf("test_last_look_reject_releases_reservation\n");
@@ -179,12 +180,21 @@ void test_last_look_reject_releases_reservation()
   CHECK(h != nullptr);
   eng.submit(InboundCommand{LastLookDecision{h->heldId, SYM, false, 1}}, 2);  // reject
   CHECK(cap.trades() == 0);
-  // Both parties fully made whole: reservations returned, no fill happened.
-  CHECK(led.available(1, BASE) == base3 && led.reserved(1, BASE) == 0);     // maker
-  CHECK(led.available(2, QUOTE) == usd300 && led.reserved(2, QUOTE) == 0);  // taker
+  // Liquidity restored: maker's ask is back, the taker's GTC residual rests.
+  CHECK(eng.book().bestAsk() == px(100));
+  CHECK(eng.book().bestBid() == px(100));
+  // Reservations still back the restored resting orders.
+  CHECK(led.available(1, BASE) == 0 && led.reserved(1, BASE) == base3);     // maker
+  CHECK(led.available(2, QUOTE) == 0 && led.reserved(2, QUOTE) == usd300);  // taker
   // Conservation: nothing created or destroyed.
   CHECK(led.total(1, BASE) == base3);
   CHECK(led.total(2, QUOTE) == usd300);
+  // Cancel the restored orders: every reserved unit returns to available.
+  eng.submit(InboundCommand{CancelOrder{1, SYM, 1}}, 3);
+  eng.submit(InboundCommand{CancelOrder{2, SYM, 2}}, 4);
+  CHECK(eng.book().empty());
+  CHECK(led.available(1, BASE) == base3 && led.reserved(1, BASE) == 0);
+  CHECK(led.available(2, QUOTE) == usd300 && led.reserved(2, QUOTE) == 0);
 }
 
 void test_mmp()

--- a/venue/tests/test_venue_prorata.cpp
+++ b/venue/tests/test_venue_prorata.cpp
@@ -162,6 +162,49 @@ void run(const std::function<Book()>& mk, const char* label)
     CHECK(cap.total() == qty(16));
     CHECK(eng.book().empty());
   }
+  {  // defensive: a lastLook maker planted PAST validate() is skipped, not
+     // filled as firm -- pro-rata cannot hold a slice, so filling it would
+     // fake firmness the maker never granted. The counter records the event;
+     // the allocation over the firm participants is unchanged.
+    Cap cap;
+    Matcher<Book> m(MatchPolicy::ProRata);
+    Book book = mk();
+    RestingOrder ll{1, 1, px(100), qty(5), Side::SELL};
+    ll.lastLook = true;  // only possible here by bypassing admission
+    book.addResting(Side::SELL, ll);
+    book.addResting(Side::SELL, RestingOrder{2, 1, px(100), qty(2), Side::SELL});
+    book.addResting(Side::SELL, RestingOrder{3, 1, px(100), qty(3), Side::SELL});
+    uint64_t seq = 0;
+    const NewOrder agg = limit(9, Side::BUY, 100, 4, 2);
+    const MatchOutcome out = m.cross(agg, book, [&]
+                                     { return ++seq; }, cap.sink());
+    CHECK(cap.forMaker(1).isZero());     // the LL maker never fills
+    CHECK(cap.forMaker(2) == qty(1.6));  // 4 pro-rata over firm 2/3
+    CHECK(cap.forMaker(3) == qty(2.4));
+    CHECK(cap.total() == qty(4));
+    CHECK(out.takerComplete);
+    CHECK(m.skippedLastLookProRata() >= 1);  // defensive path counted
+    CHECK(book.find(1) != nullptr);
+    CHECK(book.find(1)->leaves == qty(5));  // LL maker untouched on the book
+  }
+  {  // defensive: a level that is ONLY lastLook liquidity stops the sweep --
+     // the aggressor residual follows its TIF instead of faking a fill
+    Cap cap;
+    Matcher<Book> m(MatchPolicy::ProRata);
+    Book book = mk();
+    RestingOrder ll{1, 1, px(100), qty(5), Side::SELL};
+    ll.lastLook = true;
+    book.addResting(Side::SELL, ll);
+    uint64_t seq = 0;
+    const NewOrder agg = limit(9, Side::BUY, 100, 4, 2);
+    const MatchOutcome out = m.cross(agg, book, [&]
+                                     { return ++seq; }, cap.sink());
+    CHECK(cap.trades() == 0);
+    CHECK(out.leaves == qty(4));
+    CHECK(out.residualRests);  // GTC residual rests as usual
+    CHECK(m.skippedLastLookProRata() >= 1);
+    CHECK(book.find(1)->leaves == qty(5));
+  }
 }
 
 }  // namespace

--- a/venue/tests/test_venue_recovery.cpp
+++ b/venue/tests/test_venue_recovery.cpp
@@ -1,0 +1,495 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * WAL lifecycle and genesis-in-the-WAL:
+ * - a shard restart replays its journal instead of truncating it (the O_TRUNC
+ *   regression), including after a hard process death (fork + _exit);
+ * - the shard journals real, monotonic timestamps and feeds the SAME value to
+ *   the engine, so time-dependent behaviour (last-look expiry) replays exactly;
+ * - deposits/withdrawals and instrument configuration are sequenced commands,
+ *   so a replay from an EMPTY ledger/registry reproduces balances and config.
+ */
+#include "flox-venue/control_plane.h"
+#include "flox-venue/event_hash.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/sequenced_shard.h"
+
+#include <gtest/gtest.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE_ACCT = 900;
+constexpr uint64_t kHashSeed = 1469598103934665603ULL;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+int64_t baseRaw(double v) { return static_cast<int64_t>(amountOf(qty(v))); }
+int64_t quoteRaw(double v) { return static_cast<int64_t>(amountOf(Volume::fromDouble(v))); }
+int64_t i64(Amount a) { return static_cast<int64_t>(a); }
+
+venue::SymbolConfig cfg()
+{
+  venue::SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// Deterministic injected clock: base + step, base + 2*step, ...
+SequencedShard<>::TimeSource stepClock(int64_t base, int64_t step)
+{
+  auto t = std::make_shared<int64_t>(base);
+  return [t, step]()
+  {
+    *t += step;
+    return *t;
+  };
+}
+
+struct HashSink : IEngineEventListener
+{
+  uint64_t h = kHashSeed;
+  uint64_t count = 0;
+  uint64_t fillHeld = 0;
+  uint64_t fillRejected = 0;
+  void onEngineEvent(const EngineEventMsg& e) override
+  {
+    h = hashEvent(h, e.event);
+    ++count;
+    if (std::get_if<FillHeld>(&e.event))
+    {
+      ++fillHeld;
+    }
+    if (std::get_if<FillRejected>(&e.event))
+    {
+      ++fillRejected;
+    }
+  }
+};
+
+bool ledgersEqual(const Ledger& a, const Ledger& b, int maxAcct)
+{
+  for (int acct = 1; acct <= maxAcct; ++acct)
+  {
+    for (AssetId asset : {BASE, QUOTE})
+    {
+      if (a.available(acct, asset) != b.available(acct, asset) ||
+          a.reserved(acct, asset) != b.reserved(acct, asset))
+      {
+        return false;
+      }
+    }
+  }
+  return a.total(VENUE_ACCT, BASE) == b.total(VENUE_ACCT, BASE) &&
+         a.total(VENUE_ACCT, QUOTE) == b.total(VENUE_ACCT, QUOTE);
+}
+
+// The command stream the crashing child feeds its shard: journaled genesis
+// deposits, then crossing flow that leaves resting orders and reservations.
+std::vector<InboundCommand> childCommands()
+{
+  std::vector<InboundCommand> v;
+  v.emplace_back(Deposit{1, BASE, baseRaw(1000), SYM});
+  v.emplace_back(Deposit{2, QUOTE, quoteRaw(100000), SYM});
+  for (uint64_t i = 0; i < 20; ++i)
+  {
+    v.emplace_back(limit(100 + 2 * i, Side::SELL, 100.0 + static_cast<double>(i % 5) * 0.01, 1.0, 1));
+    v.emplace_back(limit(101 + 2 * i, Side::BUY, 100.0 + static_cast<double>(i % 5) * 0.01, 0.5, 2));
+  }
+  v.emplace_back(CancelOrder{100, SYM, 1});
+  v.emplace_back(Withdraw{2, QUOTE, quoteRaw(10), SYM});
+  return v;
+}
+
+}  // namespace
+
+// A shard dies mid-stream via _exit (no stop(), no flush of the tail); a new
+// shard on the same journal must recover the intact prefix and then behave
+// exactly like a reference engine that was fed that prefix directly.
+TEST(VenueRecovery, ProcessDeathRecoversFromJournal)
+{
+  const std::string path = "/tmp/flox_test_venue_recovery_procdeath.bin";
+  std::remove(path.c_str());
+
+  const auto cmds = childCommands();
+  const size_t half = cmds.size() / 2;
+
+  const pid_t pid = fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0)
+  {
+    // Child: a real shard (journal Sync::Full so every appended record survives
+    // the death), killed without any clean shutdown.
+    Ledger led;
+    auto shard = std::make_unique<SequencedShard<>>(cfg(), path);
+    shard->engine().setLedger(&led, VENUE_ACCT);
+    HashSink sink;
+    shard->subscribeOutbound(&sink);
+    shard->start();
+    for (size_t i = 0; i < half; ++i)
+    {
+      shard->submit(cmds[i]);
+    }
+    shard->flush();  // the first half is guaranteed journaled
+    for (size_t i = half; i < cmds.size(); ++i)
+    {
+      shard->submit(cmds[i]);
+    }
+    _exit(0);  // hard death: no stop(), consumer possibly mid-record
+  }
+
+  int status = 0;
+  ASSERT_EQ(::waitpid(pid, &status, 0), pid);
+  ASSERT_TRUE(WIFEXITED(status));
+
+  // The journal holds an intact prefix: at least the flushed half, never more
+  // than what was submitted, with strictly increasing non-zero timestamps.
+  const auto records = Journal::loadTimed(path);
+  ASSERT_GE(records.size(), half);
+  ASSERT_LE(records.size(), cmds.size());
+  int64_t prevTs = 0;
+  for (const auto& [ts, cmd] : records)
+  {
+    EXPECT_GT(ts, prevTs);
+    prevTs = ts;
+  }
+
+  // Reference: a fresh engine + EMPTY ledger fed the journal directly.
+  Ledger refLed;
+  uint64_t refH = kHashSeed;
+  MatchingEngine<MatchingBook> ref(cfg(), [&](const OutboundEvent& e)
+                                   { refH = hashEvent(refH, e); });
+  ref.setLedger(&refLed, VENUE_ACCT);
+  for (const auto& [ts, cmd] : records)
+  {
+    ref.submit(cmd, ts);
+  }
+
+  // Recovered shard: same journal, EMPTY ledger; recovery must run before
+  // service and reconstruct the identical book and balances.
+  const int64_t tailBase = records.back().first + 1'000'000;
+  Ledger recLed;
+  HashSink sink;
+  auto shard = std::make_unique<SequencedShard<>>(cfg(), path, MatchingBook{},
+                                                  Journal::Sync::Full, stepClock(tailBase, 1000));
+  shard->engine().setLedger(&recLed, VENUE_ACCT);
+  shard->subscribeOutbound(&sink);
+  ASSERT_FALSE(shard->ready());
+  shard->start();
+  ASSERT_TRUE(shard->ready());
+  EXPECT_EQ(shard->recoveredCommands(), records.size());
+  EXPECT_EQ(sink.count, 0u);  // recovery does not re-broadcast history
+
+  EXPECT_EQ(shard->engine().book().bestBid(), ref.book().bestBid());
+  EXPECT_EQ(shard->engine().book().bestAsk(), ref.book().bestAsk());
+  EXPECT_TRUE(ledgersEqual(recLed, refLed, 2));
+
+  // Live equivalence: identical post-recovery traffic (same timestamps via the
+  // injected clock) must produce an identical event stream on both.
+  std::vector<InboundCommand> tail;
+  tail.emplace_back(limit(9001, Side::BUY, 100.04, 3.0, 2));
+  tail.emplace_back(CancelOrder{9001, SYM, 2});
+  tail.emplace_back(limit(9002, Side::SELL, 100.10, 1.0, 1));
+  refH = kHashSeed;  // isolate the tail stream on the reference
+  for (size_t i = 0; i < tail.size(); ++i)
+  {
+    shard->submit(tail[i]);
+    ref.submit(tail[i], tailBase + static_cast<int64_t>(i + 1) * 1000);
+  }
+  shard->flush();
+  EXPECT_EQ(sink.h, refH);
+  EXPECT_EQ(shard->engine().book().bestBid(), ref.book().bestBid());
+  EXPECT_EQ(shard->engine().book().bestAsk(), ref.book().bestAsk());
+  EXPECT_TRUE(ledgersEqual(recLed, refLed, 2));
+  shard->stop();
+
+  // The crashed prefix is still in the file, with the tail appended after it.
+  EXPECT_EQ(Journal::loadTimed(path).size(), records.size() + tail.size());
+  std::remove(path.c_str());
+}
+
+// The core O_TRUNC regression: constructing a shard on an existing journal
+// must not erase it -- the restart replays it and keeps appending.
+TEST(VenueRecovery, RestartPreservesAndReplaysJournal)
+{
+  const std::string path = "/tmp/flox_test_venue_recovery_restart.bin";
+  std::remove(path.c_str());
+
+  {
+    HashSink sink;
+    auto shard = std::make_unique<SequencedShard<>>(cfg(), path, MatchingBook{},
+                                                    Journal::Sync::Off, stepClock(1'000'000, 1000));
+    shard->subscribeOutbound(&sink);
+    shard->start();
+    EXPECT_EQ(shard->recoveredCommands(), 0u);  // fresh journal
+    shard->submit(InboundCommand{limit(1, Side::SELL, 100.00, 5.0, 1)});
+    shard->submit(InboundCommand{limit(2, Side::BUY, 99.50, 2.0, 2)});
+    shard->submit(InboundCommand{limit(3, Side::SELL, 100.50, 1.0, 1)});
+    shard->flush();
+    shard->stop();
+  }
+  const auto before = Journal::loadTimed(path);
+  ASSERT_EQ(before.size(), 3u);
+
+  {
+    HashSink sink;
+    auto shard = std::make_unique<SequencedShard<>>(cfg(), path, MatchingBook{},
+                                                    Journal::Sync::Off, stepClock(2'000'000, 1000));
+    shard->subscribeOutbound(&sink);
+    shard->start();
+    EXPECT_EQ(shard->recoveredCommands(), 3u);       // replayed, not wiped
+    EXPECT_EQ(Journal::loadTimed(path).size(), 3u);  // file intact after reopen
+    EXPECT_EQ(sink.count, 0u);                       // no outbound re-broadcast
+
+    // Recovered book equals a reference engine fed the same journal.
+    MatchingEngine<MatchingBook> ref(cfg(), [](const OutboundEvent&) {});
+    for (const auto& [ts, cmd] : before)
+    {
+      ref.submit(cmd, ts);
+    }
+    EXPECT_EQ(shard->engine().book().bestBid(), ref.book().bestBid());
+    EXPECT_EQ(shard->engine().book().bestAsk(), ref.book().bestAsk());
+
+    shard->submit(InboundCommand{CancelOrder{3, SYM, 1}});
+    shard->flush();
+    shard->stop();
+  }
+  // Appended after the recovered prefix; nothing truncated at any point.
+  const auto after = Journal::loadTimed(path);
+  ASSERT_EQ(after.size(), 4u);
+  int64_t prevTs = 0;
+  for (const auto& [ts, cmd] : after)
+  {
+    EXPECT_GT(ts, prevTs);  // monotonic across the restart too
+    prevTs = ts;
+  }
+  std::remove(path.c_str());
+}
+
+// The shard journals the same timestamp it feeds the engine, so a
+// time-dependent scenario (a last-look hold expiring) replays bit-for-bit.
+// With the old ts=0 journaling, the hold would never expire on replay.
+TEST(VenueRecovery, TimedReplayReproducesLastLookExpiry)
+{
+  const std::string path = "/tmp/flox_test_venue_recovery_lastlook.bin";
+  std::remove(path.c_str());
+
+  venue::SymbolConfig c = cfg();
+  c.lastLookWindowNs = 5'000;  // five clock steps
+  c.lastLookAcceptOnTimeout = false;
+
+  HashSink sink;
+  {
+    auto shard = std::make_unique<SequencedShard<>>(c, path, MatchingBook{}, Journal::Sync::Off,
+                                                    stepClock(1'000'000, 1000));
+    shard->subscribeOutbound(&sink);
+    shard->start();
+    NewOrder maker = limit(1, Side::SELL, 100.00, 5.0, 1);
+    maker.lastLook = true;
+    shard->submit(InboundCommand{maker});
+    shard->submit(InboundCommand{limit(2, Side::BUY, 100.00, 3.0, 2)});  // held fill
+    for (OrderId id = 900; id < 906; ++id)
+    {
+      shard->submit(InboundCommand{CancelOrder{id, SYM, 3}});  // advance time past the window
+    }
+    shard->flush();
+    shard->stop();
+  }
+  EXPECT_EQ(sink.fillHeld, 1u);
+  EXPECT_EQ(sink.fillRejected, 1u);  // the window elapsed live
+
+  const auto records = Journal::loadTimed(path);
+  ASSERT_EQ(records.size(), 8u);
+  int64_t prevTs = 0;
+  for (const auto& [ts, cmd] : records)
+  {
+    EXPECT_GT(ts, prevTs);  // non-zero, strictly monotonic sequencer time
+    prevTs = ts;
+  }
+
+  // loadTimed replay reproduces the live stream, including the timed expiry.
+  uint64_t recH = kHashSeed;
+  uint64_t recRejected = 0;
+  MatchingEngine<MatchingBook> rec(c, [&](const OutboundEvent& e)
+                                   {
+                                     recH = hashEvent(recH, e);
+                                     if (std::get_if<FillRejected>(&e))
+                                     {
+                                       ++recRejected;
+                                     } });
+  for (const auto& [ts, cmd] : records)
+  {
+    rec.submit(cmd, ts);
+  }
+  EXPECT_EQ(recRejected, 1u);
+  EXPECT_EQ(recH, sink.h);
+  std::remove(path.c_str());
+}
+
+// Deposits and withdrawals are journaled commands: replay from an EMPTY ledger
+// reproduces every balance, and an uncovered withdraw is rejected (no-op) so
+// conservation holds on both runs.
+TEST(VenueRecovery, GenesisReplaysFromEmptyLedger)
+{
+  const std::string path = "/tmp/flox_test_venue_recovery_genesis.bin";
+  std::remove(path.c_str());
+
+  const std::vector<std::pair<int64_t, InboundCommand>> cmds{
+      {1, InboundCommand{Deposit{1, BASE, baseRaw(10), SYM}}},
+      {2, InboundCommand{Deposit{2, QUOTE, quoteRaw(1000), SYM}}},
+      {10, InboundCommand{limit(1, Side::SELL, 100, 5, 1)}},
+      {20, InboundCommand{limit(2, Side::BUY, 100, 3, 2)}},            // trades 3 @ 100
+      {30, InboundCommand{Withdraw{2, QUOTE, quoteRaw(10000), SYM}}},  // > available: rejected
+      {40, InboundCommand{Withdraw{1, QUOTE, quoteRaw(100), SYM}}},    // covered: applied
+  };
+
+  auto run = [&](Ledger& led)
+  {
+    uint64_t h = kHashSeed;
+    MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                     { h = hashEvent(h, e); });
+    eng.setLedger(&led, VENUE_ACCT);
+    for (const auto& [ts, cmd] : cmds)
+    {
+      eng.submit(cmd, ts);
+    }
+    return h;
+  };
+
+  Ledger live;
+  {
+    Journal j(path);
+    for (const auto& [ts, cmd] : cmds)
+    {
+      j.append(cmd, ts);
+    }
+    j.flush();
+  }
+  const uint64_t liveH = run(live);
+
+  // Live semantics: the uncovered withdraw changed nothing; the covered one did.
+  EXPECT_EQ(i64(live.available(2, QUOTE)), quoteRaw(700));  // 1000 - 300 spent, withdraw rejected
+  EXPECT_EQ(i64(live.available(1, QUOTE)), quoteRaw(200));  // 300 proceeds - 100 withdrawn
+  EXPECT_EQ(i64(live.available(2, BASE)), baseRaw(3));
+
+  // Conservation: quote total across accounts + venue = deposited - withdrawn.
+  const Amount quoteTotal =
+      live.total(1, QUOTE) + live.total(2, QUOTE) + live.total(VENUE_ACCT, QUOTE);
+  EXPECT_EQ(i64(quoteTotal), quoteRaw(900));
+
+  // Replay from an EMPTY ledger: no seeding anywhere, balances identical.
+  const auto records = Journal::loadTimed(path);
+  ASSERT_EQ(records.size(), cmds.size());
+  Ledger rec;
+  EXPECT_EQ(i64(rec.available(1, BASE)), 0);
+  const uint64_t recH = run(rec);
+  EXPECT_EQ(recH, liveH);
+  EXPECT_TRUE(ledgersEqual(rec, live, 2));
+  std::remove(path.c_str());
+}
+
+// Instrument configuration is journaled: replaying ListInstrument + SetBands +
+// SetTriggerRef + AdminCmd(Halt) into a fresh registry and a fresh engine
+// reproduces the listed instrument, its bands, its trigger reference, and the
+// halt.
+TEST(VenueRecovery, ConfigReplayReproducesInstrumentState)
+{
+  const std::string path = "/tmp/flox_test_venue_recovery_config.bin";
+  std::remove(path.c_str());
+
+  const std::vector<std::pair<int64_t, InboundCommand>> cmds{
+      {10, InboundCommand{ListInstrument{SYM, px(0.01), Quantity{}, px(50), px(150)}}},
+      {20, InboundCommand{SetBands{SYM, px(90), px(110)}}},
+      {25, InboundCommand{SetTriggerRef{SYM, TriggerRef::Mark}}},
+      {30, InboundCommand{AdminCmd{SYM, AdminAction::Halt}}},
+  };
+  {
+    Journal j(path);
+    for (const auto& [ts, cmd] : cmds)
+    {
+      j.append(cmd, ts);
+    }
+    j.flush();
+  }
+
+  const auto records = Journal::loadTimed(path);
+  ASSERT_EQ(records.size(), cmds.size());
+
+  // Registry side: the WAL rebuilds the configuration store.
+  InstrumentRegistry reg;
+  for (const auto& [ts, cmd] : records)
+  {
+    EXPECT_TRUE(reg.apply(cmd));
+  }
+  ASSERT_TRUE(reg.has(SYM));
+  EXPECT_EQ(reg.get(SYM)->tickSize, px(0.01));
+  EXPECT_EQ(reg.get(SYM)->minPrice, px(90));
+  EXPECT_EQ(reg.get(SYM)->maxPrice, px(110));
+  EXPECT_EQ(reg.get(SYM)->triggerRef, TriggerRef::Mark);
+  EXPECT_TRUE(reg.get(SYM)->halted);
+
+  // Engine side: the same stream reproduces the tightened band and the halt.
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> fresh(cfg(), [&](const OutboundEvent& e)
+                                     { ev.push_back(e); });
+  for (const auto& [ts, cmd] : records)
+  {
+    fresh.submit(cmd, ts);
+  }
+  EXPECT_EQ(fresh.config().minPrice, px(90));
+  EXPECT_EQ(fresh.config().maxPrice, px(110));
+  EXPECT_EQ(fresh.config().triggerRef, TriggerRef::Mark);
+  EXPECT_TRUE(fresh.config().halted);
+  ev.clear();
+  fresh.submit(InboundCommand{limit(1, Side::SELL, 100, 1, 1)}, 40);
+  bool rejectedHalted = false;
+  for (const auto& e : ev)
+  {
+    if (const auto* r = std::get_if<OrderRejected>(&e); r && r->reason == RejectReason::Halted)
+    {
+      rejectedHalted = true;
+    }
+  }
+  EXPECT_TRUE(rejectedHalted);
+  std::remove(path.c_str());
+}

--- a/venue/tests/test_venue_reliability.cpp
+++ b/venue/tests/test_venue_reliability.cpp
@@ -235,6 +235,30 @@ void test_event_hash_covers_fields()
     s.displayQty = Quantity::fromDouble(2);
     CHECK(changes(a, s));
   }
+  // FillHeld: the appended makerDisplayAfter (public-feed sync) must be folded.
+  {
+    FillHeld f{5, 1, 10, 11, Price::fromDouble(100), Quantity::fromDouble(2),
+               Quantity::fromDouble(3)};
+    FillHeld s = f;
+    s.makerDisplayAfter = Quantity::fromDouble(1);
+    CHECK(changes(f, s));
+    s = f;
+    s.qty = Quantity::fromDouble(4);
+    CHECK(changes(f, s));
+  }
+  // FillRejected: the appended makerId/price/qty (taker-facing report) fold in.
+  {
+    FillRejected f{5, 1, 11, 10, Price::fromDouble(100), Quantity::fromDouble(2)};
+    FillRejected s = f;
+    s.makerId = 99;
+    CHECK(changes(f, s));
+    s = f;
+    s.price = Price::fromDouble(101);
+    CHECK(changes(f, s));
+    s = f;
+    s.qty = Quantity::fromDouble(3);
+    CHECK(changes(f, s));
+  }
   // Symbol is folded into the id-only report events too.
   {
     OrderCanceled c{7, 1, CancelReason::UserRequested};

--- a/venue/tests/test_venue_sequenced.cpp
+++ b/venue/tests/test_venue_sequenced.cpp
@@ -93,9 +93,13 @@ TEST(Sequenced, EngineSuite)
   // Throughput benchmark of the Disruptor path: journal in Sync::Off so the
   // measurement is the ring + engine, not 500k fsyncs. Durability itself is
   // covered by the journal round-trip / torn-tail tests.
+  //
+  // The shard opens its journal for APPEND and replays it on start (recovery
+  // semantics), so a stale file from a previous run must be removed first.
+  const char* journalPath = "/tmp/flox_test_venue_sequenced_seq_journal.bin";
+  std::remove(journalPath);
   auto shard = std::make_unique<SequencedShard<LadderBook>>(
-      cfg(), "/tmp/flox_test_venue_sequenced_seq_journal.bin", LadderBook{ladderCfg()},
-      Journal::Sync::Off);
+      cfg(), journalPath, LadderBook{ladderCfg()}, Journal::Sync::Off);
   CHECK(shard->subscribeOutbound(&sink, true));
   shard->start();
 

--- a/venue/tests/test_venue_session.cpp
+++ b/venue/tests/test_venue_session.cpp
@@ -11,12 +11,17 @@
 #include "flox-venue/matching_book.h"
 #include "flox-venue/matching_engine.h"
 #include "flox-venue/resend_buffer.h"
+#include "flox-venue/sbe_order_entry_codec.h"
+#include "flox-venue/session_registry.h"
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 using namespace flox;
@@ -64,35 +69,115 @@ NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
   return o;
 }
 
+// Session-layer resend now lives in SessionRegistry (the ResendBuffer event
+// log was removed): the per-account stream assigns the seq at serialization
+// time and retains the framed bytes, so a replay repeats the original reports
+// byte-for-byte -- across a disconnect.
 void test_resend()
 {
   std::printf("test_resend\n");
-  ResendBuffer buf;
-  const uint64_t sess = 42;
+  SessionRegistry reg(DeliveryConfig{/*queueCapacity*/ 64, /*resendLogCapacity*/ 4});
+  const uint64_t acct = 42;
+  std::mutex m;
+  std::vector<std::vector<uint8_t>> wire;
+  auto frames = [&]
+  {
+    std::lock_guard<std::mutex> lk(m);
+    return wire;
+  };
+  auto waitFrames = [&](size_t want)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (frames().size() < want && std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return frames().size() >= want;
+  };
+  const SessionRegistry::Encoder enc =
+      [](const OutboundEvent& e, uint64_t seq, int64_t, std::vector<uint8_t>& out)
+  {
+    SbeOrderEntryCodec::encode(e, out, seq);
+    return !out.empty();
+  };
+  auto attach = [&]
+  {
+    return reg.attach(acct, enc, [&](const uint8_t* p, size_t n)
+                      {
+                        std::lock_guard<std::mutex> lk(m);
+                        wire.emplace_back(p, p + n);
+                        return true; }, [] {});
+  };
+
+  auto w = attach();
   for (int i = 1; i <= 5; ++i)
   {
-    const uint64_t seq =
-        buf.append(sess, OutboundEvent{OrderCanceled{static_cast<OrderId>(i), SYM, CancelReason::UserRequested}},
-                   /*ts*/ i * 100);
-    CHECK(seq == static_cast<uint64_t>(i));
+    reg.route(OutboundEvent{
+        OrderCanceled{static_cast<OrderId>(i), SYM, CancelReason::UserRequested, acct}});
   }
-  CHECK(buf.lastSeq(sess) == 5);
+  CHECK(reg.lastSeq(acct) == 5);
+  CHECK(waitFrames(5));
+  {
+    const auto fs = frames();
+    CHECK(SbeOrderEntryCodec::seqOf(fs.front().data(), fs.front().size()) == 1);
+    CHECK(SbeOrderEntryCodec::seqOf(fs.back().data(), fs.back().size()) == 5);
+  }
 
-  // Reconnect: client had seen through seq 2, requests resend from 3.
-  const auto gap = buf.resend(sess, 3);
-  CHECK(gap.size() == 3);
-  CHECK(gap.front().seq == 3 && gap.back().seq == 5);
-  CHECK(gap.front().tsNs == 300);
+  // Disconnect; an event that fires while the account is offline is still
+  // sequenced and logged -- exactly the maker-fill-during-reconnect case.
+  reg.detach(acct, w);
+  w->stop();
+  reg.route(OutboundEvent{OrderCanceled{6, SYM, CancelReason::UserRequested, acct}});
+  CHECK(reg.lastSeq(acct) == 6);
 
-  buf.ackThrough(sess, 4);
-  CHECK(buf.resend(sess, 1).size() == 1);  // only seq 5 remains buffered
+  // Reconnect: client had seen through seq 3, requests resend from 4. Log
+  // capacity is 4, so seqs 3..6 are retained -> served.
+  {
+    std::lock_guard<std::mutex> lk(m);
+    wire.clear();
+  }
+  auto w2 = attach();
+  CHECK(reg.resendFrom(acct, 4) == SessionRegistry::ResendResult::Served);
+  CHECK(waitFrames(3));
+  {
+    const auto fs = frames();
+    CHECK(fs.size() == 3);
+    CHECK(SbeOrderEntryCodec::seqOf(fs.front().data(), fs.front().size()) == 4);
+    CHECK(SbeOrderEntryCodec::seqOf(fs.back().data(), fs.back().size()) == 6);
+  }
 
-  // Client-side gap detection.
+  // A fromSeq older than the retained log is an explicit TooOld (the verb
+  // layer answers SnapshotRequired), never a silent hole.
+  CHECK(reg.resendFrom(acct, 1) == SessionRegistry::ResendResult::TooOld);
+  reg.detach(acct, w2);
+  w2->stop();
+
+  // Client-side gap detection (message-level, in-order delivery; the full
+  // reordering / re-raise / epoch semantics are covered in the MD tests).
   GapDetector gd;
-  CHECK(!gd.observe(1).first);
-  CHECK(!gd.observe(2).first);
-  auto g = gd.observe(5);  // skipped 3,4
-  CHECK(g.first && g.second == 3);
+  std::vector<uint64_t> delivered;
+  std::vector<uint64_t> gaps;
+  auto deliver = [&](const MdMessage& d)
+  { delivered.push_back(d.seq); };
+  auto onGap = [&](SymbolId, uint64_t, uint64_t from)
+  { gaps.push_back(from); };
+  auto msg = [](uint64_t seq)
+  {
+    MdMessage d;
+    d.symbol = SYM;
+    d.epoch = 1;
+    d.seq = seq;
+    return d;
+  };
+  gd.observe(msg(1), deliver, onGap);
+  gd.observe(msg(2), deliver, onGap);
+  gd.observe(msg(5), deliver, onGap);  // skipped 3,4 -> gap from 3; 5 is held
+  CHECK(gaps.size() == 1 && gaps[0] == 3);
+  CHECK(delivered.size() == 2);
+  gd.observe(msg(3), deliver, onGap);  // late arrival fills part of the gap -> 3 delivers
+  gd.observe(msg(4), deliver, onGap);  // gap closed -> 4 and the held 5 drain in order
+  CHECK((delivered == std::vector<uint64_t>{1, 2, 3, 4, 5}));
+  CHECK(gaps.size() == 1);
 }
 
 uint64_t runTimed(const std::vector<std::pair<int64_t, InboundCommand>>& cmds)

--- a/venue/tests/test_venue_tls.cpp
+++ b/venue/tests/test_venue_tls.cpp
@@ -6,9 +6,13 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full
  * license information.
  */
+#include "flox-venue/fix_codec.h"
+#include "flox-venue/fix_session.h"
 #include "flox-venue/matching_book.h"
 #include "flox-venue/matching_engine.h"
+#include "flox-venue/sbe.h"
 #include "flox-venue/sbe_order_entry_codec.h"
+#include "flox-venue/session_registry.h"
 #include "flox-venue/tls_gateway.h"
 
 #include <arpa/inet.h>
@@ -20,8 +24,12 @@
 #include <unistd.h>
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
 #include <mutex>
 #include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 using namespace flox;
@@ -202,12 +210,267 @@ void test_tls_cancel_on_disconnect()
   CHECK(canceled);
 }
 
+// TLS client with the same read/until helpers the plaintext delivery test
+// uses, but over an SSL* (the venue-side framing is identical).
+struct TlsClient
+{
+  int fd{-1};
+  SSL_CTX* ctx{nullptr};
+  SSL* ssl{nullptr};
+
+  bool connectTo(int port)
+  {
+    fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = htons(static_cast<uint16_t>(port));
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&a), sizeof a) != 0)
+    {
+      return false;
+    }
+    ctx = tls::clientCtx();
+    ssl = SSL_new(ctx);
+    SSL_set_fd(ssl, fd);
+    if (SSL_connect(ssl) != 1)
+    {
+      return false;
+    }
+    timeval tv{2, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    return true;
+  }
+  void sendCmd(const InboundCommand& c)
+  {
+    std::vector<uint8_t> b;
+    SbeOrderEntryCodec::encode(c, b);
+    tls::writeFrame(ssl, b.data(), b.size());
+  }
+  // Read until a frame with `wantTmpl` arrives (or timeout); returns it.
+  bool readUntil(uint8_t wantTmpl, std::vector<uint8_t>& out)
+  {
+    std::vector<uint8_t> f;
+    while (tls::readFrame(ssl, f))
+    {
+      if (!f.empty() &&
+          static_cast<uint8_t>(SbeOrderEntryCodec::templateId(f.data(), f.size())) == wantTmpl)
+      {
+        out = f;
+        return true;
+      }
+    }
+    return false;
+  }
+  void close()
+  {
+    if (ssl != nullptr)
+    {
+      SSL_shutdown(ssl);
+      SSL_free(ssl);
+      ssl = nullptr;
+    }
+    if (fd >= 0)
+    {
+      ::close(fd);
+      fd = -1;
+    }
+    if (ctx != nullptr)
+    {
+      SSL_CTX_free(ctx);
+      ctx = nullptr;
+    }
+  }
+  ~TlsClient() { close(); }
+};
+
+// Delivery through the SessionRegistry over TLS: the asynchronous maker exec
+// report reaches the MAKER's TLS session, not the aggressor's -- the TLS
+// analog of test_venue_delivery's cross-session case. The per-connection SSL
+// mutex is what makes the writer-thread SSL_write legal next to the reader's
+// SSL_read polls.
+void test_tls_cross_session_delivery()
+{
+  std::printf("test_tls_cross_session_delivery\n");
+  GatewayCounters counters;
+  SessionRegistry registry({}, &counters);
+  std::mutex m;  // serializes engine access across gateway handler threads
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { registry.route(e); });
+  const SessionRegistry::Encoder encoder =
+      [](const OutboundEvent& e, uint64_t seq, int64_t, std::vector<uint8_t>& out)
+  {
+    SbeOrderEntryCodec::encode(e, out, seq);
+    return !out.empty();
+  };
+  auto gateway = [&](uint64_t account)
+  {
+    auto gw = std::make_unique<TlsGateway>(
+        [](const uint8_t* p, size_t n)
+        { return SbeOrderEntryCodec::decode(p, n); },
+        account);
+    gw->setDelivery(&registry, encoder);
+    gw->setCounters(&counters);
+    return gw;
+  };
+  const TlsGateway::Handler handler = [&](const InboundCommand& c, const TlsGateway::Responder&)
+  {
+    std::lock_guard<std::mutex> lk(m);
+    eng.submit(c);
+  };
+
+  auto gwA = gateway(1);
+  auto gwB = gateway(2);
+  const int pA = gwA->start(0, handler);
+  const int pB = gwB->start(0, handler);
+  CHECK(pA > 0 && pB > 0);
+
+  TlsClient a;
+  TlsClient b;
+  CHECK(a.connectTo(pA) && b.connectTo(pB));
+
+  // Maker rests on session A.
+  a.sendCmd(InboundCommand{mk(1, Side::SELL, 100, 5)});
+  std::vector<uint8_t> f;
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Accepted), f));
+  CHECK(sbe::getU64(f.data() + sbe::kHeaderSize) == 1);  // orderId
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) == 1);
+
+  // Aggressor on session B fills it.
+  b.sendCmd(InboundCommand{mk(2, Side::BUY, 100, 5, 2)});
+  CHECK(b.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Executed), f));
+  CHECK(sbe::getU64(f.data() + sbe::kHeaderSize) == 2);  // the taker's own report
+
+  // The maker fill arrives on session A -- an event A never asked for on this
+  // frame exchange (the per-frame responder had no path here).
+  CHECK(a.readUntil(static_cast<uint8_t>(SbeOrderEntryCodec::OutTmpl::Executed), f));
+  CHECK(sbe::getU64(f.data() + sbe::kHeaderSize) == 1);  // maker order id
+  CHECK(f[sbe::kHeaderSize + 37] == 1);                  // complete flag (5 of 5 filled)
+  CHECK(SbeOrderEntryCodec::seqOf(f.data(), f.size()) > 1);
+
+  a.close();
+  b.close();
+  gwA->stop();
+  gwB->stop();
+}
+
+// FIX session layer over TLS (setFixSession): Logon 141=Y, a trading cycle,
+// the venue's own Heartbeat on the poll tick, and a short resend (PossDup
+// replay with the original seq). Same wire shape as TCP -- one FIX message
+// per length-prefixed frame -- inside the TLS stream; the full recovery
+// matrix stays on the TCP tests.
+void test_tls_fix_session()
+{
+  std::printf("test_tls_fix_session\n");
+  GatewayCounters counters;
+  SessionRegistry registry({}, &counters);
+  std::mutex m;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { registry.route(e); });
+  FixSessionHost fixHost;
+  const SessionRegistry::Encoder encoder =
+      [](const OutboundEvent& e, uint64_t seq, int64_t tsNs, std::vector<uint8_t>& out)
+  {
+    const std::string msg =
+        FixCodec::encode(e, seq, "VENUE", "CLIENT", FixSession::sendingTime(tsNs));
+    if (msg.empty())
+    {
+      return false;
+    }
+    out.assign(msg.begin(), msg.end());
+    return true;
+  };
+  TlsGateway gw([](const uint8_t* p, size_t n)
+                { return FixCodec::decode(std::string(reinterpret_cast<const char*>(p), n)); },
+                /*account*/ 1);
+  gw.setDelivery(&registry, encoder);
+  gw.setFixSession(&fixHost);
+  gw.setCounters(&counters);
+  const int port = gw.start(0, [&](const InboundCommand& c, const TlsGateway::Responder&)
+                            {
+                              std::lock_guard<std::mutex> lk(m);
+                              eng.submit(c); });
+  CHECK(port > 0);
+
+  TlsClient c;
+  CHECK(c.connectTo(port));
+  uint64_t seq = 1;
+  const auto sendFix = [&](const std::string& msg)
+  { tls::writeFrame(c.ssl, reinterpret_cast<const uint8_t*>(msg.data()), msg.size()); };
+  const auto admin = [&](const std::string& type,
+                         const std::vector<std::pair<int, std::string>>& fields = {})
+  {
+    sendFix(FixCodec::encodeAdmin(type, seq++, "CLIENT", "VENUE",
+                                  FixSession::sendingTime(wallClockNs()), fields));
+  };
+  using Fields = std::unordered_map<int, std::string>;
+  const auto readType = [&](const std::string& type, Fields& f)
+  {
+    std::vector<uint8_t> frame;
+    while (tls::readFrame(c.ssl, frame))
+    {
+      f = FixCodec::parseFields(std::string(frame.begin(), frame.end()));
+      if (f.count(35) != 0 && f[35] == type)
+      {
+        return true;
+      }
+    }
+    return false;
+  };
+  const auto u64f = [](Fields& f, int tag)
+  { return f.count(tag) != 0 ? std::strtoull(f[tag].c_str(), nullptr, 10) : 0ULL; };
+
+  admin("A", {{108, "1"}, {141, "Y"}});
+  Fields f;
+  CHECK(readType("A", f));
+  CHECK(u64f(f, 34) == 1 && f[141] == "Y" && u64f(f, 108) == 1);
+
+  {
+    std::string b;
+    auto add = [&](int t, const std::string& v)
+    { b += std::to_string(t) + "=" + v + std::string(1, FixCodec::SOH); };
+    add(35, "D");
+    add(34, std::to_string(seq++));
+    add(49, "CLIENT");
+    add(56, "VENUE");
+    add(52, FixSession::sendingTime(wallClockNs()));
+    add(11, "1");
+    add(55, "1");
+    add(54, "2");
+    add(38, "5");
+    add(44, "100");
+    add(40, "2");
+    sendFix(FixCodec::frame(b));
+  }
+  CHECK(readType("8", f));
+  CHECK(u64f(f, 34) == 2 && f[150] == "0" && u64f(f, 37) == 1);
+
+  // Idle past HeartBtInt: the venue heartbeats on the poll tick.
+  CHECK(readType("0", f));
+  CHECK(u64f(f, 34) >= 3);
+  admin("0");
+
+  // Short resend: the Accepted (seq 2) replays with PossDup + OrigSendingTime
+  // at its ORIGINAL seq; the shared resend counter is bumped.
+  admin("2", {{7, "2"}, {16, "2"}});
+  CHECK(readType("8", f));
+  CHECK(u64f(f, 34) == 2 && f[43] == "Y" && f.count(122) != 0 && u64f(f, 37) == 1);
+  CHECK(counters.resendServed.load() >= 1);
+
+  admin("5");
+  CHECK(readType("5", f));  // Logout confirmed
+
+  c.close();
+  gw.stop();
+}
+
 }  // namespace
 
 TEST(Tls, EngineSuite)
 {
   test_tls_roundtrip();
   test_tls_cancel_on_disconnect();
+  test_tls_cross_session_delivery();
+  test_tls_fix_session();
   std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
   EXPECT_EQ(g_failures, 0);
 }

--- a/venue/tests/test_venue_venue.cpp
+++ b/venue/tests/test_venue_venue.cpp
@@ -13,8 +13,8 @@
 #include "flox-venue/matching_book.h"
 #include "flox-venue/matching_engine.h"
 #include "flox-venue/metrics.h"
-#include "flox-venue/resend_buffer.h"
 #include "flox-venue/sbe_order_entry_codec.h"
+#include "flox-venue/session_registry.h"
 
 #include "flox/backtest/fee_schedule.h"
 
@@ -23,7 +23,10 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 using namespace flox;
@@ -77,6 +80,20 @@ NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
   return o;
 }
 
+// Balance genesis as journaled commands: every replay below starts from an
+// EMPTY ledger and rebuilds balances from the stream itself.
+std::vector<std::pair<int64_t, InboundCommand>> genesis()
+{
+  std::vector<std::pair<int64_t, InboundCommand>> g;
+  int64_t ts = 1;
+  for (uint64_t a = 1; a <= 3; ++a)
+  {
+    g.emplace_back(ts++, InboundCommand{Deposit{a, BASE, static_cast<int64_t>(base(1000)), SYM}});
+    g.emplace_back(ts++, InboundCommand{Deposit{a, QUOTE, static_cast<int64_t>(quote(100000)), SYM}});
+  }
+  return g;
+}
+
 // A representative session of order flow (crossing pairs + a cancel).
 std::vector<std::pair<int64_t, InboundCommand>> session()
 {
@@ -90,13 +107,10 @@ std::vector<std::pair<int64_t, InboundCommand>> session()
   return s;
 }
 
+// Replay from an EMPTY ledger: deposits are part of `cmds` (genesis in the
+// WAL), so no manual seeding happens here.
 uint64_t runReplay(const std::vector<std::pair<int64_t, InboundCommand>>& cmds, Ledger& led)
 {
-  for (int a = 1; a <= 3; ++a)
-  {
-    led.deposit(a, BASE, base(1000));
-    led.deposit(a, QUOTE, quote(100000));
-  }
   uint64_t h = 1469598103934665603ULL;
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
                                    { h = hashEvent(h, e); });
@@ -119,19 +133,15 @@ void test_auction_recovery()
 {
   std::printf("test_auction_recovery\n");
   const std::string jpath = "/tmp/flox_test_venue_venue_auction_journal.bin";
-  std::vector<std::pair<int64_t, InboundCommand>> cmds;
+  std::vector<std::pair<int64_t, InboundCommand>> cmds = genesis();  // deposits in the stream
   cmds.emplace_back(10, InboundCommand{AdminCmd{SYM, AdminAction::BeginPreOpen}});
   cmds.emplace_back(20, InboundCommand{limit(1, Side::SELL, 100, 5, 1)});             // accumulate (no match)
   cmds.emplace_back(30, InboundCommand{limit(2, Side::BUY, 100, 5, 2)});              // crossed book in pre-open
   cmds.emplace_back(40, InboundCommand{AdminCmd{SYM, AdminAction::OpenContinuous}});  // uncross @100
 
   // Live run: journal every command, hash the event stream, count trades.
+  // The ledger starts empty; the genesis deposits fund it through the stream.
   Ledger liveLed;
-  for (int a = 1; a <= 3; ++a)
-  {
-    liveLed.deposit(a, BASE, base(1000));
-    liveLed.deposit(a, QUOTE, quote(100000));
-  }
   Journal jr(jpath);
   uint64_t liveHash = 1469598103934665603ULL;
   int liveTrades = 0;
@@ -148,15 +158,12 @@ void test_auction_recovery()
   jr.flush();
   CHECK(liveTrades > 0);  // the uncross produced fills -> AdminCmd(OpenContinuous) dispatched
 
-  // Recovery: replay the journal into a fresh engine; state must match bit-for-bit.
+  // Recovery: replay the journal into a fresh engine and an EMPTY ledger;
+  // state must match bit-for-bit (deposits replay from the WAL).
   const auto replayed = Journal::loadTimed(jpath);
   CHECK(replayed.size() == cmds.size());  // AdminCmds round-tripped (not truncated at an unknown tag)
   Ledger recLed;
-  for (int a = 1; a <= 3; ++a)
-  {
-    recLed.deposit(a, BASE, base(1000));
-    recLed.deposit(a, QUOTE, quote(100000));
-  }
+  CHECK(recLed.available(1, BASE) == 0);  // nothing seeded before replay
   uint64_t recHash = 1469598103934665603ULL;
   int recTrades = 0;
   MatchingEngine<MatchingBook> reng(cfg(), [&](const OutboundEvent& e)
@@ -183,32 +190,73 @@ TEST(Venue, EngineSuite)
   test_auction_recovery();
 
   Ledger led;
-  for (int a = 1; a <= 3; ++a)
-  {
-    led.deposit(a, BASE, base(1000));
-    led.deposit(a, QUOTE, quote(100000));
-  }
   const Amount initBase = base(1000) * 3;
   const Amount initQuote = quote(100000) * 3;
 
   Metrics metrics;
-  ResendBuffer resend;
+  // Delivery/resend now lives in SessionRegistry: per-account seq + frame log,
+  // replayable via resendFrom (what the SBE ResendRequest verb serves).
+  SessionRegistry registry(DeliveryConfig{4096, 4096});
+  std::mutex wiresMutex;
+  std::unordered_map<uint64_t, std::vector<std::vector<uint8_t>>> wires;
+  const SessionRegistry::Encoder enc =
+      [](const OutboundEvent& e, uint64_t seq, int64_t, std::vector<uint8_t>& out)
+  {
+    SbeOrderEntryCodec::encode(e, out, seq);
+    return !out.empty();
+  };
+  auto attachAccount = [&](uint64_t a)
+  {
+    return registry.attach(a, enc, [&wiresMutex, &wires, a](const uint8_t* fp, size_t fn)
+                           {
+                             std::lock_guard<std::mutex> lk(wiresMutex);
+                             wires[a].emplace_back(fp, fp + fn);
+                             return true; }, [] {});
+  };
+  std::vector<std::shared_ptr<SessionWriter>> writers;
+  for (uint64_t a = 1; a <= 3; ++a)
+  {
+    writers.push_back(attachAccount(a));
+  }
+  auto frameCount = [&](uint64_t a)
+  {
+    std::lock_guard<std::mutex> lk(wiresMutex);
+    return wires[a].size();
+  };
+  auto waitFrames = [&](uint64_t a, size_t want)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (frameCount(a) < want && std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return frameCount(a) >= want;
+  };
   MarketDataPublisher<> md([](const MdMessage&) {}, px(0.01), SYM);
   const std::string journalPath = "/tmp/flox_test_venue_venue_venue_journal.bin";
   Journal journal(journalPath);
-  const uint64_t clientSession = 7;
   uint64_t liveHash = 1469598103934665603ULL;
 
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
                                    {
                                      metrics.observe(e);
                                      md.onEvent(e);
-                                     resend.append(clientSession, e, /*ts*/ 0);
+                                     registry.route(e);
                                      liveHash = hashEvent(liveHash, e); });
   flox::FeeSchedule fs;
   fs.addTier(0.0, -1.0, 2.0);
   eng.setFeeSchedule(fs);
   eng.setLedger(&led, VENUE);
+
+  // Genesis deposits enter as sequenced commands (journaled like everything
+  // else). They are not order-entry wire, so they bypass the SBE codec: an ops
+  // channel, not a client session, originates them.
+  const auto gen = genesis();
+  for (const auto& [ts, cmd] : gen)
+  {
+    eng.submit(cmd, ts);
+    journal.append(cmd, ts);
+  }
 
   // Drive the session through the SBE order-entry wire codec, timing each submit.
   const auto cmds = session();
@@ -253,18 +301,34 @@ TEST(Venue, EngineSuite)
               (unsigned long long)metrics.trades,
               (double)metrics.volumeRaw / 1e8);
 
-  // 4. Reconnect: client had seen through seq K, resends the remainder.
-  const uint64_t total = resend.lastSeq(clientSession);
+  // 4. Reconnect: account 1 had seen through seq K; a resend replays the
+  // remainder byte-for-byte with the original per-session seqs.
+  const uint64_t total = registry.lastSeq(1);
   CHECK(total > 0);
   const uint64_t k = total / 2;
-  const auto gap = resend.resend(clientSession, k + 1);
-  CHECK(gap.size() == total - k);
-  CHECK(gap.front().seq == k + 1 && gap.back().seq == total);
+  CHECK(waitFrames(1, total));  // live delivery flushed through the writer
+  const size_t before = frameCount(1);
+  CHECK(registry.resendFrom(1, k + 1) == SessionRegistry::ResendResult::Served);
+  CHECK(waitFrames(1, before + (total - k)));
+  {
+    std::lock_guard<std::mutex> lk(wiresMutex);
+    const auto& fs1 = wires[1];
+    CHECK(fs1.size() == before + (total - k));
+    CHECK(SbeOrderEntryCodec::seqOf(fs1[before].data(), fs1[before].size()) == k + 1);
+    CHECK(SbeOrderEntryCodec::seqOf(fs1.back().data(), fs1.back().size()) == total);
+  }
+  for (uint64_t a = 1; a <= 3; ++a)
+  {
+    registry.detach(a, writers[a - 1]);
+    writers[a - 1]->stop();
+  }
 
-  // 5. Deterministic recovery: replay the journal reproduces the event stream.
+  // 5. Deterministic recovery: replay the journal (genesis + session) into an
+  // EMPTY ledger reproduces the event stream and every balance.
   const auto replayed = Journal::loadTimed(journalPath);
-  CHECK(replayed.size() == cmds.size());
+  CHECK(replayed.size() == gen.size() + cmds.size());
   Ledger recovered;
+  CHECK(recovered.available(1, BASE) == 0);  // nothing seeded before replay
   CHECK(runReplay(replayed, recovered) == liveHash);
 
   // 6. Real-money recovery: the recovered ledger balances match the live ledger


### PR DESCRIPTION
A boundary survey of the venue module turned up eleven gaps; this closes all of them, and then closes every limitation the fixes themselves were documented with.

The matcher and clearing were already production-grade. Everything *around* them -- restart, delivery, retries, recovery -- was scaffolding or absent. This branch is that perimeter.

## Recovery

The journal opened with `O_TRUNC`, so **restarting a shard erased the log it was meant to recover from**, and the shard journaled `ts=0` while the engine advanced its own clock, so any timed replay (GTD, last-look windows, LULD) diverged from live. Both fixed: append mode, replay-before-serving gated on readiness, and one injected timestamp shared by journal and engine. Deposits, withdrawals and instrument config became journaled commands, so replay reproduces balances from an **empty** ledger with no hand-seeding.

On top of that, checkpoints: a snapshot is a journal-format file whose records rebuild state through the same appliers as live traffic -- one code path, and the CRC/torn-tail protection from #442 comes free. Balances, MMP windows, reservations and STP groups snapshot exactly; `SnapshotBegin` carries a `configHash` so a snapshot cannot load into a differently configured instrument. Publishing is asynchronous: the pause covers only a state clone plus segment rotation, **227 ms -> 28.7 ms** on a 100k-order book, byte-identical output. `fork()` was rejected deliberately -- in a multi-threaded process a foreign malloc-arena lock deadlocks the child.

## Last look

A reject **destroyed liquidity**: the held size was carved out of the book and never returned, the taker exited "complete" with zero fills, and the public feed kept a phantom level forever. Now the maker's displayed quantity is restored and the taker residual follows its TIF; market data applies `FillHeld`/`FillRejected` so feed equals book after any hold sequence. Decisions are ownership-checked and reach the wire on SBE/FIX/REST (previously `heldId` never left the process, making the decision API unreachable). Holds expire on quiet symbols via a journaled `TimeTick`; every cancel path resolves holds first, which closed a cancel-then-accept conservation break. The conservation fuzzer drives 15872 holds with zero breaches, and found two further reservation-lifetime holes on the way.

Pro-rata instruments now refuse last-look orders at admission, and `crossProRata` additionally refuses to fill such a maker as firm even if `validate()` were bypassed.

## Sessions

There was no outbound path at all: asynchronous events -- a maker's fill from another session's aggressor, stop triggers, liquidations -- **had nowhere to go**, and the only wiring pattern in the tree would have delivered them to whichever session happened to be in the handler. Rejected frames answered with silence. Now a `SessionRegistry` routes per account through a seq-stamped event log into a bounded per-session queue with its own writer thread; matching never blocks on a client socket, slow consumers are disconnected and counted. TLS delivers through the same path (per-connection mutex with poll-before-lock; the naive lock-around-`SSL_read` starved the writer and was rejected after measurement).

Sequence numbers exist in both directions on SBE and FIX -- FIX previously emitted no 34/49/56/52 at all, i.e. structurally invalid FIX 4.4. A full FIX session layer now runs on tcp, ws and tls: logon negotiation, heartbeat/TestRequest into cancel-on-disconnect, PossDup replay with GapFill over admin ranges, `35=3` for unknown types, cancel-on-disconnect negotiated on the wire. Sequence state survives a venue restart through a CRC'd sidecar written at checkpoint. `ResendRequest` and `AccountSnapshotRequest` make the previously dead `ResendBuffer`/`snapshotAccount` scaffolding reachable; deposits and withdrawals emit `BalanceUpdate`.

A half-open peer used to hold its orders and a thread forever, and one idle client blocked venue shutdown permanently. Idle timeouts, connection-fd shutdown and a pruning disconnect canceller fix that.

## Market data

A publisher restart reset `seq` to 0 and **silently stalled every surviving consumer** -- the feed looked alive and delivered nothing. Messages now carry an epoch, so a restart is visible and triggers re-snapshot. Snapshots have a wire form paired atomically with `lastSeq`, a TCP recovery server serves resends from a bounded ring or answers `SnapshotRequired`, and `RecoveringMdSubscriber` automates the whole loop with bounded backoff. `GapDetector` was rewritten (per-symbol, epoch-aware, reorder-tolerant, re-raises unfilled gaps) and is actually wired into the receive path. `sendto` failures are counted instead of swallowed.

## Deliberately out of scope

Application policy (FOK-only filters, last-look decisions), client auth beyond the documented boundary, HA/replication (checkpoint and the append journal are its prerequisites), MD conflation, and pro-rata variant B -- hold-aware proportional allocation, which is designed but product-driven.

Remaining by design: the checkpoint pause is O(state); `configHash` excludes the fee schedule and ladder geometry (no stable digest, and a mismatch there is not a corruption signal); STP groups are per-symbol as no cross-shard owner exists; a FIX resend reaching past a restart answers GapFill.

## Verification

Full suite **191/191** (184 baseline plus 7 new venue binaries). Highlights: process-death recovery (fork, `_exit` mid-stream, compare against a reference engine); torn-snapshot truncation at every offset falling back a generation; the crash-between-rotation-and-publish race; differential checkpoint equality including tail event hashes; conservation fuzz with last look and periodic checkpoints; scripted FIX counterparty across six recovery scenarios.

Two tests were caught passing **vacuously** during this work and now assert against it permanently: the checkpoint differential test (a lagging consumer snapshotted a near-empty boundary) and the hot-path allocation guard from the earlier branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
