### PR TITLE
feat(venue): external market-data distribution over TCP, with FIX and SBE encodings

### DIFF
--- a/docs/venue/index.md
+++ b/docs/venue/index.md
@@ -52,7 +52,7 @@ someone's hands. This is useful for:
 | Ledger | Double-entry money, conservation-exact | [Clearing](clearing.md) |
 | Derivatives risk | Margin, liquidation, insurance, ADL, funding, mark price | [Risk](risk.md) |
 | Runtime | Single-writer sequenced core, journal, deterministic replay | [Runtime and recovery](runtime.md) |
-| Market data | Venue events to an L2 feed (SBE) | [Market data](market-data.md) |
+| Market data | Venue events to an L2 feed: multicast or unicast TCP, SBE or FIX | [Market data](market-data.md) |
 | Perimeter | TCP/WS/TLS/UDP gateways, sessions, FIX/SBE-OE/REST codecs, control plane | [Perimeter](perimeter.md) |
 
 ## Design notes

--- a/docs/venue/market-data.md
+++ b/docs/venue/market-data.md
@@ -10,7 +10,9 @@ MarketDataPublisher<> md([](const MdMessage& m) { multicast(m); },
 
 MatchingEngine<MatchingBook> venue(cfg, [&](const OutboundEvent& e)
                                    {
-                                     md.onEvent(e);   // fan the venue stream into MD
+                                     // The engine's sequencer time stamps the feed;
+                                     // the publisher never reads a clock for it.
+                                     md.onEvent(e, venue.engineTimeNs());
                                      ledgerOrMetrics(e);
                                    });
 
@@ -19,20 +21,193 @@ md.book();   // flox::NLevelOrderBook kept in step with the venue book
 
 ## Messages
 
-| `MdType` | Meaning | `qty` field |
-|---|---|---|
-| `AddOrder` | an order joined the book | shown quantity |
-| `Trade` | a print (`id` is the taker) | executed quantity |
-| `Executed` | a resting order was hit | displayed remaining |
-| `Cancel` | an order left the book | — |
-| `Replace` | an order was repriced/resized | displayed remaining |
-| `Triggered` | a stop fired | — |
+| `MdType` | Meaning | `price` field | `qty` field |
+|---|---|---|---|
+| `AddOrder` | an order joined the book | limit price | shown quantity |
+| `Trade` | a print (`id` is the taker) | trade price | executed quantity |
+| `Executed` | a resting order was hit | resting price | displayed remaining |
+| `Cancel` | an order left the book | resting price | — |
+| `Replace` | an order was repriced/resized | new price | displayed remaining |
+| `Triggered` | a stop fired | reference price | — |
+| `TradingStatus` | halt / pause / auction transition | — | — |
+| `DerivativesUpdate` | mark, funding, open interest | mark price | open interest |
 
 Every message carries `(symbol, epoch, seq)`: `seq` is contiguous from 1
 within one publisher lifetime, `epoch` is a random value minted when the
 publisher is constructed. One publisher serves one symbol; several publishers
 may share a multicast group, and the symbol in every root block is what a
 consumer demultiplexes on before any gap accounting.
+
+## Time: `engineTsNs` and `sendTsNs`
+
+Every message on every path carries two nanosecond timestamps, and they mean
+different things on purpose.
+
+| Field | Source | Reproducible on replay? |
+|---|---|---|
+| `engineTsNs` | the sequencer-ts of the command that caused the event (`MatchingEngine::engineTimeNs()`) | **yes** |
+| `sendTsNs` | wall clock when the publisher sent *this copy* | **no** |
+
+`engineTsNs` is journaled input, so replaying the same command stream produces
+the same value on every message — it is what time bars, a faithful tape and
+any metric with time as a variable are built on, and it is safe to fold into a
+determinism digest. The publisher does not invent it: an `OutboundEvent`
+carries no time of its own, so the caller — which knows the engine's time —
+passes it to `onEvent`.
+
+`sendTsNs` is a wall-clock read at send time and is deliberately **not**
+reproducible. A resend of the same message carries a later `sendTsNs` than the
+original, which is exactly how a consumer tells a replayed copy from live
+flow. `sendTsNs - engineTsNs` is the venue's own outbound latency. It must
+never enter an event hash or a determinism comparison (`hashEvent` does not
+see it: the timestamps are added by the publisher, below the event layer).
+
+Both are non-decreasing within one publisher: `engineTsNs` because sequencer
+time is, `sendTsNs` because the publisher latches the maximum it has issued —
+a backwards step of the system clock cannot make the feed look reordered.
+
+On the wire:
+
+- **SBE** — two trailing `int64` fields (`engineTs`, `sendTs`, `sinceVersion=3`)
+  appended to the end of every incremental root block, exactly as `epoch` was
+  in version 1. A version-1/2 reader skips them via the header's `blockLength`
+  and decodes everything else byte for byte.
+- **FIX** — `52 SendingTime` carries `sendTsNs`, `60 TransactTime` and
+  `273 MDEntryTime` carry `engineTsNs`. All standard fields; a message from a
+  publisher that has no timestamp (0) omits the tag rather than printing the
+  epoch.
+
+## Trading status
+
+Halts, volatility pauses and auction phases are published as transitions, from
+the engine's own state changes — a subscriber never has to infer a halt from a
+feed that went quiet, and never sees a repeat for a state that did not change.
+
+| `TradingStatus` | Meaning | `untilNs` |
+|---|---|---|
+| `Trading` | continuous matching | 0 |
+| `Halted` | operator halt; new orders rejected | 0 |
+| `LuldPause` | timed limit-up/limit-down volatility pause | pause deadline (sequencer time) |
+| `AuctionPreOpen` | pre-open accumulation, no matching | 0 |
+| `AuctionUncross` | the uncross itself | 0 |
+| `Closed` | the session is closed; new orders rejected, the book stands | 0 |
+
+`TradingStatusReason` says why: `Administrative` (an operator `AdminCmd`),
+`LuldBreach`, `LuldPauseElapsed` (the timed pause ran out and trading
+resumed), `Auction`, `Session` (a session boundary).
+
+`untilNs` is the deadline of the **timed pause and of nothing else**. Any other
+state publishes 0, even when a pause deadline is still stored underneath it — a
+subscriber is never handed an expiry for a state that does not expire.
+
+An opening auction publishes three transitions — `AuctionPreOpen`,
+`AuctionUncross`, `Trading` — so the uncross fills sit between the last two and
+can be attributed to the auction rather than to continuous trading.
+
+### `Closed` is not `Halted`
+
+They are different states on purpose. A halt is an *exception* — something went
+wrong and an operator stopped the instrument, with no promise about when it
+resumes. A closed session is the instrument's *normal* out-of-hours condition.
+A subscriber that cannot tell them apart cannot tell a broken market from a
+sleeping one, and the two reject an order with different reasons
+(`Halted` vs `MarketClosed`).
+
+- `Closed` is the outermost state: it wins over an auction phase and over a
+  halt in `tradingStatus()`, and the halt or auction underneath it is left
+  untouched — a close during a halt reopens **still halted**, because a session
+  boundary must not silently clear an exception an operator raised.
+- Closing does **not** pull the book (that is `HaltAndCancelAll`). Resting
+  orders stand across the close, and a cancel is still accepted: a client must
+  be able to get out of what it cannot add to.
+- Transitions arrive as the sequenced `AdminCmd` actions `CloseSession` /
+  `OpenSession`, so they journal, replay, hash and checkpoint like a halt.
+
+What the engine deliberately does **not** own is the **calendar**. Nothing here
+fires on a clock; the schedule that decides *when* to send `CloseSession` /
+`OpenSession` belongs to the operator / control plane (see
+[runtime.md](runtime.md)), which drives it through the control-plane `session`
+verb.
+
+On the wire the value is appended at the end of the enum, so no root block
+changes and a reader of the previous schema decodes every field of the message
+and sees only an unrecognised status code — which it must treat as **not
+tradeable**, never as `Trading`. On FIX it is `326 = 18` (*Not available for
+trading*, FIX 4.4's end-of-session value), deliberately not the halt code `2`.
+
+The engine reaches the feed through a new `OutboundEvent`,
+`TradingStatusChanged`, which is hashed like every other event
+(`untilNs` is sequencer time, so it replays). It carries no account: the
+order-entry codecs have no exec-report form for it, exactly like
+`MmpTriggered` / `FeeCharged` / `Liquidation`.
+
+On FIX it is the standard `35=f SecurityStatus`:
+`326 SecurityTradingStatus` = `17` trading, `2` halt (both an operator halt
+and a volatility pause), `21` pre-open, `22` opening rotation, with the
+distinction FIX 4.4 cannot express in `326` spelled out in `58 Text`. It is
+sent regardless of the subscription's `MDEntryType` filter — a subscriber that
+asked for trades only still has to be told the instrument stopped trading.
+
+## Derivatives
+
+`DerivativesUpdate` carries what a perp holder needs to value a position:
+
+| Field | Meaning |
+|---|---|
+| `price` | mark price (the last `SetMark` the engine was given) |
+| `fundingRateRaw` | last applied funding rate, at `kFundingRateScale` (= the price/qty scale, 1e-8). A rate never travels as a float |
+| `nextFundingNs` | next settlement boundary; **0 = the venue does not fund this instrument** |
+| `qty` | open interest: the long side of the open positions the engine tracks (equal to the short side) |
+
+It is emitted from the sequenced `SetMark`, `ApplyFunding` and
+`SetFundingSchedule` commands — all journaled, so mark, rate, calendar and open
+interest all replay. Open interest is published *with the mark*, not on every
+fill: a per-trade open-interest message would multiply the feed's rate for a
+number consumers read at mark cadence.
+
+### The funding calendar is state, not a formula
+
+`nextFundingNs` used to be derived from `(now, SymbolConfig::fundingIntervalNs)`
+— a computation over startup config rather than a fact, which drifts from
+reality the moment an operator changes the interval or shifts a settlement. It
+is now engine state:
+
+- **`SetFundingSchedule{symbol, intervalNs, nextFundingNs}`** — a sequenced,
+  journaled command (control-plane verb of the same name). The operator owns the
+  calendar; the engine holds it.
+- **`ApplyFunding` advances it** by one whole interval, and by further whole
+  intervals if the settlement ran late enough that one step would still leave
+  the boundary in the past (an operator catching up after an outage does not
+  leave a stale boundary in the feed).
+- It is **hashed and checkpointed** (`RestoreFunding`), so a restored engine
+  publishes the boundary the venue will actually settle on.
+- With **no schedule set** the historical derivation from
+  `SymbolConfig::fundingIntervalNs` still applies, unchanged — an engine that
+  never learned a schedule behaves exactly as it did before the command
+  existed. A non-positive interval or boundary clears the schedule back to it.
+
+The engine still settles funding only when told to (`ApplyFunding`). This is
+the calendar it publishes and advances, **not** a timer that fires payments.
+
+The funding **rate** likewise survives a checkpoint now (same `RestoreFunding`
+record), so an engine restored from a snapshot publishes the real rate instead
+of `0` until the next `ApplyFunding`.
+
+One honest limit remains: on an instrument the engine has never been given a
+mark for, no `DerivativesUpdate` is published at all — the feed says nothing
+rather than publishing a zero mark. A schedule set before the first mark is in
+force but silent until that mark arrives.
+
+On FIX the layer travels as a `35=X` with two standard MDEntries —
+`269=6` SettlementPrice for the mark and `269=C` OpenInterest — plus the
+funding rate and next funding time in the user-defined tag range, because FIX
+4.4 predates the instrument and has no field for either:
+
+| Tag | Field |
+|---|---|
+| `5001` | funding rate (exact decimal, same printing path as prices) |
+| `5002` | next funding time (UTCTimestamp) |
+| `5003` | volatility-pause deadline on `35=f` |
 
 ## Sequencing, restarts and epochs
 
@@ -78,9 +253,32 @@ length-prefixed frames, one request per connection:
 - client sends `ResendRequest{symbol, fromSeq}` (`fromSeq=0` = late joiner);
 - if `fromSeq` is inside the ring, the server replays the increments with
   `seq >= fromSeq` and closes (EOF terminates the replay);
-- otherwise it answers `SnapshotRequired` followed by `SnapshotBegin` +
-  `AddOrder` body messages (`seq=0`, epoch set) + `SnapshotEnd{lastSeq}`; the
-  consumer applies the body and resumes the incremental feed at `lastSeq+1`.
+- otherwise it answers `SnapshotRequired` followed by `SnapshotBegin` + the
+  instrument's current state + `AddOrder` body messages (`seq=0`, epoch set) +
+  `SnapshotEnd{lastSeq}`; the consumer applies the body and resumes the
+  incremental feed at `lastSeq+1`.
+
+### What a snapshot carries
+
+A book alone is not a startable state: a halted, paused or pre-open instrument
+looks exactly like a quiet one, and a perp position cannot be valued without a
+mark. So a snapshot carries the **current** `TradingStatus` and
+`DerivativesUpdate` (whichever the publisher has published) as `seq=0` body
+records placed **between `SnapshotBegin` and the orders**, so a subscriber
+knows the instrument is halted before it applies a single order.
+
+`SnapshotBegin::orderCount` still counts `AddOrder` messages only, and
+`MdRecoveryClient::Result` keeps them out of `messages` (the book body) in
+`hasStatus`/`status` and `hasDerivatives`/`derivatives`. On a **resend** the
+same two message types are ordinary sequenced increments and stay in the
+stream — diverting them there would punch a hole in the seq run.
+`RecoveringMdSubscriber::onSnapshotState` is the optional hook for consumers
+that track halts or value positions; a consumer that only rebuilds a book
+ignores it.
+
+On FIX the snapshot leads with `35=f SecurityStatus` and the derivatives
+`35=X` before the `35=W` full refresh, whose entries each carry `273
+MDEntryTime`.
 
 `MdRecoveryClient` (same header) is the consumer-side counterpart: one
 `recover(symbol, fromSeq, out)` call opens the connection, sends the request
@@ -154,6 +352,192 @@ Single-threaded like the subscriber itself: all recovery work happens inside
 `recv()` on the calling thread (the backoff sleeps block the caller, as any
 synchronous recovery would).
 
+## Choosing a transport
+
+Two transports carry the same feed. They differ in reach, not in content: a
+subscriber on either sees the same messages with the same `seq` under the same
+`epoch`.
+
+| | Multicast (`udp_multicast.h`) | Unicast TCP (`md_distribution.h`) |
+|---|---|---|
+| Reach | one layer-2 segment | anywhere the venue is reachable |
+| Fan-out cost | one datagram per message, any number of consumers | one encode + one write per subscriber |
+| Delivery | best effort; holes are the consumer's to recover | in order, on a reliable stream |
+| Snapshot / resend | separate channel (`MdRecoveryServer`) | inline on the same connection |
+| Encodings | SBE | SBE, FIX, or another registered one |
+
+**Pick multicast when the consumer is colocated** — inside the same segment,
+on the data NIC. It is the lowest-latency, lowest-cost fan-out there is, and
+the venue does the same work for one consumer as for a hundred.
+
+**Pick unicast TCP for everybody else.** Multicast does not survive a WAN hop,
+most cloud networks do not route it, and a consumer behind NAT cannot join a
+group. That is not a tuning problem — it is the reason an external consumer
+has no multicast option at all.
+
+Running both is the normal arrangement: fan the publisher's sink into the
+multicast publisher and the distribution server together.
+
+```cpp
+MdDistributionServer dist(&counters);
+
+MarketDataPublisher<> md([&](const MdMessage& m)
+                         {
+                           udpPub.publish(m);   // colocated consumers
+                           dist.publish(m);     // everybody else
+                         },
+                         /*tickSize*/ Price::fromDouble(0.01), /*symbol*/ 1);
+
+dist.addPublisher(md);
+dist.start(/*port*/ 9010, /*bindIp*/ "0.0.0.0");
+```
+
+## Unicast distribution (`MdDistributionServer`)
+
+A long-lived TCP session per subscriber. Nothing about sequencing is
+reinvented: `MarketDataPublisher` stays the source of truth for `seq`, the
+`epoch`, `snapshotAtomic()` and the resend ring, and the server is a fan-out
+in front of it.
+
+**Verbs** (SBE templates 11/12 and the existing 7; the FIX equivalents are
+below):
+
+- `Subscribe{symbol, fromSeq, snapshotOnly}` — start streaming. `fromSeq = 0`
+  asks for the atomic snapshot followed by increments; `fromSeq > 0` resumes
+  at that seq. `snapshotOnly` serves one book and leaves no subscription.
+- `Unsubscribe{symbol}` — stop that symbol; the others keep flowing. One
+  connection carries any number of symbols.
+- `ResendRequest{symbol, fromSeq}` — the same verb the recovery channel uses,
+  answered inline on this connection.
+
+**Subscribing mid-stream.** A snapshot taken while the feed is moving must
+neither lose an increment nor let one jump ahead of the book it belongs to.
+The symbol is registered *unarmed* first, so every increment from that instant
+is encoded and parked in a bounded buffer; the snapshot is then taken outside
+the session lock; finally the snapshot frames are queued, the parked
+increments past `lastSeq` are queued behind them, and the subscription arms at
+`lastSeq + 1`. A test drives exactly that race and checks the joiner's book
+against a consumer that watched from the first message.
+
+**Resend.** `fromSeq` inside the ring is replayed from it
+(`MdCounters::resendServed`). `fromSeq` older than the ring's tail gets the
+explicit `SnapshotRequired` followed by a full snapshot
+(`MdCounters::snapshotsServed`) — the same two-way answer the recovery channel
+gives, without a second connection. Replayed increments may arrive behind
+newer live ones; a consumer sequences with `GapDetector` exactly as on the
+multicast path.
+
+**Slow consumers.** Each subscriber has a bounded outbound queue drained by
+its own writer thread, the same shape as the order-entry session writer. The
+publishing thread encodes and enqueues; it never waits on a socket. A full
+queue is the verdict: the connection is shut down, its frames are dropped and
+`MdCounters::slowConsumerDisconnects` is bumped. One wedged subscriber cannot
+delay another and cannot delay the engine. There is deliberately no send
+timeout on the socket — a blocked writer thread is fine, and a socket timer
+would misreport a slow reader as a broken connection. `sendBufferBytes` bounds
+`SO_SNDBUF` so the kernel does not hide backlog the queue is meant to see.
+Conflation is not the v1 policy; the bounded queue and the disconnect are.
+
+**Liveness.** No inbound byte within `idleTimeoutMs` drops the subscriber
+(`MdCounters::idleDisconnects`), the same policy the order-entry gateways
+hold. The server sends its own beat every `heartbeatMs` when the connection is
+quiet — an empty frame on the binary encoding, `35=0` on FIX. A subscriber is
+expected to beat back.
+
+**Publisher restart.** A message whose `epoch` differs from the
+subscription's resets the delivery position, so a feed that restarted at
+`seq = 1` is not filtered out as stale by a subscription still expecting
+`seq = 500`. The subscriber sees the epoch change and re-subscribes.
+
+**Counters.** `subscribers` (live sessions), `slowConsumerDisconnects`,
+`idleDisconnects`, `subscribeRejects`, plus the shared `resendServed` /
+`snapshotsServed`.
+
+**Exposure.** `start(port, bindIp)` binds loopback unless given an explicit
+address. The protocol carries no authentication and no encryption of its own,
+so anything reachable off-host belongs behind TLS termination and/or a
+firewall — the same contract as the recovery channel and the order-entry
+gateways.
+
+## Pluggable encodings
+
+Transport and encoding are independent axes. `MdEncoder` (`md_encoder.h`) owns
+the bytes and knows nothing about subscriptions, snapshots or sequencing; the
+distribution server owns those and knows nothing about the bytes. Framing
+belongs to the encoder — every method appends complete, self-framed wire bytes
+that the session writes verbatim, which is what lets one port carry a
+length-prefixed binary encoding and a self-delimiting text one. Adding an
+encoding is writing one `MdEncoder` and registering it; no distribution logic
+changes.
+
+The encoding is chosen per connection **from its first byte, peeked and not
+consumed**, so both protocols still start at their own first byte and an
+off-the-shelf implementation of either connects unmodified:
+
+| First byte | Encoding | Why it is unambiguous |
+|---|---|---|
+| `0x00` | SBE | the high byte of the u32 frame length; feed frames are tens of bytes |
+| `'8'` | FIX | the first byte of the BeginString `8=FIX.4.4` |
+
+`registerEncoding(leadByte, factory)` adds a third.
+`MdDistributionConfig::encoding` pins a port to one encoding instead, for a
+deployment that prefers a port per protocol. One encoder instance lives per
+connection, so an encoder may hold session state; every call on it is
+serialized by the session.
+
+## FIX market data
+
+`fix_md_codec.h`. The framing, the checksum, the exact decimal printing and
+the UTCTimestamp all come from the order-entry codec unchanged — prices and
+sizes go through `decwire`, never through a double, so `100.25` prints as
+`100.25`.
+
+It is a separate header because market data is a different message family:
+order entry is flat `tag=value` and `FixCodec::parseFields` deliberately
+collapses repeats into a map, while market data is built on repeating groups
+(146, 267, 268) where the repeats *are* the payload.
+
+**Inbound — MarketDataRequest (35=V)**
+
+| Tag | Field | Handling |
+|---|---|---|
+| 262 | MDReqID | required; echoed on every W/X/Y |
+| 263 | SubscriptionRequestType | `0` snapshot, `1` snapshot + updates, `2` unsubscribe; anything else → `35=Y`, `281=4` |
+| 264 | MarketDepth | `0` or absent = full book; a positive depth → `35=Y`, `281=5` |
+| 267 / 269 | MDEntryTypes | `0` bid, `1` offer, `2` trade; omitted = all three; unknown → `35=Y`, `281=8` |
+| 146 / 55 | Symbols | one subscription per symbol; none → `35=Y`, `281=0` |
+
+**Outbound**
+
+- **35=W MarketDataSnapshotFullRefresh** — 262, 55, 268 `NoMDEntries`, then
+  per entry 269 `MDEntryType`, 270 `MDEntryPx`, 271 `MDEntrySize`, 273
+  `MDEntryTime` (the engine time the order was accepted at), 278 `MDEntryID`.
+  The feed is order-level, so every entry carries its order id. The current
+  `35=f` and the derivatives `35=X` are sent ahead of it.
+- **35=X MarketDataIncrementalRefresh** — 262, 60 `TransactTime`, 268, then
+  279 `MDUpdateAction` (`0` New, `1` Change, `2` Delete), 269, 55, 270, 271,
+  273, 278. `AddOrder` and a trade print map to New, `Cancel` and a fully
+  consumed order to Delete, `Replace` and a partial fill to Change. A stop
+  trigger has no market-data entry and is not sent. The derivatives layer uses
+  the same message with two entries (`269=6` mark, `269=C` open interest) plus
+  tags 5001/5002.
+- **35=f SecurityStatus** — 324, 55, 326 `SecurityTradingStatus`, 60, 58, and
+  5003 for a volatility-pause deadline. Sent on every trading-status
+  transition regardless of the `MDEntryType` filter.
+- **35=Y MarketDataRequestReject** — 262, 281 `MDReqRejReason`, 58.
+
+**Session layer.** Deliberately a light one — Logon (35=A), Heartbeat (35=0),
+TestRequest (35=1), Logout (35=5) and a monotonic outbound MsgSeqNum — not
+`FixSessionHost`/`FixConnection`. That session layer is built around order
+entry: accounts, the `SessionRegistry` exec-report log, application-level
+resend with PossDup. None of it has a meaning for a broadcast feed. Market
+data is not account-scoped, and a consumer recovers from a hole with the
+feed's own tools (a fresh MarketDataRequest, or a seq-based resend on the
+binary encoding), never by replaying a per-account message log. FIX market
+data has no seq-based resend at all, so a re-request is answered with a fresh
+full refresh. A message before the Logon is answered with a Logout; an
+unsupported MsgType with a session Reject (35=3) rather than silence.
+
 ## Icebergs and the public feed
 
 An iceberg shows a peak and hides the rest. The public feed must only ever see
@@ -185,10 +569,25 @@ canonical SBE message header (`blockLength`, `templateId`, `schemaId`,
 `version`) followed by a per-type little-endian root block. One template per
 `MdType`, each carrying only the fields that type needs, plus the recovery
 templates (`ResendRequest`, `SnapshotBegin`, `SnapshotEnd`,
-`SnapshotRequired`). Schema version 1 appended a trailing `epoch` (u64) to
+`SnapshotRequired`) and the distribution verbs (`Subscribe`, `Unsubscribe`,
+`SubscribeReject`), the instrument-wide messages (`TradingStatus`,
+`DerivativesUpdate`). Schema version 1 appended a trailing `epoch` (u64) to
 every incremental template — the SBE-sanctioned extension path: a version-0
 reader skips it via the header's `blockLength`, and the decoder accepts v0
-frames (epoch reads as 0). The schema in `venue/schema/md-sbe.xml` is the
+frames (epoch reads as 0). Version 2 added the three distribution templates
+and nothing else: no existing root block changed, so a version-1 reader
+decodes every incremental and recovery message byte for byte as before.
+Version 3 added the two instrument-wide templates and, on every incremental
+template, the two trailing timestamps (`engineTs`, `sendTs`) at the end of the
+root block — again the same path, so a version-1/2 reader decodes every field
+it knows out of a version-3 frame unchanged and skips the rest. Template ids
+1..6 mirror the order-level `MdType`s (`templateId = MdType + 1`); the two new
+ones are 14 and 15 and are mapped explicitly, since 7..13 were already taken by
+the recovery and session verbs. Enumerations extend the same way fields do —
+new values are appended (`TradingStatus::Closed`, `StatusReason::Session`), so
+no root block changes and an older reader decodes every field of the message,
+seeing only a status code it does not recognise. A consumer must treat an
+unknown `TradingStatus` as *not tradeable*. The schema in `venue/schema/md-sbe.xml` is the
 source of truth; the codec is hand-written against it (no Java codegen in the
 build). This is the venue's own SBE schema, not Nasdaq ITCH.
 

--- a/docs/venue/runtime.md
+++ b/docs/venue/runtime.md
@@ -32,8 +32,9 @@ Same commands in, same events out, byte for byte. That is what makes replay
 and hot standby work, and the tests enforce it:
 
 - **Every state-mutating input is a command.** Orders, cancels, modifies, mass
-  cancels, quotes, last-look decisions, and also `SetMark`, `ApplyFunding`, and
-  `AdminCmd` (auction transitions, halts, emergency cancel-all). A crash after
+  cancels, quotes, last-look decisions, and also `SetMark`, `ApplyFunding`,
+  `SetFundingSchedule` (the funding calendar) and `AdminCmd` (auction
+  transitions, halts, emergency cancel-all, session open/close). A crash after
   an opening uncross must recover the same book, so the uncross has to be in
   the stream. The same holds for money and configuration: `Deposit` /
   `Withdraw` (balance genesis; a withdraw exceeding `available` is rejected and
@@ -55,6 +56,32 @@ trigger-reference switches and halts arrive as `ListInstrument` / `SetBands` /
 registry from the same stream the engines replay. Structural knobs the control
 plane cannot express (assets, scales, margin parameters, fee schedule) are
 startup configuration supplied when a shard is constructed.
+
+## Trading sessions and the funding calendar
+
+The engine owns two pieces of *schedule-shaped* state, and in both cases it
+holds the **state and the transitions** while the **calendar stays outside**.
+Nothing in the matching path fires on a clock.
+
+| State | Set by | Engine behaviour |
+|---|---|---|
+| Session open / closed | `AdminCmd{CloseSession \| OpenSession}` (control-plane `session` verb) | while closed, new orders are rejected with `MarketClosed`; the resting book stands and cancels are still accepted |
+| Next funding boundary | `SetFundingSchedule{intervalNs, nextFundingNs}` (control-plane verb of the same name) | published on the derivatives feed; advanced by one whole interval on each `ApplyFunding` |
+
+**There is deliberately no session calendar in the engine.** A venue's trading
+hours are a product-level configuration — holidays, half days, per-instrument
+variations, timezone rules — and none of it belongs in a matching engine that
+must stay deterministic and clock-free. The operator (or the control plane
+driving it) runs the schedule and sends the command; what the engine guarantees
+is that the transition is *sequenced*: journaled, replayed at its exact point in
+the stream, hashed into the determinism digest, published to the feed as a
+`TradingStatusChanged`, and carried by the checkpoint. The same contract holds
+for funding: the engine publishes and advances the calendar, but settles only
+when told to with `ApplyFunding`.
+
+`Closed` is not a halt (see [market-data.md](market-data.md)): a close leaves a
+halt or auction phase underneath it untouched, so reopening returns to exactly
+the state the close interrupted.
 
 ## Journal and replay
 
@@ -111,7 +138,16 @@ deterministic):
   reinterpret every price and quantity;
 - instrument config as the **existing** records (`ListInstrument`, `SetBands`,
   `SetTriggerRef`, `SetStpGroup` firm-group STP memberships, `AdminCmd`
-  halt/auction state);
+  halt/auction/session state -- the session record is written last of the
+  three so it restores as the outermost state);
+- derivatives funding state as a snapshot-only `RestoreFunding` record: the
+  last applied rate and the live funding calendar (`nextFundingNs`,
+  `intervalNs`). It is a record rather than three more fields on `SnapshotEnd`
+  because `SnapshotEnd` is a strictly-sized journal body -- widening it would
+  change its `expectedBodySize` and make every existing snapshot unreadable.
+  An engine with no funding state at all writes no such record, and a file
+  without one restores rate 0 and no schedule, exactly as before the record
+  existed (read compatibility, pinned by a test);
 - balances as snapshot-only `RestoreBalance` records, one per account x asset
   carrying the EXACT signed `(available, reserved)` split -- every live
   moment is representable, including a negative wallet mid-liquidation.
@@ -133,7 +169,12 @@ deterministic):
 
 `stateHash` is an event-hash-style FNV fold over the same canonical traversal
 (book, stops, holds, positions, balances available+reserved, MMP windows,
-STP groups, config, sequence counters). The loader re-verifies it at
+STP groups, config, session and funding state, sequence counters). The session
+and funding terms fold in **only when set**, the same "zero == absent" rule the
+balance traversal follows -- an engine that was never closed and never saw a
+funding rate or schedule hashes exactly as it did before those fields existed,
+which is what lets a snapshot written without them still verify on load. The
+loader re-verifies it at
 `SnapshotEnd`; a mismatch rejects the generation. Startup wiring
 (`setLedger`, `setFeeSchedule`, ladder config) is construction state, not
 snapshot state -- re-apply it before `start()`, exactly as for plain journal

--- a/venue/README.md
+++ b/venue/README.md
@@ -42,10 +42,10 @@ behaviour emerge from the interaction.
 | Derivatives risk | `cross_margin.h` (portfolio margin), `collateral.h` (haircut basket), `funding_rate.h` + `funding_scheduler.h`, `index_feed.h` (manipulation-resistant mark), `mark_feed_driver.h` (stale-feed circuit breaker) |
 | Runtime | `sequenced_shard.h` — single-writer core on the FLOX `EventBus`, journalled |
 | Recovery | `journal.h` (WAL + replay), `event_hash.h` (bit-identical determinism check) |
-| Market data out | `market_data.h` + `sbe_md_codec.h` (SBE) — turns venue events into an L2 feed |
+| Market data out | `market_data.h` + `sbe_md_codec.h` (SBE) — turns venue events into an L2 feed; `md_recovery.h` (snapshot/resend), `md_distribution.h` + `md_encoder.h` (unicast TCP, pluggable encoding) |
 | Protocol / ops | `fix_codec.h`, `resend_buffer.h`, `messages.h`, `reject_reason.h`, `metrics.h`, `prometheus.h` |
 | Perimeter | `socket_acceptor.h`, `session.h` (API-key HMAC logon, rate limits), `cancel_on_disconnect.h`, `tcp_gateway.h`, `ws_gateway.h`, `tls_gateway.h` (OpenSSL, optional), `udp_multicast.h`, `control_plane.h` / `control_api.h` / `control_server.h`, `metrics_server.h`, `tape_recorder.h` |
-| Wire protocols | `fix_codec.h`, `sbe_order_entry_codec.h`, `rest_json.h`, `sbe_md_codec.h` (+ shared `sbe.h`) |
+| Wire protocols | `fix_codec.h`, `fix_md_codec.h`, `sbe_order_entry_codec.h`, `rest_json.h`, `sbe_md_codec.h` (+ shared `sbe.h`) |
 
 ## Two margin models
 

--- a/venue/include/flox-venue/control_api.h
+++ b/venue/include/flox-venue/control_api.h
@@ -75,6 +75,33 @@ class ControlApi
       forward(InboundCommand{AdminCmd{sym, halted ? AdminAction::Halt : AdminAction::Resume}});
       return ok();
     }
+    if (method == "session")
+    {
+      // Session boundary. The engine holds the STATE; the CALENDAR that decides
+      // when to call this is the operator's -- a scheduler here, not in the
+      // matching path. Registry-invisible (a closed session is not instrument
+      // configuration), so only the sequenced AdminCmd is forwarded.
+      const SymbolId sym = symOf(f, "symbol");
+      if (reg_.get(sym) == nullptr)
+      {
+        return err("unknown_symbol");
+      }
+      const bool open = get(f, "open") == "true";
+      forward(InboundCommand{
+          AdminCmd{sym, open ? AdminAction::OpenSession : AdminAction::CloseSession}});
+      return ok();
+    }
+    if (method == "setFundingSchedule")
+    {
+      const SymbolId sym = symOf(f, "symbol");
+      if (reg_.get(sym) == nullptr)
+      {
+        return err("unknown_symbol");
+      }
+      forward(InboundCommand{
+          SetFundingSchedule{sym, i64Of(f, "intervalNs"), i64Of(f, "nextFundingNs")}});
+      return ok();
+    }
     if (method == "setBand")
     {
       const SymbolId sym = symOf(f, "symbol");
@@ -183,6 +210,10 @@ class ControlApi
   static uint64_t u64Of(const std::unordered_map<std::string, std::string>& f, const char* k)
   {
     return std::strtoull(get(f, k).c_str(), nullptr, 10);
+  }
+  static int64_t i64Of(const std::unordered_map<std::string, std::string>& f, const char* k)
+  {
+    return static_cast<int64_t>(std::strtoll(get(f, k).c_str(), nullptr, 10));
   }
   static Price priceOf(const std::unordered_map<std::string, std::string>& f, const char* k)
   {

--- a/venue/include/flox-venue/control_plane.h
+++ b/venue/include/flox-venue/control_plane.h
@@ -109,10 +109,15 @@ class InstrumentRegistry
         case AdminAction::ResumeAuction:
           return halt(ad->symbol, false);
         default:
-          return true;  // auction transitions carry no registry state
+          // Auction phases and session boundaries carry no registry state: the
+          // registry holds instrument CONFIGURATION, and neither an uncross nor
+          // a closed session is configuration -- both are engine state the
+          // shards own and the checkpoint carries.
+          return true;
       }
     }
-    if (std::get_if<SetStpGroup>(&cmd) != nullptr)
+    if (std::get_if<SetStpGroup>(&cmd) != nullptr ||
+        std::get_if<SetFundingSchedule>(&cmd) != nullptr)
     {
       return true;  // engine-owned state: the shards consume it, no registry state
     }

--- a/venue/include/flox-venue/event_hash.h
+++ b/venue/include/flox-venue/event_hash.h
@@ -161,6 +161,23 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, static_cast<uint64_t>(x->reservedRaw));
     h = mix(h, static_cast<uint64_t>(x->reason));
   }
+  else if (const auto* x = std::get_if<TradingStatusChanged>(&e))
+  {
+    h = mix(h, 14);
+    h = mix(h, x->symbol);
+    h = mix(h, static_cast<uint64_t>(x->status));
+    h = mix(h, static_cast<uint64_t>(x->reason));
+    h = mix(h, static_cast<uint64_t>(x->untilNs));  // sequencer-ts deadline: reproducible
+  }
+  else if (const auto* x = std::get_if<DerivativesUpdated>(&e))
+  {
+    h = mix(h, 15);
+    h = mix(h, x->symbol);
+    h = mix(h, static_cast<uint64_t>(x->mark.raw()));
+    h = mix(h, static_cast<uint64_t>(x->fundingRateRaw));
+    h = mix(h, static_cast<uint64_t>(x->nextFundingNs));
+    h = mix(h, static_cast<uint64_t>(x->openInterest.raw()));
+  }
   return h;
 }
 

--- a/venue/include/flox-venue/fix_md_codec.h
+++ b/venue/include/flox-venue/fix_md_codec.h
@@ -1,0 +1,773 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * FIX 4.4 market data: MarketDataRequest (35=V) in,
+ * MarketDataSnapshotFullRefresh (35=W), MarketDataIncrementalRefresh (35=X)
+ * and MarketDataRequestReject (35=Y) out -- the encoding that lets an
+ * integration which already speaks FIX consume the feed without implementing
+ * the binary one.
+ *
+ * Why its own header rather than more of fix_codec.h: market data is a
+ * different message family with a different shape. Order entry is flat
+ * tag=value, and FixCodec::parseFields deliberately collapses repeats into a
+ * map (last occurrence wins). Market data is built on REPEATING GROUPS (146
+ * NoRelatedSym, 267 NoMDEntryTypes, 268 NoMDEntries), where the repeats are
+ * the payload, so it needs an order-preserving parse. The framing, the
+ * checksum, the exact decimal printing and the UTCTimestamp all come from
+ * fix_codec.h unchanged -- prices and sizes go through decwire exactly as
+ * order entry prints them, never through a double.
+ *
+ * Session layer: deliberately a light one, NOT FixSessionHost/FixConnection.
+ * That session layer is built around order entry -- accounts, the
+ * SessionRegistry exec-report log, application-level resend with PossDup --
+ * and none of it has a meaning for a broadcast feed: market data is not
+ * account-scoped, and a market-data consumer recovers from a hole with the
+ * feed's own tools (a fresh MarketDataRequest -> a new full refresh, or a
+ * seq-based resend on the binary encoding), not by replaying a per-account
+ * message log. So this is Logon / Heartbeat / TestRequest / Logout with a
+ * monotonic outbound MsgSeqNum, and nothing else.
+ */
+#pragma once
+
+#include "flox-venue/decimal_wire.h"
+#include "flox-venue/fix_codec.h"
+#include "flox-venue/md_encoder.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+class FixMdCodec
+{
+ public:
+  static constexpr char SOH = FixCodec::SOH;
+
+  // MDUpdateAction (279) on an incremental refresh.
+  static constexpr char kNew = '0';
+  static constexpr char kChange = '1';
+  static constexpr char kDelete = '2';
+
+  // MDEntryType (269). '6' SettlementPrice carries the derivatives mark and
+  // 'C' OpenInterest the open interest -- both standard FIX 4.4 entry types, so
+  // an off-the-shelf consumer reads them without a private extension.
+  static constexpr char kBid = '0';
+  static constexpr char kOffer = '1';
+  static constexpr char kTrade = '2';
+  static constexpr char kSettlement = '6';
+  static constexpr char kOpenInterest = 'C';
+
+  // SecurityTradingStatus (326) values used by 35=f SecurityStatus.
+  static constexpr const char* kStatusHalted = "2";    // Trading Halt
+  static constexpr const char* kStatusTrading = "17";  // Ready to Trade
+  // 18 "Not available for trading" is FIX 4.4's end-of-session value, so a
+  // closed session maps onto a standard code that means exactly that -- not
+  // onto the halt code, which would erase the distinction the state exists for.
+  static constexpr const char* kStatusClosed = "18";      // Not Available For Trading
+  static constexpr const char* kStatusPreOpen = "21";     // Pre-open
+  static constexpr const char* kStatusUncrossing = "22";  // Opening Rotation
+
+  // FIX 4.4 has no field for a perpetual funding rate or a funding calendar:
+  // the protocol predates the instrument. They travel in the user-defined tag
+  // range (5000-9999), documented in docs/venue/market-data.md, rather than as
+  // an abuse of a standard tag that means something else.
+  static constexpr int kTagFundingRate = 5001;
+  static constexpr int kTagNextFundingTime = 5002;
+  static constexpr int kTagHaltUntilTime = 5003;
+
+  // Length of the complete FIX message at the head of [p, p+n).
+  // 1 = complete (`len` set), 0 = need more bytes, -1 = malformed.
+  static int messageLength(const uint8_t* p, size_t n, size_t& len)
+  {
+    static constexpr char kBegin[] = "8=FIX";
+    const size_t probe = n < sizeof(kBegin) - 1 ? n : sizeof(kBegin) - 1;
+    if (std::memcmp(p, kBegin, probe) != 0)
+    {
+      return -1;  // not FIX at all: never wait for bytes that cannot help
+    }
+    if (n < sizeof(kBegin) - 1)
+    {
+      return 0;
+    }
+    const uint8_t* soh1 = static_cast<const uint8_t*>(std::memchr(p, SOH, n));
+    if (soh1 == nullptr)
+    {
+      return n > kMaxHeader ? -1 : 0;
+    }
+    const size_t lenTag = static_cast<size_t>(soh1 - p) + 1;  // start of "9="
+    if (n < lenTag + 2)
+    {
+      return 0;
+    }
+    if (p[lenTag] != '9' || p[lenTag + 1] != '=')
+    {
+      return -1;  // BodyLength must be the second field
+    }
+    const uint8_t* soh2 =
+        static_cast<const uint8_t*>(std::memchr(p + lenTag, SOH, n - lenTag));
+    if (soh2 == nullptr)
+    {
+      return n > kMaxHeader ? -1 : 0;
+    }
+    uint64_t body = 0;
+    size_t digits = 0;
+    for (const uint8_t* q = p + lenTag + 2; q < soh2; ++q)
+    {
+      if (*q < '0' || *q > '9' || ++digits > 9)
+      {
+        return -1;
+      }
+      body = body * 10 + static_cast<uint64_t>(*q - '0');
+    }
+    if (digits == 0)
+    {
+      return -1;
+    }
+    // body counts the bytes between the SOH after BodyLength and the SOH
+    // before the CheckSum field; the trailer is a fixed "10=nnn" + SOH.
+    const size_t total = static_cast<size_t>(soh2 - p) + 1 + static_cast<size_t>(body) + 7;
+    if (total > kMaxMessage)
+    {
+      return -1;
+    }
+    if (n < total)
+    {
+      return 0;
+    }
+    len = total;
+    return 1;
+  }
+
+  // Order-preserving tag/value list: repeating groups ARE the payload of a
+  // market-data message, so nothing may be collapsed.
+  static std::vector<std::pair<int, std::string>> parseOrdered(std::string_view msg)
+  {
+    std::vector<std::pair<int, std::string>> f;
+    size_t i = 0;
+    while (i < msg.size())
+    {
+      const size_t eq = msg.find('=', i);
+      if (eq == std::string_view::npos)
+      {
+        break;
+      }
+      size_t soh = msg.find(SOH, eq + 1);
+      if (soh == std::string_view::npos)
+      {
+        soh = msg.size();
+      }
+      f.emplace_back(std::atoi(std::string(msg.substr(i, eq - i)).c_str()),
+                     std::string(msg.substr(eq + 1, soh - eq - 1)));
+      i = soh + 1;
+    }
+    return f;
+  }
+
+  // First value of `tag`, empty when absent.
+  static std::string first(const std::vector<std::pair<int, std::string>>& f, int tag)
+  {
+    for (const auto& [t, v] : f)
+    {
+      if (t == tag)
+      {
+        return v;
+      }
+    }
+    return {};
+  }
+
+  static bool hasTag(const std::vector<std::pair<int, std::string>>& f, int tag)
+  {
+    for (const auto& [t, v] : f)
+    {
+      (void)v;
+      if (t == tag)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static void add(std::string& b, int tag, std::string_view val)
+  {
+    b += std::to_string(tag);
+    b += '=';
+    b.append(val.data(), val.size());
+    b += SOH;
+  }
+
+  static void addPrice(std::string& b, int tag, Price p)
+  {
+    b += std::to_string(tag);
+    b += '=';
+    decwire::append(b, p.raw());
+    b += SOH;
+  }
+
+  static void addQty(std::string& b, int tag, Quantity q)
+  {
+    b += std::to_string(tag);
+    b += '=';
+    decwire::append(b, q.raw());
+    b += SOH;
+  }
+
+  // UTCTimestamp for tag 52, from the wall clock.
+  static std::string nowStamp()
+  {
+    return FixSession::sendingTime(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                       std::chrono::system_clock::now().time_since_epoch())
+                                       .count());
+  }
+
+  // UTCTimestamp for a nanosecond timestamp carried by a feed message. 0 (an
+  // unstamped message from an older publisher) prints nothing -- the tag is
+  // omitted rather than filled with the epoch.
+  static void addTime(std::string& b, int tag, int64_t tsNs)
+  {
+    if (tsNs != 0)
+    {
+      add(b, tag, FixSession::sendingTime(tsNs));
+    }
+  }
+
+ private:
+  static constexpr size_t kMaxHeader = 64;          // 8=...|9=...| can never be longer
+  static constexpr size_t kMaxMessage = 64u << 20;  // bound a hostile BodyLength
+};
+
+struct FixMdConfig
+{
+  std::string senderCompId{"VENUE"};
+  std::string targetCompId{"CLIENT"};
+  uint32_t defaultHeartBtIntSec{30};
+};
+
+// FIX 4.4 market-data encoding for the unicast distribution server. One
+// instance per connection; the session serializes every call.
+class FixMdEncoder final : public MdEncoder
+{
+ public:
+  // Lead byte of a FIX stream: '8', the first byte of BeginString "8=FIX.4.4".
+  static constexpr uint8_t kLeadByte = static_cast<uint8_t>('8');
+
+  explicit FixMdEncoder(FixMdConfig cfg = {}) : cfg_(std::move(cfg)) {}
+
+  const char* name() const noexcept override { return "FIX"; }
+
+  Parse parse(const uint8_t* in, size_t n, size_t& consumed, std::vector<MdRequest>& out,
+              std::vector<uint8_t>& reply) override
+  {
+    size_t total = 0;
+    const int st = FixMdCodec::messageLength(in, n, total);
+    if (st == 0)
+    {
+      return Parse::Need;
+    }
+    if (st < 0)
+    {
+      return Parse::Bad;
+    }
+    consumed = total;
+    const std::string msg(reinterpret_cast<const char*>(in), total);
+    if (!FixCodec::checksumValid(msg))
+    {
+      return Parse::Bad;
+    }
+    const auto f = FixMdCodec::parseOrdered(msg);
+    const std::string type = FixMdCodec::first(f, 35);
+    if (type.empty())
+    {
+      return Parse::Bad;
+    }
+    const std::string inSeq = FixMdCodec::first(f, 34);
+
+    if (type == "A")  // Logon
+    {
+      const std::string hb = FixMdCodec::first(f, 108);
+      heartBtInt_ = hb.empty() ? cfg_.defaultHeartBtIntSec
+                               : static_cast<uint32_t>(std::strtoul(hb.c_str(), nullptr, 10));
+      loggedOn_ = true;
+      std::string b = header("A");
+      FixMdCodec::add(b, 98, "0");  // EncryptMethod: none, the transport does that
+      FixMdCodec::add(b, 108, std::to_string(heartBtInt_));
+      emit(reply, b);
+      return Parse::Ok;
+    }
+    if (!loggedOn_)
+    {
+      // A feed session starts with a Logon, like any other FIX session.
+      std::string b = header("5");
+      FixMdCodec::add(b, 58, "Logon required");
+      emit(reply, b);
+      out.push_back(MdRequest{MdRequestKind::Close, 0, 0, false});
+      return Parse::Ok;
+    }
+    if (type == "0")  // Heartbeat
+    {
+      return Parse::Ok;
+    }
+    if (type == "1")  // TestRequest
+    {
+      std::string b = header("0");
+      const std::string id = FixMdCodec::first(f, 112);
+      if (!id.empty())
+      {
+        FixMdCodec::add(b, 112, id);
+      }
+      emit(reply, b);
+      return Parse::Ok;
+    }
+    if (type == "5")  // Logout
+    {
+      std::string b = header("5");
+      emit(reply, b);
+      out.push_back(MdRequest{MdRequestKind::Close, 0, 0, false});
+      return Parse::Ok;
+    }
+    if (type == "V")  // MarketDataRequest
+    {
+      marketDataRequest(f, out, reply);
+      return Parse::Ok;
+    }
+    // Anything else gets an honest session Reject rather than silence.
+    std::string b = header("3");
+    FixMdCodec::add(b, 45, inSeq.empty() ? "0" : inSeq);
+    FixMdCodec::add(b, 372, type);
+    FixMdCodec::add(b, 58, "Unsupported MsgType on the market-data session");
+    emit(reply, b);
+    return Parse::Ok;
+  }
+
+  // 35=W MarketDataSnapshotFullRefresh: the whole displayed book as MDEntries.
+  // The feed is order-level, so each entry carries its MDEntryID (278) and its
+  // MDEntryTime (273) -- the engine time the order was accepted at.
+  //
+  // The snapshot is preceded by the instrument's current state: a 35=f
+  // SecurityStatus and, when the venue publishes one, the derivatives entries.
+  // A FIX consumer joining a halted instrument is told it is halted instead of
+  // reading an idle book.
+  void snapshot(SymbolId symbol, const MdSnapshot& snap, std::vector<uint8_t>& out) override
+  {
+    const Sub* s = find(symbol);
+    if (s == nullptr)
+    {
+      return;
+    }
+    if (snap.hasStatus)
+    {
+      securityStatus(snap.status, out);
+    }
+    if (snap.hasDerivatives)
+    {
+      derivatives(snap.derivatives, *s, out);
+    }
+    size_t entries = 0;
+    for (const MdMessage& m : snap.orders)
+    {
+      if (m.symbol == symbol && wants(*s, entryType(m)))
+      {
+        ++entries;
+      }
+    }
+    std::string b = header("W", snap.hasStatus ? snap.status.sendTsNs : 0);
+    FixMdCodec::add(b, 262, s->reqId);
+    FixMdCodec::add(b, 55, std::to_string(symbol));
+    FixMdCodec::add(b, 268, std::to_string(entries));
+    for (const MdMessage& m : snap.orders)
+    {
+      if (m.symbol != symbol)
+      {
+        continue;
+      }
+      const char et = entryType(m);
+      if (!wants(*s, et))
+      {
+        continue;
+      }
+      FixMdCodec::add(b, 269, std::string(1, et));
+      FixMdCodec::addPrice(b, 270, m.price);
+      FixMdCodec::addQty(b, 271, m.qty);
+      FixMdCodec::addTime(b, 273, m.engineTsNs);
+      FixMdCodec::add(b, 278, std::to_string(m.id));
+    }
+    emit(out, b);
+  }
+
+  // 35=X MarketDataIncrementalRefresh, one MDEntry per message -- except the
+  // trading status, which has its own standard message (35=f SecurityStatus).
+  void increment(const MdMessage& m, std::vector<uint8_t>& out) override
+  {
+    const Sub* s = find(m.symbol);
+    if (s == nullptr || m.type == MdType::Triggered)
+    {
+      return;  // a stop firing is not a book or trade event on the FIX feed
+    }
+    if (m.type == MdType::TradingStatus)
+    {
+      securityStatus(m, out);
+      return;
+    }
+    if (m.type == MdType::DerivativesUpdate)
+    {
+      derivatives(m, *s, out);
+      return;
+    }
+    const char et = entryType(m);
+    if (!wants(*s, et))
+    {
+      return;
+    }
+    std::string b = header("X", m.sendTsNs);
+    FixMdCodec::add(b, 262, s->reqId);
+    // TransactTime: when the ENGINE produced this event, not when the message
+    // was framed. The two differ by the venue's own outbound latency, which is
+    // exactly what a consumer measuring it needs.
+    FixMdCodec::addTime(b, 60, m.engineTsNs);
+    FixMdCodec::add(b, 268, "1");
+    FixMdCodec::add(b, 279, std::string(1, updateAction(m)));
+    FixMdCodec::add(b, 269, std::string(1, et));
+    FixMdCodec::add(b, 55, std::to_string(m.symbol));
+    FixMdCodec::addPrice(b, 270, m.price);
+    FixMdCodec::addQty(b, 271, m.qty);
+    FixMdCodec::addTime(b, 273, m.engineTsNs);
+    FixMdCodec::add(b, 278, std::to_string(m.id));
+    emit(out, b);
+  }
+
+  // FIX has no "your resend is too old" message: the full refresh that follows
+  // IS the answer, and it replaces the client's book wholesale.
+  void snapshotRequired(SymbolId symbol, uint64_t epoch, uint64_t lastSeq,
+                        std::vector<uint8_t>& out) override
+  {
+    (void)symbol;
+    (void)epoch;
+    (void)lastSeq;
+    (void)out;
+  }
+
+  // 35=Y MarketDataRequestReject.
+  void reject(SymbolId symbol, MdRejectReason reason, std::vector<uint8_t>& out) override
+  {
+    std::string reqId = lastReqId_;
+    if (const Sub* s = find(symbol); s != nullptr)
+    {
+      reqId = s->reqId;
+    }
+    subs_.erase(symbol);  // a rejected request leaves no subscription behind
+    std::string b = header("Y");
+    FixMdCodec::add(b, 262, reqId);
+    FixMdCodec::add(b, 281, reason == MdRejectReason::UnknownSymbol ? "0" : "4");
+    FixMdCodec::add(b, 58, reason == MdRejectReason::UnknownSymbol ? "Unknown symbol" : "Unsupported request");
+    emit(out, b);
+  }
+
+  void heartbeat(std::vector<uint8_t>& out) override
+  {
+    if (!loggedOn_)
+    {
+      return;  // nothing is sequenced before the Logon
+    }
+    std::string b = header("0");
+    emit(out, b);
+  }
+
+  uint64_t outboundSeq() const noexcept { return outSeq_; }
+
+ private:
+  struct Sub
+  {
+    std::string reqId;
+    bool bid{true};
+    bool offer{true};
+    bool trade{true};
+  };
+
+  const Sub* find(SymbolId s) const
+  {
+    const auto it = subs_.find(s);
+    return it == subs_.end() ? nullptr : &it->second;
+  }
+
+  static bool wants(const Sub& s, char entry)
+  {
+    return entry == FixMdCodec::kBid ? s.bid : (entry == FixMdCodec::kOffer ? s.offer : s.trade);
+  }
+
+  static char entryType(const MdMessage& m)
+  {
+    if (m.type == MdType::Trade)
+    {
+      return FixMdCodec::kTrade;
+    }
+    return m.side == Side::BUY ? FixMdCodec::kBid : FixMdCodec::kOffer;
+  }
+
+  static char updateAction(const MdMessage& m)
+  {
+    switch (m.type)
+    {
+      case MdType::AddOrder:
+      case MdType::Trade:
+        return FixMdCodec::kNew;
+      case MdType::Cancel:
+        return FixMdCodec::kDelete;
+      case MdType::Executed:
+        // A fully consumed order leaves the book; a partial fill resizes it.
+        return m.qty.raw() == 0 ? FixMdCodec::kDelete : FixMdCodec::kChange;
+      case MdType::Replace:
+      case MdType::Triggered:
+      case MdType::TradingStatus:      // own message (35=f), never an MDEntry
+      case MdType::DerivativesUpdate:  // built by derivatives(), not here
+        return FixMdCodec::kChange;
+    }
+    return FixMdCodec::kChange;
+  }
+
+  void marketDataRequest(const std::vector<std::pair<int, std::string>>& f,
+                         std::vector<MdRequest>& out, std::vector<uint8_t>& reply)
+  {
+    const std::string reqId = FixMdCodec::first(f, 262);
+    if (reqId.empty())
+    {
+      std::string b = header("3");
+      FixMdCodec::add(b, 45, FixMdCodec::first(f, 34));
+      FixMdCodec::add(b, 372, "V");
+      FixMdCodec::add(b, 58, "MDReqID (262) required");
+      emit(reply, b);
+      return;
+    }
+    lastReqId_ = reqId;
+
+    const std::string subType = FixMdCodec::first(f, 263);
+    if (subType != "0" && subType != "1" && subType != "2")
+    {
+      emitReject(reply, reqId, "4", "Unsupported SubscriptionRequestType");
+      return;
+    }
+    // Full displayed depth is what the feed carries; a partial book is not
+    // something it can honestly serve, so ask for 0 (or leave 264 out).
+    const std::string depth = FixMdCodec::first(f, 264);
+    if (FixMdCodec::hasTag(f, 264) && depth != "0")
+    {
+      emitReject(reply, reqId, "5", "Unsupported MarketDepth: full book only");
+      return;
+    }
+
+    Sub want;
+    bool anyEntryType = false;
+    want.bid = want.offer = want.trade = false;
+    for (const auto& [tag, val] : f)
+    {
+      if (tag != 269)
+      {
+        continue;
+      }
+      anyEntryType = true;
+      if (val == std::string(1, FixMdCodec::kBid))
+      {
+        want.bid = true;
+      }
+      else if (val == std::string(1, FixMdCodec::kOffer))
+      {
+        want.offer = true;
+      }
+      else if (val == std::string(1, FixMdCodec::kTrade))
+      {
+        want.trade = true;
+      }
+      else
+      {
+        emitReject(reply, reqId, "8", "Unsupported MDEntryType");
+        return;
+      }
+    }
+    if (!anyEntryType)
+    {
+      want.bid = want.offer = want.trade = true;  // 267 omitted: everything
+    }
+    want.reqId = reqId;
+
+    std::vector<SymbolId> symbols;
+    for (const auto& [tag, val] : f)
+    {
+      if (tag == 55)
+      {
+        symbols.push_back(static_cast<SymbolId>(std::strtoul(val.c_str(), nullptr, 10)));
+      }
+    }
+    if (symbols.empty())
+    {
+      emitReject(reply, reqId, "0", "No symbol in the request");
+      return;
+    }
+
+    for (SymbolId s : symbols)
+    {
+      if (subType == "2")
+      {
+        subs_.erase(s);
+        out.push_back(MdRequest{MdRequestKind::Unsubscribe, s, 0, false});
+        continue;
+      }
+      subs_[s] = want;
+      // FIX market data has no seq-based resend: a re-request is answered with
+      // a fresh full refresh, so every subscribe starts from the snapshot.
+      out.push_back(MdRequest{MdRequestKind::Subscribe, s, 0, subType == "0"});
+    }
+  }
+
+  void emitReject(std::vector<uint8_t>& out, const std::string& reqId, const char* reason,
+                  const char* text)
+  {
+    std::string b = header("Y");
+    FixMdCodec::add(b, 262, reqId);
+    FixMdCodec::add(b, 281, reason);
+    FixMdCodec::add(b, 58, text);
+    emit(out, b);
+  }
+
+  // sendTsNs > 0 puts the PUBLISHER's send time into SendingTime (52) instead
+  // of a second clock read here: 52 then means exactly what the binary
+  // encoding's sendTs means, and the two encodings of one message agree.
+  // Session-level messages (logon, heartbeat, reject) have no feed timestamp
+  // and keep the wall-clock read.
+  std::string header(const char* msgType, int64_t sendTsNs = 0)
+  {
+    std::string b;
+    FixMdCodec::add(b, 35, msgType);
+    FixMdCodec::add(b, 34, std::to_string(outSeq_++));
+    FixMdCodec::add(b, 49, cfg_.senderCompId);
+    FixMdCodec::add(b, 56, cfg_.targetCompId);
+    FixMdCodec::add(b, 52,
+                    sendTsNs != 0 ? FixSession::sendingTime(sendTsNs) : FixMdCodec::nowStamp());
+    return b;
+  }
+
+  // 35=f SecurityStatus: the standard FIX message for a halt, a resume and an
+  // auction phase. Not gated on a subscription's MDEntryType filter -- a
+  // subscriber that asked for trades only still has to know the instrument
+  // stopped trading.
+  void securityStatus(const MdMessage& m, std::vector<uint8_t>& out)
+  {
+    const Sub* s = find(m.symbol);
+    std::string b = header("f", m.sendTsNs);
+    if (s != nullptr)
+    {
+      FixMdCodec::add(b, 324, s->reqId);  // SecurityStatusReqID: the request this answers
+    }
+    FixMdCodec::add(b, 55, std::to_string(m.symbol));
+    FixMdCodec::add(b, 326, statusValue(m.status));
+    FixMdCodec::addTime(b, 60, m.engineTsNs);
+    FixMdCodec::addTime(b, FixMdCodec::kTagHaltUntilTime, m.untilNs);
+    FixMdCodec::add(b, 58, statusText(m.status, m.reason));
+    emit(out, b);
+  }
+
+  // 35=X carrying the derivatives layer: SettlementPrice ('6') = the mark,
+  // OpenInterest ('C') = the open interest, plus the funding rate and the next
+  // funding time in the user-defined tag range.
+  void derivatives(const MdMessage& m, const Sub& s, std::vector<uint8_t>& out)
+  {
+    std::string b = header("X", m.sendTsNs);
+    FixMdCodec::add(b, 262, s.reqId);
+    FixMdCodec::addTime(b, 60, m.engineTsNs);
+    FixMdCodec::add(b, 268, "2");
+    FixMdCodec::add(b, 279, std::string(1, FixMdCodec::kChange));
+    FixMdCodec::add(b, 269, std::string(1, FixMdCodec::kSettlement));
+    FixMdCodec::add(b, 55, std::to_string(m.symbol));
+    FixMdCodec::addPrice(b, 270, m.price);
+    FixMdCodec::addTime(b, 273, m.engineTsNs);
+    FixMdCodec::add(b, 279, std::string(1, FixMdCodec::kChange));
+    FixMdCodec::add(b, 269, std::string(1, FixMdCodec::kOpenInterest));
+    FixMdCodec::add(b, 55, std::to_string(m.symbol));
+    FixMdCodec::addQty(b, 271, m.qty);
+    FixMdCodec::addTime(b, 273, m.engineTsNs);
+    // The rate prints through the same exact-decimal path prices use: it is a
+    // raw fixed-point value at the shared scale, never a double.
+    std::string rate;
+    decwire::append(rate, m.fundingRateRaw);
+    FixMdCodec::add(b, FixMdCodec::kTagFundingRate, rate);
+    FixMdCodec::addTime(b, FixMdCodec::kTagNextFundingTime, m.nextFundingNs);
+    emit(out, b);
+  }
+
+  static const char* statusValue(flox::venue::TradingStatus s)
+  {
+    switch (s)
+    {
+      case flox::venue::TradingStatus::Trading:
+        return FixMdCodec::kStatusTrading;
+      case flox::venue::TradingStatus::Halted:
+      case flox::venue::TradingStatus::LuldPause:
+        return FixMdCodec::kStatusHalted;
+      case flox::venue::TradingStatus::AuctionPreOpen:
+        return FixMdCodec::kStatusPreOpen;
+      case flox::venue::TradingStatus::AuctionUncross:
+        return FixMdCodec::kStatusUncrossing;
+      case flox::venue::TradingStatus::Closed:
+        return FixMdCodec::kStatusClosed;
+    }
+    return FixMdCodec::kStatusTrading;
+  }
+
+  // FIX 4.4's HaltReason (327) has no value for a volatility pause, so the
+  // distinction that 326 cannot carry goes into Text (58) rather than into an
+  // invented enumeration value.
+  static const char* statusText(flox::venue::TradingStatus s, TradingStatusReason r)
+  {
+    if (s == flox::venue::TradingStatus::LuldPause)
+    {
+      return "LULD volatility pause";
+    }
+    if (r == TradingStatusReason::LuldPauseElapsed)
+    {
+      return "LULD pause elapsed";
+    }
+    switch (s)
+    {
+      case flox::venue::TradingStatus::Trading:
+        return "Trading";
+      case flox::venue::TradingStatus::Halted:
+        return "Trading halt";
+      case flox::venue::TradingStatus::AuctionPreOpen:
+        return "Pre-open auction";
+      case flox::venue::TradingStatus::AuctionUncross:
+        return "Auction uncross";
+      case flox::venue::TradingStatus::Closed:
+        return "Session closed";
+      case flox::venue::TradingStatus::LuldPause:
+        break;
+    }
+    return "Trading";
+  }
+
+  static void emit(std::vector<uint8_t>& out, const std::string& body)
+  {
+    const std::string msg = FixCodec::frame(body);
+    out.insert(out.end(), msg.begin(), msg.end());
+  }
+
+  FixMdConfig cfg_;
+  std::unordered_map<SymbolId, Sub> subs_;
+  std::string lastReqId_;
+  uint64_t outSeq_{1};
+  uint32_t heartBtInt_{30};
+  bool loggedOn_{false};
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/journal.h
+++ b/venue/include/flox-venue/journal.h
@@ -77,7 +77,10 @@ static_assert(std::is_trivially_copyable_v<RestoreReservation>,
 static_assert(std::is_trivially_copyable_v<RestoreBalance>, "RestoreBalance must be blittable");
 static_assert(std::is_trivially_copyable_v<RestoreMmpFills>, "RestoreMmpFills must be blittable");
 static_assert(std::is_trivially_copyable_v<SetStpGroup>, "SetStpGroup must be blittable");
-static_assert(std::variant_size_v<InboundCommand> == 28,
+static_assert(std::is_trivially_copyable_v<SetFundingSchedule>,
+              "SetFundingSchedule must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreFunding>, "RestoreFunding must be blittable");
+static_assert(std::variant_size_v<InboundCommand> == 30,
               "new InboundCommand alternative: extend expectedBodySize/appendDecoded and the "
               "blittable asserts above");
 
@@ -310,6 +313,10 @@ class Journal
         return sizeof(RestoreMmpFills);
       case 27:
         return sizeof(SetStpGroup);
+      case 28:
+        return sizeof(SetFundingSchedule);
+      case 29:
+        return sizeof(RestoreFunding);
       default:
         return 0;
     }
@@ -411,6 +418,12 @@ class Journal
         break;
       case 27:
         v.emplace_back(ts, fromBody<SetStpGroup>(body));
+        break;
+      case 28:
+        v.emplace_back(ts, fromBody<SetFundingSchedule>(body));
+        break;
+      case 29:
+        v.emplace_back(ts, fromBody<RestoreFunding>(body));
         break;
     }
   }

--- a/venue/include/flox-venue/market_data.h
+++ b/venue/include/flox-venue/market_data.h
@@ -37,6 +37,11 @@ enum class MdType : uint8_t
   Cancel,
   Replace,
   Triggered,
+  // Appended types. The order-level types above map onto SBE template ids
+  // 1..6; these do NOT continue that arithmetic (7..13 are the recovery and
+  // session verbs), so the codec maps them explicitly.
+  TradingStatus,      // halt / LULD pause / auction phase transition
+  DerivativesUpdate,  // mark price, funding rate + next funding time, open interest
 };
 
 struct MdMessage
@@ -46,19 +51,54 @@ struct MdMessage
   SymbolId symbol{};
   OrderId id{};  // subject order; for Trade this is the taker
   Side side{};
-  Price price{};
-  Quantity qty{};     // AddOrder: shown qty; Trade: exec qty; Executed/Replace: leaves
+  Price price{};      // DerivativesUpdate: the mark price
+  Quantity qty{};     // AddOrder: shown qty; Trade: exec qty; Executed/Replace: leaves;
+                      // DerivativesUpdate: open interest
   OrderId makerId{};  // Trade only
   uint64_t epoch{};   // publisher lifetime id; changes on restart (consumer re-snapshots)
+
+  // ---- time (every type, every path) ----
+  // When the ENGINE produced the event: the sequencer-ts of the command that
+  // caused it (MatchingEngine::engineTimeNs), handed to the publisher by the
+  // caller. It is journaled input, so a replay of the same journal produces the
+  // same value -- time bars, latency budgets and a faithful tape are all built
+  // on this one, and determinism checks may hash it.
+  int64_t engineTsNs{};
+  // When the PUBLISHER sent this copy: a wall-clock read at send time. It is
+  // deliberately NOT reproducible -- a resend of the same message carries a
+  // later value than the original -- so it must never enter an event hash or a
+  // determinism comparison. Its use is measuring the venue's own outbound
+  // latency (sendTsNs - engineTsNs) and the wire delay a consumer sees.
+  int64_t sendTsNs{};
+
+  // ---- TradingStatus only ----
+  flox::venue::TradingStatus status{};
+  TradingStatusReason reason{};
+  int64_t untilNs{};  // pause deadline in sequencer time (0 = state has no deadline)
+
+  // ---- DerivativesUpdate only (mark = price, open interest = qty) ----
+  int64_t fundingRateRaw{};  // kFundingRateScale, per funding interval
+  int64_t nextFundingNs{};   // next funding boundary (0 = no funding schedule)
 };
 
 // Consistent (snapshot, lastSeq) pair from MarketDataPublisher::snapshotAtomic:
 // apply `orders`, then resume the incremental feed at lastSeq+1 under `epoch`.
+//
+// The book alone is not a startable state for a late joiner: an instrument that
+// is halted, paused or in a pre-open auction looks exactly like a quiet one,
+// and a perp position cannot be valued without a mark. So the snapshot carries
+// the CURRENT trading status and the current derivatives layer alongside the
+// orders -- the same messages the incremental feed publishes on a transition,
+// with seq=0 like the rest of the body.
 struct MdSnapshot
 {
   uint64_t epoch{};
   uint64_t lastSeq{};
   std::vector<MdMessage> orders;  // AddOrder body messages (seq=0, epoch set)
+  bool hasStatus{false};
+  MdMessage status{};  // current TradingStatus (valid when hasStatus)
+  bool hasDerivatives{false};
+  MdMessage derivatives{};  // current DerivativesUpdate (valid when hasDerivatives)
 };
 
 // One publisher per symbol. Each emitted message carries (symbol, epoch, seq):
@@ -91,9 +131,15 @@ class MarketDataPublisher
   {
   }
 
-  void onEvent(const OutboundEvent& e)
+  // `engineTsNs` is the sequencer-ts the engine applied the causing command at
+  // (MatchingEngine::engineTimeNs()). The publisher does NOT invent one: an
+  // OutboundEvent carries no time of its own, and a clock read here would make
+  // the feed unreproducible on replay -- so the caller, which knows the engine's
+  // time, passes it in and every message inherits it verbatim.
+  void onEvent(const OutboundEvent& e, int64_t engineTsNs)
   {
     std::lock_guard<std::mutex> lk(m_);
+    engineTs_ = engineTsNs;
     if (const auto* x = std::get_if<OrderAccepted>(&e))
     {
       onAccepted(*x);
@@ -121,6 +167,14 @@ class MarketDataPublisher
     else if (const auto* x = std::get_if<FillHeld>(&e))
     {
       onFillHeld(*x);
+    }
+    else if (const auto* x = std::get_if<TradingStatusChanged>(&e))
+    {
+      onTradingStatus(*x);
+    }
+    else if (const auto* x = std::get_if<DerivativesUpdated>(&e))
+    {
+      onDerivatives(*x);
     }
     // FillRejected itself has no direct market impact: when a rejected hold
     // returns quantity to the book the engine emits OrderModified (combine /
@@ -156,10 +210,31 @@ class MarketDataPublisher
     s.epoch = epoch_;
     s.lastSeq = seq_;
     s.orders.reserve(orders_.size());
+    const int64_t sendTs = stampSendLocked();
     for (const auto& [id, r] : orders_)
     {
-      s.orders.push_back(
-          MdMessage{MdType::AddOrder, 0, r.symbol, id, r.side, r.price, r.leaves, 0, epoch_});
+      MdMessage m{MdType::AddOrder, 0, r.symbol, id, r.side, r.price, r.leaves, 0, epoch_};
+      // The order's engine time is the one it was accepted at -- the snapshot
+      // states when each resting order arrived, not when the snapshot was taken.
+      m.engineTsNs = r.engineTsNs;
+      m.sendTsNs = sendTs;
+      s.orders.push_back(m);
+    }
+    // Current state, so a late joiner starts halted when the instrument is
+    // halted and can value a position from the first message it applies.
+    if (statusValid_)
+    {
+      s.hasStatus = true;
+      s.status = status_;
+      s.status.seq = 0;
+      s.status.sendTsNs = sendTs;
+    }
+    if (derivativesValid_)
+    {
+      s.hasDerivatives = true;
+      s.derivatives = derivatives_;
+      s.derivatives.seq = 0;
+      s.derivatives.sendTsNs = sendTs;
     }
     return s;
   }
@@ -179,17 +254,35 @@ class MarketDataPublisher
       return std::nullopt;
     }
     std::vector<MdMessage> out;
+    const int64_t sendTs = stampSendLocked();
     for (const auto& m : ring_)
     {
       if (m.seq >= fromSeq)
       {
         out.push_back(m);
+        // A replayed copy is being sent NOW: engineTsNs is the event's own time
+        // and never changes, sendTsNs is this transmission's. That asymmetry is
+        // the point -- it is what lets a consumer tell a replay from live flow.
+        out.back().sendTsNs = sendTs;
       }
     }
     return out;
   }
 
  private:
+  // Wall clock for sendTsNs, latched non-decreasing: a step backwards in the
+  // system clock must not make an already-sent message look newer than one that
+  // follows it. Callers hold m_.
+  int64_t stampSendLocked() const
+  {
+    const int64_t now = static_cast<int64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
+    lastSend_ = now > lastSend_ ? now : lastSend_;
+    return lastSend_;
+  }
+
   static uint64_t makeEpoch()
   {
     std::random_device rd;
@@ -206,6 +299,7 @@ class MarketDataPublisher
     Side side{};
     Price price{};
     Quantity leaves{};
+    int64_t engineTsNs{};  // engine time the order was accepted at (snapshot bodies carry it)
   };
 
   Quantity atPrice(Side s, Price p) const
@@ -234,12 +328,43 @@ class MarketDataPublisher
   {
     m.seq = ++seq_;
     m.epoch = epoch_;
+    m.engineTsNs = engineTs_;
+    m.sendTsNs = stampSendLocked();
     ring_.push_back(m);
     if (ring_.size() > resendCapacity_)
     {
       ring_.pop_front();
     }
     sink_(m);
+  }
+
+  void onTradingStatus(const TradingStatusChanged& s)
+  {
+    MdMessage m{};
+    m.type = MdType::TradingStatus;
+    m.symbol = s.symbol;
+    m.status = s.status;
+    m.reason = s.reason;
+    m.untilNs = s.untilNs;
+    emit(m);
+    // Remember it AFTER emit stamped seq/epoch/time, so the snapshot copy is
+    // the message the incremental feed actually published.
+    status_ = ring_.back();
+    statusValid_ = true;
+  }
+
+  void onDerivatives(const DerivativesUpdated& d)
+  {
+    MdMessage m{};
+    m.type = MdType::DerivativesUpdate;
+    m.symbol = d.symbol;
+    m.price = d.mark;
+    m.qty = d.openInterest;
+    m.fundingRateRaw = d.fundingRateRaw;
+    m.nextFundingNs = d.nextFundingNs;
+    emit(m);
+    derivatives_ = ring_.back();
+    derivativesValid_ = true;
   }
 
   void onAccepted(const OrderAccepted& a)
@@ -251,7 +376,7 @@ class MarketDataPublisher
     // Public depth shows only the displayed size; an iceberg's hidden reserve is
     // never leaked (displayQty carries the peak, 0 -> non-iceberg, use leavesQty).
     const Quantity shown = a.displayQty.raw() > 0 ? a.displayQty : a.leavesQty;
-    orders_[a.id] = Resting{a.symbol, a.side, a.price, shown};
+    orders_[a.id] = Resting{a.symbol, a.side, a.price, shown, engineTs_};
     applyLevel(a.side, a.price, atPrice(a.side, a.price) + shown);
     emit(MdMessage{MdType::AddOrder, 0, a.symbol, a.id, a.side, a.price, shown, 0});
   }
@@ -355,8 +480,16 @@ class MarketDataPublisher
   uint64_t seq_{0};
   uint64_t epoch_{};
   size_t resendCapacity_{};
-  std::deque<MdMessage> ring_;  // recent increments (seq embedded) for resendFrom
-  mutable std::mutex m_;        // matching thread vs recovery-server threads
+  std::deque<MdMessage> ring_;   // recent increments (seq embedded) for resendFrom
+  int64_t engineTs_{0};          // engine time of the event being processed
+  mutable int64_t lastSend_{0};  // latched wall clock, so sendTsNs never goes backwards
+  // Last published instrument state, replayed into every snapshot so a late
+  // joiner starts with the real status and mark instead of a blank one.
+  MdMessage status_{};
+  bool statusValid_{false};
+  MdMessage derivatives_{};
+  bool derivativesValid_{false};
+  mutable std::mutex m_;  // matching thread vs recovery-server threads
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/matching_engine.h
+++ b/venue/include/flox-venue/matching_engine.h
@@ -68,6 +68,17 @@ struct SymbolConfig
   // kMoneyScale regardless. Must satisfy scalesValid().
   int64_t priceScale{Price::Scale};
   int64_t qtyScale{Quantity::Scale};
+
+  // Startup FALLBACK funding interval (0 = the venue does not fund this
+  // instrument). The engine settles funding only when told to (the sequenced
+  // ApplyFunding command); this is the calendar it publishes when no schedule
+  // has been set -- the next boundary of a fixed-interval grid anchored at the
+  // sequencer-ts origin, a function of (now, interval). The AUTHORITATIVE
+  // calendar is engine state set by SetFundingSchedule, which overrides this;
+  // see MatchingEngine::nextFundingNs. Excluded from configHash for the same
+  // reason the other mutable knobs are: it reinterprets no stored number, so it
+  // cannot invalidate a snapshot.
+  int64_t fundingIntervalNs{0};
 };
 
 // Book selects the resting-book implementation. The default MatchingBook is
@@ -153,6 +164,7 @@ class MatchingEngine
     {
       cfg_.halted = false;  // timed LULD volatility pause elapsed
       haltUntil_ = 0;
+      publishStatus(TradingStatusReason::LuldPauseElapsed);
     }
     expireHolds();
     expireOrders();
@@ -219,6 +231,13 @@ class MatchingEngine
       if (sg->symbol == cfg_.id)
       {
         setStpGroup(sg->account, sg->group);  // sequenced -> journaled -> replayed
+      }
+    }
+    else if (const auto* fs = std::get_if<SetFundingSchedule>(&cmd))
+    {
+      if (fs->symbol == cfg_.id)
+      {
+        setFundingSchedule(fs->intervalNs, fs->nextFundingNs);  // sequenced -> journaled -> replayed
       }
     }
     else if (std::get_if<TimeTick>(&cmd) != nullptr)
@@ -294,6 +313,110 @@ class MatchingEngine
   // Live resting orders tracked on this symbol (observability gauge).
   uint64_t restingOrderCount() const noexcept { return orderAccount_.size(); }
 
+  // Sequencer-ts of the last command the engine applied. This is the ONLY
+  // honest "when" an outbound event has: the events themselves carry no time,
+  // and a wall-clock read taken downstream would not reproduce on replay. A
+  // publisher that stamps market data with it (market_data.h) produces the same
+  // timestamps on a journal replay as it did live.
+  int64_t engineTimeNs() const noexcept { return now_; }
+
+  // Open interest: the long side of the perp positions the engine tracks for
+  // this symbol. Every contract has a long and a short leg, so the long side is
+  // the open interest; summing signed quantities would give zero. Integer sum
+  // over an unordered map -- addition is associative, so the result does not
+  // depend on the map's layout.
+  Quantity openInterest() const
+  {
+    int64_t oi = 0;
+    for (const auto& [acct, p] : positions_)
+    {
+      (void)acct;
+      if (p.qtyRaw > 0)
+      {
+        oi += p.qtyRaw;
+      }
+    }
+    return Quantity::fromRaw(oi);
+  }
+
+  // Next funding boundary, in sequencer time. A schedule set by the operator
+  // (SetFundingSchedule) is a FACT: it is engine state, hashed, checkpointed
+  // and advanced by each ApplyFunding, so what the feed publishes is what the
+  // venue will actually settle on. With no schedule set the value falls back to
+  // the historical derivation from (now, SymbolConfig::fundingIntervalNs) --
+  // a computation over startup config, kept so an engine that never learned a
+  // schedule behaves exactly as it did before the command existed. 0 = neither
+  // a schedule nor a configured interval, i.e. the venue does not fund this
+  // instrument.
+  int64_t nextFundingNs() const noexcept
+  {
+    if (nextFundingNs_ > 0)
+    {
+      return nextFundingNs_;
+    }
+    if (cfg_.fundingIntervalNs <= 0)
+    {
+      return 0;
+    }
+    return (now_ / cfg_.fundingIntervalNs + 1) * cfg_.fundingIntervalNs;
+  }
+
+  // The live funding interval: the operator-set schedule when there is one,
+  // otherwise the startup config value it falls back to.
+  int64_t fundingIntervalNs() const noexcept
+  {
+    return fundingIntervalNs_ > 0 ? fundingIntervalNs_ : cfg_.fundingIntervalNs;
+  }
+
+  // Last funding rate the engine applied, at kFundingRateScale. Carried by the
+  // checkpoint (RestoreFunding), so a restored engine publishes the real rate
+  // instead of 0 until the next ApplyFunding.
+  int64_t fundingRateRaw() const noexcept { return fundingRateRaw_; }
+
+  // Operator-set funding calendar. Sequenced as SetFundingSchedule in
+  // production (journaled, replayed, checkpointed); this direct setter is the
+  // pre-start wiring / recovery path, like setStpGroup. A non-positive interval
+  // or boundary clears the schedule, dropping back to the config derivation.
+  void setFundingSchedule(int64_t intervalNs, int64_t nextFundingNs)
+  {
+    fundingIntervalNs_ = intervalNs > 0 ? intervalNs : 0;
+    nextFundingNs_ = nextFundingNs > 0 ? nextFundingNs : 0;
+    // The calendar is a published field, so a change is news -- but only for an
+    // instrument the engine has a mark for. Publishing before the first SetMark
+    // would break the feed's standing promise that an unmarked instrument gets
+    // no DerivativesUpdate at all (the first mark carries the new schedule
+    // anyway).
+    if (hasMark_)
+    {
+      publishDerivatives(markPrice_);
+    }
+  }
+
+  // Current trading state, derived from the engine's own session / halt /
+  // pause / auction flags -- the same value the transition events publish.
+  // Closed wins over everything: a closed session is the instrument's outermost
+  // state, and the halt or auction phase underneath it is preserved untouched
+  // so reopening returns to exactly the state the close interrupted.
+  TradingStatus tradingStatus() const noexcept
+  {
+    if (closed_)
+    {
+      return TradingStatus::Closed;
+    }
+    if (auctionMode_)
+    {
+      return TradingStatus::AuctionPreOpen;
+    }
+    if (cfg_.halted)
+    {
+      return haltUntil_ > 0 ? TradingStatus::LuldPause : TradingStatus::Halted;
+    }
+    return TradingStatus::Trading;
+  }
+
+  // Session state (see AdminAction::CloseSession / OpenSession).
+  bool sessionClosed() const noexcept { return closed_; }
+
   struct OrderView
   {
     OrderId id{};
@@ -365,8 +488,14 @@ class MatchingEngine
   // to/from the clearing pool -- longs pay when rate > 0. `mark` values the leg.
   void applyFunding(double rate, Price mark)
   {
+    // The rate is known whether or not there is a ledger to settle against, and
+    // it is what the derivatives feed publishes -- record it before the early
+    // return, or a venue running without a bound ledger would never publish one.
+    fundingRateRaw_ = static_cast<int64_t>(rate * static_cast<double>(kFundingRateScale));
+    advanceFundingSchedule();
     if (ledger_ == nullptr)
     {
+      publishDerivatives(mark);
       return;
     }
     for (auto& [acct, p] : positions_)
@@ -384,6 +513,7 @@ class MatchingEngine
     // equity -- so an unaffordable funding payment triggers liquidation instead
     // of accruing silent bad debt.
     checkLiquidations(mark);
+    publishDerivatives(mark);
   }
 
   // External mark-price update (derivatives). Drives mark-referenced stops and
@@ -394,6 +524,10 @@ class MatchingEngine
     hasMark_ = true;
     processTriggers();
     checkLiquidations(mark);
+    // After the consequences, so the published open interest matches the state
+    // the mark left behind (a liquidation the mark caused has already closed
+    // its position).
+    publishDerivatives(mark);
   }
 
   // Unrealized PnL of an account's perp position marked at `mark` (quote raw).
@@ -414,7 +548,19 @@ class MatchingEngine
   uint64_t tradesGenerated() const noexcept { return tradeSeq_; }
 
   const SymbolConfig& config() const noexcept { return cfg_; }
-  void setHalted(bool halted) noexcept { cfg_.halted = halted; }  // control-plane hook
+
+  // Control-plane hook (and the AdminCmd Halt/Resume path). Clears any timed
+  // pause deadline on resume, so the state the feed publishes is the state the
+  // engine is actually in.
+  void setHalted(bool halted)
+  {
+    cfg_.halted = halted;
+    if (!halted)
+    {
+      haltUntil_ = 0;
+    }
+    publishStatus(TradingStatusReason::Administrative);
+  }
 
   // Live risk-limit adjustment (control-plane): operators tighten these during
   // volatility without a restart. Only the risk knobs are mutable -- structural
@@ -457,6 +603,11 @@ class MatchingEngine
   void haltAndCancelAll()
   {
     cfg_.halted = true;
+    haltUntil_ = 0;  // an operator halt has no deadline, unlike the LULD pause
+    // The halt reaches the feed BEFORE the flood of cancels it causes, so a
+    // subscriber reads them as consequences of a halt rather than as an
+    // unexplained mass cancel.
+    publishStatus(TradingStatusReason::Administrative);
     // Resolve every open hold first: restored quantity lands back on the book
     // and is then swept by the cancel loop below, so nothing survives the halt.
     rejectAllHolds();
@@ -488,9 +639,36 @@ class MatchingEngine
     }
   }
 
+  // ---- session ----
+  // Close the trading session: new orders are rejected with MarketClosed, and
+  // the resting book STANDS (a close is not a cancel-all -- an operator who
+  // wants the book pulled has HaltAndCancelAll). The halt / auction state
+  // underneath is deliberately untouched, so a close during a halt reopens
+  // still halted: the session boundary must not silently clear an exception
+  // state an operator raised for a reason.
+  //
+  // The engine owns the STATE, never the calendar: nothing here fires on a
+  // clock. The schedule that decides when to send CloseSession / OpenSession is
+  // the operator's / control plane's (docs/venue/runtime.md).
+  void closeSession()
+  {
+    closed_ = true;
+    publishStatus(TradingStatusReason::Session);
+  }
+
+  void openSession()
+  {
+    closed_ = false;
+    publishStatus(TradingStatusReason::Session);
+  }
+
   // ---- session / auctions ----
   // Pre-open: orders accumulate without matching (a crossed book is allowed).
-  void beginPreOpen() noexcept { auctionMode_ = true; }
+  void beginPreOpen()
+  {
+    auctionMode_ = true;
+    publishStatus(TradingStatusReason::Auction);
+  }
 
   // Dispatch a sequenced operator action (see AdminCmd). Routing admin actions
   // through the command stream (not direct method calls) is what makes them
@@ -518,6 +696,12 @@ class MatchingEngine
       case AdminAction::Resume:
         setHalted(false);
         break;
+      case AdminAction::CloseSession:
+        closeSession();
+        break;
+      case AdminAction::OpenSession:
+        openSession();
+        break;
     }
   }
 
@@ -526,18 +710,24 @@ class MatchingEngine
   // book without matching until the operator calls openContinuous(), which
   // uncrosses at the single volume-maximizing price and switches to continuous.
   // This is how venues reopen after a halt -- never straight into continuous.
-  void resumeWithAuction() noexcept
+  void resumeWithAuction()
   {
     cfg_.halted = false;
     haltUntil_ = 0;
     auctionMode_ = true;
+    publishStatus(TradingStatusReason::Auction);
   }
   // Run the (opening / closing) uncross auction: match everything at the single
   // volume-maximizing price, then resume continuous trading.
   void openContinuous()
   {
+    // The uncross is a state of its own for exactly as long as it runs: a
+    // subscriber must be able to attribute the burst of fills to it rather than
+    // to continuous trading that has not resumed yet.
+    emitStatus(TradingStatus::AuctionUncross, TradingStatusReason::Auction, 0);
     runAuction();
     auctionMode_ = false;
+    publishStatus(TradingStatusReason::Auction);
   }
   // Explicit uncross without changing session mode (closing auction, etc.).
   void runAuction()
@@ -662,6 +852,23 @@ class MatchingEngine
     h = mix(h, static_cast<uint64_t>(cfg_.triggerRef));
     h = mix(h, auctionMode_ ? 1U : 0U);
     h = mix(h, static_cast<uint64_t>(haltUntil_));
+    // Session and funding state fold in only when they are set, the same
+    // "zero == absent" rule the balance traversal follows. An engine that has
+    // never been closed and never seen a funding rate or schedule therefore
+    // hashes exactly as it did before these fields existed -- which is what
+    // lets a snapshot written without them still verify on load.
+    if (closed_)
+    {
+      h = mix(h, 0xB00AU);
+      h = mix(h, 1U);
+    }
+    if (fundingRateRaw_ != 0 || fundingIntervalNs_ != 0 || nextFundingNs_ != 0)
+    {
+      h = mix(h, 0xB00BU);
+      h = mix(h, static_cast<uint64_t>(fundingRateRaw_));
+      h = mix(h, static_cast<uint64_t>(fundingIntervalNs_));
+      h = mix(h, static_cast<uint64_t>(nextFundingNs_));
+    }
     h = mix(h, hasLast_ ? 1U : 0U);
     h = mix(h, static_cast<uint64_t>(lastPrice_.raw()));
     h = mix(h, hasMark_ ? 1U : 0U);
@@ -915,6 +1122,21 @@ class MatchingEngine
     {
       out.append(InboundCommand{AdminCmd{cfg_.id, AdminAction::BeginPreOpen}}, ts);
     }
+    // The session state rides the same existing AdminCmd path the halt and the
+    // auction phase do. Written last of the three so it restores as the
+    // outermost state, exactly as tradingStatus() ranks it.
+    if (closed_)
+    {
+      out.append(InboundCommand{AdminCmd{cfg_.id, AdminAction::CloseSession}}, ts);
+    }
+    // Funding state: written only when there is any, so an engine with none
+    // produces the same file it did before the record existed (and that file
+    // still loads -- see RestoreFunding).
+    if (fundingRateRaw_ != 0 || fundingIntervalNs_ != 0 || nextFundingNs_ != 0)
+    {
+      out.append(InboundCommand{RestoreFunding{fundingRateRaw_, nextFundingNs_, fundingIntervalNs_}},
+                 ts);
+    }
 
     if (ledger_ != nullptr)
     {
@@ -1167,6 +1389,16 @@ class MatchingEngine
       }
       return true;
     }
+    if (const auto* r = std::get_if<RestoreFunding>(&cmd))
+    {
+      // Restored verbatim: the rate is a fact the venue published and the
+      // calendar is a fact it will settle on. Neither is re-derived from
+      // config, which is the whole point of the record.
+      fundingRateRaw_ = r->fundingRateRaw;
+      nextFundingNs_ = r->nextFundingNs > 0 ? r->nextFundingNs : 0;
+      fundingIntervalNs_ = r->fundingIntervalNs > 0 ? r->fundingIntervalNs : 0;
+      return true;
+    }
     if (const auto* r = std::get_if<RestoreReservation>(&cmd))
     {
       return applyRestoreReservation(*r);
@@ -1241,6 +1473,13 @@ class MatchingEngine
     e.positions_ = positions_;
     e.auctionMode_ = auctionMode_;
     e.haltUntil_ = haltUntil_;
+    e.closed_ = closed_;
+    e.lastStatus_ = lastStatus_;
+    e.lastStatusUntil_ = lastStatusUntil_;
+    e.statusPublished_ = statusPublished_;
+    e.fundingRateRaw_ = fundingRateRaw_;
+    e.fundingIntervalNs_ = fundingIntervalNs_;
+    e.nextFundingNs_ = nextFundingNs_;
     for (const auto& [acct, grp] : matcher_.stpGroups())
     {
       e.matcher_.setStpGroup(acct, grp);
@@ -1266,6 +1505,13 @@ class MatchingEngine
     if (o.symbol != cfg_.id)
     {
       return RejectReason::UnknownSymbol;
+    }
+    // Ahead of the halt check: a client whose order is refused deserves the
+    // outer reason. "The market is closed" tells it to come back next session;
+    // "halted" would tell it something is wrong with the instrument.
+    if (closed_)
+    {
+      return RejectReason::MarketClosed;
     }
     if (cfg_.halted)
     {
@@ -1586,6 +1832,63 @@ class MatchingEngine
   {
     cfg_.halted = true;  // trip a timed volatility pause
     haltUntil_ = now_ + cfg_.luldHaltNs;
+    publishStatus(TradingStatusReason::LuldBreach);
+  }
+
+  // ---- instrument-wide publications ----
+  // Emit the state the engine is now in, if it differs from the last one
+  // published. Every halt / pause / auction transition routes through here, so
+  // the feed carries transitions and only transitions: no duplicate on a
+  // re-halt of an already halted symbol, and nothing to infer downstream.
+  void publishStatus(TradingStatusReason reason)
+  {
+    const TradingStatus s = tradingStatus();
+    // The deadline belongs to the timed pause and to nothing else. A state that
+    // is not the pause publishes 0 even when a pause deadline is still stored
+    // underneath it (a closed session or an auction phase over a paused
+    // instrument) -- a subscriber must never be handed an expiry for a state
+    // that does not expire.
+    emitStatus(s, reason, s == TradingStatus::LuldPause ? haltUntil_ : 0);
+  }
+
+  void emitStatus(TradingStatus status, TradingStatusReason reason, int64_t untilNs)
+  {
+    if (statusPublished_ && status == lastStatus_ && untilNs == lastStatusUntil_)
+    {
+      return;
+    }
+    statusPublished_ = true;
+    lastStatus_ = status;
+    lastStatusUntil_ = untilNs;
+    sink_(TradingStatusChanged{cfg_.id, status, reason, untilNs});
+  }
+
+  // A settlement just happened, so the calendar moves on: one whole interval
+  // past the boundary that was settled, and further whole intervals if the
+  // settlement ran late enough that one step would still leave the boundary in
+  // the past (an operator catching up after an outage must not leave a stale
+  // "next funding" in the feed). Only an operator-set schedule moves -- with no
+  // schedule the published value is derived from `now` and moves by itself.
+  void advanceFundingSchedule()
+  {
+    if (fundingIntervalNs_ <= 0 || nextFundingNs_ <= 0)
+    {
+      return;
+    }
+    nextFundingNs_ += fundingIntervalNs_;
+    if (nextFundingNs_ <= now_)
+    {
+      const int64_t behind = now_ - nextFundingNs_;
+      nextFundingNs_ += (behind / fundingIntervalNs_ + 1) * fundingIntervalNs_;
+    }
+  }
+
+  // Emit the derivatives layer the engine knows: the mark it was just given,
+  // the last funding rate it applied, the next funding boundary of the
+  // configured schedule and the live open interest.
+  void publishDerivatives(Price mark)
+  {
+    sink_(DerivativesUpdated{cfg_.id, mark, fundingRateRaw_, nextFundingNs(), openInterest()});
   }
 
   // Conditional order (stop / take-profit / trailing): park in the stop book
@@ -1598,6 +1901,11 @@ class MatchingEngine
     if (o.symbol != cfg_.id)
     {
       sink_(OrderRejected{o.id, o.symbol, RejectReason::UnknownSymbol, o.accountId});
+      return false;
+    }
+    if (closed_)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::MarketClosed, o.accountId});
       return false;
     }
     if (cfg_.halted)
@@ -2897,6 +3205,12 @@ class MatchingEngine
     markPrice_ = Price::fromRaw(e.markPriceRaw);
     hasMark_ = e.hasMark;
     haltUntil_ = e.haltUntilNs;
+    // The restored flags are the state the feed must start from: re-sync the
+    // transition memo so the next real transition is measured against the
+    // recovered state, not against the one the config records replayed.
+    lastStatus_ = tradingStatus();
+    lastStatusUntil_ = lastStatus_ == TradingStatus::LuldPause ? haltUntil_ : 0;
+    statusPublished_ = true;
     // Full verification: the reconstructed state must hash to what the writer
     // measured. A mismatch (torn/corrupted/semantically-drifted snapshot)
     // rejects the generation.
@@ -3496,6 +3810,28 @@ class MatchingEngine
   std::unordered_map<uint64_t, Position> positions_;  // perp positions per account
   bool auctionMode_{false};
   int64_t haltUntil_{0};
+  // Session state, deliberately separate from cfg_.halted: a closed session and
+  // an operator halt are different facts with different reject reasons, and a
+  // close must not clear a halt underneath it. Hashed and checkpointed.
+  bool closed_{false};
+
+  // Last trading state published, so the feed carries transitions only. Not
+  // hashed and not snapshotted: it is a de-duplication memo of what went OUT,
+  // not engine state -- the state itself is (halted, haltUntil_, auctionMode_,
+  // closed_), which stateHash already covers and a snapshot already restores.
+  TradingStatus lastStatus_{TradingStatus::Trading};
+  int64_t lastStatusUntil_{0};
+  bool statusPublished_{false};
+
+  // Last funding rate applied, kFundingRateScale (published, never used in
+  // matching), and the live funding calendar set by SetFundingSchedule
+  // (0 = none: nextFundingNs() falls back to the config derivation). All three
+  // are hashed and carried by the checkpoint as RestoreFunding -- a restored
+  // engine publishes the rate and the boundary the venue will actually settle
+  // on, not a zero and a formula.
+  int64_t fundingRateRaw_{0};
+  int64_t fundingIntervalNs_{0};
+  int64_t nextFundingNs_{0};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/md_distribution.h
+++ b/venue/include/flox-venue/md_distribution.h
@@ -1,0 +1,698 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Unicast (TCP) market-data distribution.
+ *
+ * The multicast feed (udp_multicast.h) is the right feed for a consumer that
+ * sits inside the same layer-2 segment, and an impossible one for anybody
+ * else: multicast does not survive a WAN hop, most cloud networks do not route
+ * it, and a consumer behind NAT cannot join a group. This server is the same
+ * feed over an ordinary TCP connection, so an external consumer can take it
+ * from anywhere the venue is reachable.
+ *
+ * Nothing about sequencing is reinvented here. MarketDataPublisher stays the
+ * single source of truth -- per-message seq, the publisher epoch, the atomic
+ * (snapshot, lastSeq) pair and the bounded resend ring -- and this server is a
+ * fan-out in front of it. A subscriber on this channel and a subscriber on the
+ * multicast channel see the same messages with the same seq under the same
+ * epoch.
+ *
+ *   engine -> MarketDataPublisher -> sink
+ *                                     |-> UdpMdPublisher      (colocated)
+ *                                     `-> MdDistributionServer::publish
+ *                                            -> per-session encode
+ *                                               -> SessionWriter (bounded queue)
+ *                                                  -> writer thread -> socket
+ *
+ * Threading contract, the same one the order-entry delivery path holds: the
+ * matching thread NEVER blocks on a subscriber's socket. publish() encodes and
+ * hands the frame to the session's bounded queue; the write happens on that
+ * session's writer thread. A full queue is a slow consumer -- the connection is
+ * shut down, the frames are dropped and MdCounters::slowConsumerDisconnects is
+ * bumped. One slow subscriber cannot delay another and cannot delay the engine.
+ * (The one section where publish() waits on a session is the handover at the
+ * end of a subscribe: the snapshot frames are queued under the session mutex so
+ * they cannot be overtaken. That is a bounded, CPU-only stretch proportional to
+ * the book size -- never a socket wait.)
+ *
+ * Subscription handover. A snapshot taken while the feed keeps moving must
+ * neither lose an increment nor let one jump ahead of the book it belongs to.
+ * The session therefore registers the symbol UNARMED first: from that instant
+ * every increment for it is encoded and parked in a bounded per-symbol buffer.
+ * The snapshot is then taken outside the session lock (it takes the publisher's
+ * lock, which the fan-out holds while calling in -- taking both in that order
+ * would deadlock). Finally, under the session lock, the snapshot frames are
+ * queued, the parked increments past lastSeq are queued behind them, and the
+ * subscription arms at lastSeq+1.
+ *
+ * Resend on the same connection: ResendRequest{symbol, fromSeq} replays the
+ * increments from the publisher's ring; when fromSeq is older than the ring's
+ * tail the answer is the explicit "you need a snapshot" message followed by
+ * one -- the same two-way answer the recovery channel gives, inline in the
+ * session instead of on a connection of its own.
+ *
+ * Publisher restart: a message whose epoch differs from the subscription's
+ * resets the delivery position, so a feed that restarted at seq=1 is not
+ * filtered out as stale by a subscription still expecting seq=500. The
+ * subscriber sees the epoch change and re-subscribes.
+ *
+ * Encoding is chosen per connection by its FIRST BYTE, with no preamble of the
+ * venue's own invention:
+ *
+ *   0x00 -> SBE   (the high byte of the u32 frame length; feed frames are tens
+ *                  of bytes, so it is always zero)
+ *   '8'  -> FIX   (the first byte of the BeginString "8=FIX.4.4")
+ *
+ * The byte is peeked, not consumed, so both encodings speak their own protocol
+ * from their own first byte and an off-the-shelf implementation of either
+ * connects unmodified. One port serves both. registerEncoding() adds a third
+ * without touching a line of distribution logic, and MdDistributionConfig::
+ * encoding pins a port to one encoding when a deployment prefers that.
+ *
+ * Hardening: like the recovery channel and the order-entry gateways, this
+ * protocol carries no authentication and no encryption of its own. start()
+ * binds loopback unless given an explicit address; anything reachable off-host
+ * belongs behind TLS termination and/or a firewall. See
+ * docs/venue/market-data.md.
+ */
+#pragma once
+
+#include "flox-venue/fix_md_codec.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/md_encoder.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/session_registry.h"
+#include "flox-venue/socket_acceptor.h"
+
+#include "flox/util/transport.h"
+
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace flox::venue
+{
+
+enum class MdWireEncoding : uint8_t
+{
+  Auto,  // pick per connection from its first byte
+  Sbe,
+  Fix,
+};
+
+struct MdDistributionConfig
+{
+  size_t queueCapacity{4096};    // queued outbound writes before a subscriber is dropped
+  size_t pendingCapacity{4096};  // increments parked per symbol while its snapshot is in flight
+  int readTimeoutMs{200};        // socket read timeout: also the liveness tick
+  int idleTimeoutMs{30000};      // no inbound byte for this long -> drop the subscriber
+  int heartbeatMs{5000};         // send a heartbeat when the connection has been quiet
+  int sendBufferBytes{0};        // SO_SNDBUF on the accepted socket; 0 = kernel default
+  MdWireEncoding encoding{MdWireEncoding::Auto};
+};
+
+class MdDistributionServer
+{
+ public:
+  using EncoderFactory = std::function<std::unique_ptr<MdEncoder>()>;
+
+  explicit MdDistributionServer(MdCounters* counters = nullptr, MdDistributionConfig cfg = {})
+      : counters_(counters), cfg_(cfg)
+  {
+    encodings_[SbeMdEncoder::kLeadByte] = []
+    { return std::unique_ptr<MdEncoder>(new SbeMdEncoder()); };
+    encodings_[FixMdEncoder::kLeadByte] = [this]
+    { return std::unique_ptr<MdEncoder>(new FixMdEncoder(fixCfg_)); };
+  }
+
+  ~MdDistributionServer() { stop(); }
+
+  MdDistributionServer(const MdDistributionServer&) = delete;
+  MdDistributionServer& operator=(const MdDistributionServer&) = delete;
+
+  // Register the feed source for the publisher's symbol (one per symbol;
+  // re-adding replaces, e.g. after a publisher restart). The publisher must
+  // outlive the server, or be replaced before it is destroyed.
+  template <size_t Levels>
+  void addPublisher(MarketDataPublisher<Levels>& pub)
+  {
+    std::lock_guard<std::mutex> lk(sourcesMutex_);
+    sources_[pub.symbol()] = Source{[&pub]
+                                    { return pub.snapshotAtomic(); },
+                                    [&pub](uint64_t fromSeq)
+                                    { return pub.resendFrom(fromSeq); }};
+  }
+
+  // Add (or replace) an encoding, keyed by the first byte a client of it
+  // sends. Distribution logic is untouched by this.
+  void registerEncoding(uint8_t leadByte, EncoderFactory factory)
+  {
+    std::lock_guard<std::mutex> lk(sourcesMutex_);
+    encodings_[leadByte] = std::move(factory);
+  }
+
+  // CompIDs for the built-in FIX encoding. Must be set before start().
+  void setFixConfig(FixMdConfig cfg) { fixCfg_ = std::move(cfg); }
+
+  // Listen on bindIp:port (0 = ephemeral). Returns the bound port, or -1.
+  // bindIp nullptr/"" keeps the loopback-only default; an explicit address
+  // ("0.0.0.0", a NIC address) exposes the feed beyond the host under the
+  // hardening contract in the file comment.
+  int start(uint16_t port, const char* bindIp = nullptr)
+  {
+    return acceptor_.start(port, [this](int fd)
+                           { serve(fd); }, bindIp);
+  }
+
+  void stop() { acceptor_.stop(); }
+  int port() const noexcept { return acceptor_.port(); }
+
+  // Fan one published increment out to every subscriber of its symbol. Called
+  // from the MarketDataPublisher sink, i.e. on the matching thread: it encodes
+  // and enqueues, and never waits on a socket.
+  void publish(const MdMessage& m)
+  {
+    std::shared_lock<std::shared_mutex> lk(sessionsMutex_);
+    for (const auto& s : sessions_)
+    {
+      s->onIncrement(m);
+    }
+  }
+
+  size_t subscriberCount() const
+  {
+    std::shared_lock<std::shared_mutex> lk(sessionsMutex_);
+    return sessions_.size();
+  }
+
+ private:
+  struct Source
+  {
+    std::function<MdSnapshot()> snapshot;
+    std::function<std::optional<std::vector<MdMessage>>(uint64_t)> resend;
+  };
+
+  bool source(SymbolId symbol, Source& out) const
+  {
+    std::lock_guard<std::mutex> lk(sourcesMutex_);
+    const auto it = sources_.find(symbol);
+    if (it == sources_.end())
+    {
+      return false;
+    }
+    out = it->second;
+    return true;
+  }
+
+  // One connected subscriber: its encoder, its bounded outbound queue and its
+  // per-symbol subscriptions. Everything that touches the encoder or the queue
+  // runs under m_, so the reader thread and the matching thread never race and
+  // the wire order matches the order decisions were made in.
+  class Session
+  {
+   public:
+    Session(MdDistributionServer& server, std::unique_ptr<MdEncoder> enc, int fd)
+        : server_(server), enc_(std::move(enc))
+    {
+      writer_ = std::make_shared<SessionWriter>(
+          [fd](const uint8_t* p, size_t n)
+          { return net::writeAll(fd, p, n); }, [fd]
+          { ::shutdown(fd, SHUT_RDWR); }, server_.cfg_.queueCapacity, &writerCounters_);
+    }
+
+    ~Session() { writer_->stop(); }
+
+    const char* encodingName() const noexcept { return enc_->name(); }
+    bool dead() const { return writer_->dead(); }
+    void stop() { writer_->stop(); }
+
+    // Producer side (matching thread).
+    void onIncrement(const MdMessage& m)
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      const auto it = subs_.find(m.symbol);
+      if (it == subs_.end())
+      {
+        return;
+      }
+      Sub& s = it->second;
+      scratch_.clear();
+      enc_->increment(m, scratch_);
+      if (scratch_.empty())
+      {
+        return;  // the encoding has no form for this message
+      }
+      if (!s.armed)
+      {
+        if (s.pending.size() >= server_.cfg_.pendingCapacity)
+        {
+          // The subscriber cannot even absorb its own snapshot handover: the
+          // same slow-consumer verdict, reached one step earlier.
+          writer_->kill();
+          if (!slowCounted_)
+          {
+            slowCounted_ = true;
+            if (server_.counters_ != nullptr)
+            {
+              server_.counters_->slowConsumerDisconnects.fetch_add(1, std::memory_order_relaxed);
+            }
+          }
+          return;
+        }
+        s.pending.emplace_back(m.seq, scratch_);
+        return;
+      }
+      if (s.epoch == 0)
+      {
+        s.epoch = m.epoch;
+      }
+      else if (m.epoch != s.epoch)
+      {
+        // The publisher restarted: seq began again at 1 under a new epoch, so
+        // the old delivery position would silently swallow the new stream.
+        s.epoch = m.epoch;
+        s.deliverFrom = m.seq;
+      }
+      if (m.seq < s.deliverFrom)
+      {
+        return;  // already covered by the snapshot or the replay
+      }
+      enqueueLocked(scratch_);
+    }
+
+    // Consumer side (this connection's reader thread).
+    void handle(const MdRequest& req)
+    {
+      switch (req.kind)
+      {
+        case MdRequestKind::Subscribe:
+        case MdRequestKind::Resend:
+          armFrom(req.symbol, req.fromSeq, req.snapshotOnly);
+          break;
+        case MdRequestKind::Unsubscribe:
+        {
+          std::lock_guard<std::mutex> lk(m_);
+          subs_.erase(req.symbol);
+          break;
+        }
+        case MdRequestKind::None:
+        case MdRequestKind::Close:
+          break;
+      }
+    }
+
+    void enqueue(const std::vector<uint8_t>& frames)
+    {
+      if (frames.empty())
+      {
+        return;
+      }
+      std::lock_guard<std::mutex> lk(m_);
+      enqueueLocked(frames);
+    }
+
+    void sendHeartbeat()
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      scratch_.clear();
+      enc_->heartbeat(scratch_);
+      enqueueLocked(scratch_);
+    }
+
+    // Decode one inbound message. The encoder is session state, so parsing is
+    // serialized with the fan-out like every other use of it.
+    MdEncoder::Parse parse(const uint8_t* in, size_t n, size_t& consumed,
+                           std::vector<MdRequest>& out, std::vector<uint8_t>& reply)
+    {
+      std::lock_guard<std::mutex> lk(m_);
+      return enc_->parse(in, n, consumed, out, reply);
+    }
+
+   private:
+    struct Sub
+    {
+      bool armed{false};                                               // false while the snapshot for this symbol is in flight
+      uint64_t deliverFrom{0};                                         // first seq this subscriber still needs
+      uint64_t epoch{0};                                               // publisher lifetime the position belongs to
+      std::vector<std::pair<uint64_t, std::vector<uint8_t>>> pending;  // parked during handover
+    };
+
+    // Subscribe, resume or resend -- one path, because they are one thing:
+    // "put this subscriber at fromSeq and keep it there". fromSeq 0 (or older
+    // than the ring) means the snapshot; otherwise the ring replay.
+    void armFrom(SymbolId symbol, uint64_t fromSeq, bool snapshotOnly)
+    {
+      {
+        // Park increments from this instant on, so the window between here and
+        // the handover below loses nothing.
+        std::lock_guard<std::mutex> lk(m_);
+        Sub& s = subs_[symbol];
+        s.armed = false;
+        s.pending.clear();
+      }
+
+      Source src;
+      if (!server_.source(symbol, src))
+      {
+        std::lock_guard<std::mutex> lk(m_);
+        subs_.erase(symbol);
+        scratch_.clear();
+        enc_->reject(symbol, MdRejectReason::UnknownSymbol, scratch_);
+        enqueueLocked(scratch_);
+        if (server_.counters_ != nullptr)
+        {
+          server_.counters_->subscribeRejects.fetch_add(1, std::memory_order_relaxed);
+        }
+        return;
+      }
+
+      // Outside the session lock: these take the publisher's lock, and the
+      // fan-out calls in while holding it.
+      std::optional<std::vector<MdMessage>> replay;
+      if (fromSeq > 0)
+      {
+        replay = src.resend(fromSeq);
+      }
+      std::optional<MdSnapshot> snap;
+      if (!replay.has_value())
+      {
+        snap = src.snapshot();
+      }
+
+      std::lock_guard<std::mutex> lk(m_);
+      const auto it = subs_.find(symbol);
+      if (it == subs_.end())
+      {
+        return;  // unsubscribed while the snapshot was being taken
+      }
+      Sub& s = it->second;
+      uint64_t deliverFrom = 0;
+      uint64_t epoch = 0;
+      scratch_.clear();
+      if (replay.has_value())
+      {
+        for (const MdMessage& m : *replay)
+        {
+          enc_->increment(m, scratch_);
+        }
+        deliverFrom = replay->empty() ? fromSeq : replay->back().seq + 1;
+        epoch = replay->empty() ? 0 : replay->back().epoch;
+        if (server_.counters_ != nullptr)
+        {
+          server_.counters_->resendServed.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+      else
+      {
+        if (fromSeq > 0)
+        {
+          // The increments asked for have been trimmed: say so explicitly
+          // before the book that replaces them.
+          enc_->snapshotRequired(symbol, snap->epoch, snap->lastSeq, scratch_);
+        }
+        enc_->snapshot(symbol, *snap, scratch_);
+        deliverFrom = snap->lastSeq + 1;
+        epoch = snap->epoch;
+        if (server_.counters_ != nullptr)
+        {
+          server_.counters_->snapshotsServed.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+      enqueueLocked(scratch_);
+      for (auto& [seq, frame] : s.pending)
+      {
+        if (seq >= deliverFrom)
+        {
+          enqueueLocked(frame);
+        }
+      }
+      s.pending.clear();
+      s.armed = true;
+      s.deliverFrom = deliverFrom;
+      s.epoch = epoch;
+      if (snapshotOnly)
+      {
+        subs_.erase(it);  // one book, no stream
+      }
+    }
+
+    void enqueueLocked(const std::vector<uint8_t>& frames)
+    {
+      if (frames.empty())
+      {
+        return;
+      }
+      writer_->enqueue(frames);
+      noteWriterLocked();
+    }
+
+    // SessionWriter latches the overflow verdict once per connection into its
+    // own counters; mirror that single transition onto the feed counters.
+    void noteWriterLocked()
+    {
+      if (slowCounted_ ||
+          writerCounters_.slowConsumerDisconnects.load(std::memory_order_relaxed) == 0)
+      {
+        return;
+      }
+      slowCounted_ = true;
+      if (server_.counters_ != nullptr)
+      {
+        server_.counters_->slowConsumerDisconnects.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+
+    MdDistributionServer& server_;
+    mutable std::mutex m_;
+    std::unique_ptr<MdEncoder> enc_;
+    std::shared_ptr<SessionWriter> writer_;
+    GatewayCounters writerCounters_;  // per-connection, so the overflow verdict is exact
+    std::unordered_map<SymbolId, Sub> subs_;
+    std::vector<uint8_t> scratch_;  // encode buffer, guarded by m_
+    bool slowCounted_{false};
+  };
+
+  // Pick the encoding for a fresh connection from its first byte WITHOUT
+  // consuming it, so each protocol still starts at its own first byte.
+  std::unique_ptr<MdEncoder> makeEncoder(int fd)
+  {
+    uint8_t lead = 0;
+    switch (cfg_.encoding)
+    {
+      case MdWireEncoding::Sbe:
+        lead = SbeMdEncoder::kLeadByte;
+        break;
+      case MdWireEncoding::Fix:
+        lead = FixMdEncoder::kLeadByte;
+        break;
+      case MdWireEncoding::Auto:
+      {
+        // The socket carries a read timeout (it is also the liveness tick), so
+        // wait for the first byte across ticks rather than dropping a client
+        // that connects a moment before it speaks.
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(cfg_.idleTimeoutMs);
+        ssize_t r = -1;
+        while (acceptor_.running() && std::chrono::steady_clock::now() < deadline)
+        {
+          r = ::recv(fd, &lead, 1, MSG_PEEK);
+          if (r == 1)
+          {
+            break;
+          }
+          if (r == 0 || (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR))
+          {
+            return nullptr;
+          }
+        }
+        if (r != 1)
+        {
+          return nullptr;
+        }
+        break;
+      }
+    }
+    std::lock_guard<std::mutex> lk(sourcesMutex_);
+    const auto it = encodings_.find(lead);
+    return it == encodings_.end() ? nullptr : it->second();
+  }
+
+  void serve(int fd)
+  {
+    timeval tv{};
+    tv.tv_sec = cfg_.readTimeoutMs / 1000;
+    tv.tv_usec = (cfg_.readTimeoutMs % 1000) * 1000;
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    // Deliberately NO send timeout. The writer thread is allowed to block on a
+    // wedged peer -- that is what it is for. The slow-consumer verdict belongs
+    // to the venue's own bounded queue, not to a socket timer that would
+    // misreport a slow reader as a broken connection. Bounding SO_SNDBUF keeps
+    // the kernel from hiding backlog the queue is supposed to see.
+    if (cfg_.sendBufferBytes > 0)
+    {
+      const int sz = cfg_.sendBufferBytes;
+      ::setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sz, sizeof sz);
+    }
+
+    auto enc = makeEncoder(fd);
+    if (!enc)
+    {
+      return;  // unknown encoding, or the peer never sent its first byte
+    }
+
+    auto session = std::make_shared<Session>(*this, std::move(enc), fd);
+    {
+      std::unique_lock<std::shared_mutex> lk(sessionsMutex_);
+      sessions_.push_back(session);
+    }
+    if (counters_ != nullptr)
+    {
+      counters_->subscribers.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    readLoop(fd, *session);
+
+    {
+      std::unique_lock<std::shared_mutex> lk(sessionsMutex_);
+      for (auto it = sessions_.begin(); it != sessions_.end(); ++it)
+      {
+        if (*it == session)
+        {
+          sessions_.erase(it);
+          break;
+        }
+      }
+    }
+    if (counters_ != nullptr)
+    {
+      counters_->subscribers.fetch_sub(1, std::memory_order_relaxed);
+    }
+    // The writer thread may be parked in a blocking write on a peer that
+    // stopped reading; shut the socket down so it comes back and can be
+    // joined. The acceptor still owns the close.
+    ::shutdown(fd, SHUT_RDWR);
+    session->stop();
+  }
+
+  void readLoop(int fd, Session& session)
+  {
+    std::vector<uint8_t> in;
+    uint8_t chunk[4096];
+    const auto idleLimit = std::chrono::milliseconds(cfg_.idleTimeoutMs);
+    const auto beatEvery = std::chrono::milliseconds(cfg_.heartbeatMs);
+    auto lastIn = std::chrono::steady_clock::now();
+    auto lastBeat = lastIn;
+
+    while (acceptor_.running())
+    {
+      const ssize_t r = ::recv(fd, chunk, sizeof chunk, 0);
+      if (r > 0)
+      {
+        lastIn = std::chrono::steady_clock::now();
+        in.insert(in.end(), chunk, chunk + r);
+        if (!drain(in, session))
+        {
+          return;
+        }
+      }
+      else if (r == 0)
+      {
+        return;  // peer closed
+      }
+      else if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR)
+      {
+        return;
+      }
+
+      if (session.dead())
+      {
+        return;  // slow consumer, or the peer vanished mid-write
+      }
+      const auto now = std::chrono::steady_clock::now();
+      if (now - lastIn > idleLimit)
+      {
+        if (counters_ != nullptr)
+        {
+          counters_->idleDisconnects.fetch_add(1, std::memory_order_relaxed);
+        }
+        return;
+      }
+      if (now - lastBeat >= beatEvery)
+      {
+        lastBeat = now;
+        session.sendHeartbeat();
+      }
+    }
+  }
+
+  // Decode as many complete messages as the buffer holds. False tears the
+  // session down (protocol error, or the peer asked to close).
+  bool drain(std::vector<uint8_t>& in, Session& session)
+  {
+    size_t off = 0;
+    while (off < in.size())
+    {
+      size_t consumed = 0;
+      std::vector<MdRequest> reqs;
+      std::vector<uint8_t> reply;
+      const MdEncoder::Parse st =
+          session.parse(in.data() + off, in.size() - off, consumed, reqs, reply);
+      if (st == MdEncoder::Parse::Need)
+      {
+        break;
+      }
+      if (st == MdEncoder::Parse::Bad || consumed == 0)
+      {
+        return false;
+      }
+      off += consumed;
+      session.enqueue(reply);
+      bool close = false;
+      for (const MdRequest& req : reqs)
+      {
+        if (req.kind == MdRequestKind::Close)
+        {
+          close = true;
+          continue;
+        }
+        session.handle(req);
+      }
+      if (close)
+      {
+        in.erase(in.begin(), in.begin() + static_cast<long>(off));
+        return false;
+      }
+    }
+    in.erase(in.begin(), in.begin() + static_cast<long>(off));
+    return true;
+  }
+
+  MdCounters* counters_;
+  MdDistributionConfig cfg_;
+  FixMdConfig fixCfg_;
+  SocketAcceptor acceptor_;
+  mutable std::mutex sourcesMutex_;
+  std::unordered_map<SymbolId, Source> sources_;
+  std::unordered_map<uint8_t, EncoderFactory> encodings_;
+  mutable std::shared_mutex sessionsMutex_;
+  std::vector<std::shared_ptr<Session>> sessions_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/md_encoder.h
+++ b/venue/include/flox-venue/md_encoder.h
@@ -1,0 +1,254 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Pluggable wire encoding for the unicast market-data distribution server
+ * (md_distribution.h).
+ *
+ * Transport and encoding are independent axes. The distribution server owns
+ * the transport and the semantics -- subscriptions, the atomic snapshot, the
+ * bounded resend ring, seq/epoch, the slow-consumer policy -- and knows
+ * nothing about the bytes. An MdEncoder owns the bytes and knows nothing about
+ * the semantics: it turns the peer's inbound stream into MdRequest values and
+ * turns snapshots / increments / rejects / heartbeats into wire bytes. Adding
+ * an encoding is writing one MdEncoder and registering it; no distribution
+ * logic changes.
+ *
+ * One encoder instance per connection, so an encoder may hold per-session
+ * state (a sequence counter, the peer's request ids). Every call on it is
+ * serialized by the session, on either the connection's reader thread or the
+ * publishing thread -- an implementation needs no locking of its own.
+ *
+ * FRAMING BELONGS TO THE ENCODER. Every method appends COMPLETE, self-framed
+ * wire bytes to `out` (length prefixes, FIX BodyLength/CheckSum, ... all
+ * included); the session writes those bytes to the socket verbatim. That is
+ * what lets one server carry a length-prefixed binary encoding and a
+ * self-delimiting text encoding on the same port. Appending -- not clearing --
+ * lets one call batch a whole snapshot into a single queued write.
+ */
+#pragma once
+
+#include "flox-venue/market_data.h"
+#include "flox-venue/sbe_md_codec.h"
+
+#include "flox/util/transport.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace flox::venue
+{
+
+enum class MdRequestKind : uint8_t
+{
+  None,         // a session-level frame that needs no distribution action (heartbeat, logon)
+  Subscribe,    // start (or resume) streaming a symbol on this connection
+  Unsubscribe,  // stop streaming a symbol; other symbols keep flowing
+  Resend,       // fill a gap: replay from `fromSeq`, or say a snapshot is needed
+  Close,        // the peer asked for an orderly shutdown
+};
+
+// One decoded distribution request. A single inbound message may carry
+// several (a market-data request naming several symbols decodes into one
+// Subscribe per symbol), which is why parse() fills a vector.
+struct MdRequest
+{
+  MdRequestKind kind{MdRequestKind::None};
+  SymbolId symbol{};
+  uint64_t fromSeq{0};       // Subscribe/Resend: 0 = full snapshot, >0 = resume at that seq
+  bool snapshotOnly{false};  // serve one snapshot, then drop the subscription
+};
+
+enum class MdRejectReason : uint8_t
+{
+  UnknownSymbol,       // no publisher registered for the symbol
+  UnsupportedRequest,  // the request type itself cannot be served
+};
+
+class MdEncoder
+{
+ public:
+  enum class Parse : uint8_t
+  {
+    Need,  // an incomplete message at the head of the buffer: read more bytes
+    Ok,    // `consumed` bytes decoded; `out` and/or `reply` filled (both may be empty)
+    Bad,   // unparseable / protocol violation: the session is torn down
+  };
+
+  virtual ~MdEncoder() = default;
+
+  // Human-readable encoding name, for logs and tests.
+  virtual const char* name() const noexcept = 0;
+
+  // Decode ONE message from the head of [in, in+n). On Ok, `consumed` is that
+  // message's length in bytes, `out` gets the distribution requests it carries
+  // and `reply` gets any session-level answer the encoding owes the peer (a
+  // logon acknowledgement, a heartbeat echo, a protocol-level reject) -- the
+  // session queues `reply` verbatim before acting on `out`.
+  virtual Parse parse(const uint8_t* in, size_t n, size_t& consumed, std::vector<MdRequest>& out,
+                      std::vector<uint8_t>& reply) = 0;
+
+  // Full-book snapshot for `symbol`, consistent with the incremental stream at
+  // snap.lastSeq under snap.epoch.
+  virtual void snapshot(SymbolId symbol, const MdSnapshot& snap, std::vector<uint8_t>& out) = 0;
+
+  // One incremental message. May append nothing when the encoding has no form
+  // for it (the session then queues nothing).
+  virtual void increment(const MdMessage& m, std::vector<uint8_t>& out) = 0;
+
+  // "The increments you asked for are gone, a snapshot follows." Encodings
+  // whose snapshot already carries that meaning append nothing.
+  virtual void snapshotRequired(SymbolId symbol, uint64_t epoch, uint64_t lastSeq,
+                                std::vector<uint8_t>& out) = 0;
+
+  // A request that cannot be served at all; no subscription is left behind.
+  virtual void reject(SymbolId symbol, MdRejectReason reason, std::vector<uint8_t>& out) = 0;
+
+  // Liveness beat, sent when the connection has been quiet.
+  virtual void heartbeat(std::vector<uint8_t>& out) = 0;
+};
+
+// SBE encoding: the same schema and the same templates the multicast feed and
+// the recovery channel use (sbe_md_codec.h), carried over TCP in the same
+// length-prefixed frames (flox::net framing). A consumer that already decodes
+// the multicast feed decodes this stream with the same code -- the only new
+// templates are the session verbs (Subscribe / Unsubscribe / SubscribeReject).
+//
+// Inbound verbs: Subscribe (11), Unsubscribe (12), ResendRequest (7). An empty
+// frame is the client's heartbeat; the server answers idleness with the same.
+class SbeMdEncoder final : public MdEncoder
+{
+ public:
+  // Lead byte of an SBE distribution stream: the high byte of the u32
+  // big-endian frame length. Distribution frames are tens of bytes, so it is
+  // always zero -- which is what distinguishes them from a text encoding.
+  static constexpr uint8_t kLeadByte = 0x00;
+
+  const char* name() const noexcept override { return "SBE"; }
+
+  Parse parse(const uint8_t* in, size_t n, size_t& consumed, std::vector<MdRequest>& out,
+              std::vector<uint8_t>& reply) override
+  {
+    (void)reply;
+    if (n < 4)
+    {
+      return Parse::Need;
+    }
+    const uint32_t len = (static_cast<uint32_t>(in[0]) << 24) | (static_cast<uint32_t>(in[1]) << 16) |
+                         (static_cast<uint32_t>(in[2]) << 8) | static_cast<uint32_t>(in[3]);
+    if (len > net::kMaxFrame)
+    {
+      return Parse::Bad;  // hostile length prefix: never reserve on it
+    }
+    if (n < 4 + static_cast<size_t>(len))
+    {
+      return Parse::Need;
+    }
+    consumed = 4 + static_cast<size_t>(len);
+    if (len == 0)
+    {
+      return Parse::Ok;  // client heartbeat
+    }
+    const uint8_t* p = in + 4;
+    switch (static_cast<SbeMdCodec::Tmpl>(SbeMdCodec::templateId(p, len)))
+    {
+      case SbeMdCodec::Tmpl::Subscribe:
+      {
+        MdSubscribeRequest s{};
+        if (!SbeMdCodec::decode(p, len, s))
+        {
+          return Parse::Bad;
+        }
+        out.push_back(MdRequest{MdRequestKind::Subscribe, s.symbol, s.fromSeq, s.snapshotOnly});
+        return Parse::Ok;
+      }
+      case SbeMdCodec::Tmpl::Unsubscribe:
+      {
+        MdUnsubscribeRequest u{};
+        if (!SbeMdCodec::decode(p, len, u))
+        {
+          return Parse::Bad;
+        }
+        out.push_back(MdRequest{MdRequestKind::Unsubscribe, u.symbol, 0, false});
+        return Parse::Ok;
+      }
+      case SbeMdCodec::Tmpl::ResendRequest:
+      {
+        MdResendRequest r{};
+        if (!SbeMdCodec::decode(p, len, r))
+        {
+          return Parse::Bad;
+        }
+        out.push_back(MdRequest{MdRequestKind::Resend, r.symbol, r.fromSeq, false});
+        return Parse::Ok;
+      }
+      default:
+        return Parse::Bad;  // not an inbound verb
+    }
+  }
+
+  void snapshot(SymbolId symbol, const MdSnapshot& snap, std::vector<uint8_t>& out) override
+  {
+    appendFrame(out, MdSnapshotBegin{symbol, snap.epoch, snap.lastSeq,
+                                     static_cast<uint32_t>(snap.orders.size())});
+    // State before book: the subscriber knows whether the instrument is halted,
+    // paused or auctioning -- and what the position is worth -- before it
+    // applies a single order. orderCount stays the AddOrder count.
+    if (snap.hasStatus)
+    {
+      appendFrame(out, snap.status);
+    }
+    if (snap.hasDerivatives)
+    {
+      appendFrame(out, snap.derivatives);
+    }
+    for (const MdMessage& m : snap.orders)
+    {
+      appendFrame(out, m);
+    }
+    appendFrame(out, MdSnapshotEnd{symbol, snap.epoch, snap.lastSeq});
+  }
+
+  void increment(const MdMessage& m, std::vector<uint8_t>& out) override { appendFrame(out, m); }
+
+  void snapshotRequired(SymbolId symbol, uint64_t epoch, uint64_t lastSeq,
+                        std::vector<uint8_t>& out) override
+  {
+    appendFrame(out, MdSnapshotRequired{symbol, epoch, lastSeq});
+  }
+
+  void reject(SymbolId symbol, MdRejectReason reason, std::vector<uint8_t>& out) override
+  {
+    appendFrame(out, MdSubscribeReject{symbol, reason == MdRejectReason::UnknownSymbol
+                                                   ? MdSubscribeRejectReason::UnknownSymbol
+                                                   : MdSubscribeRejectReason::UnsupportedRequest});
+  }
+
+  // An empty frame: a beat that costs four bytes and needs no template.
+  void heartbeat(std::vector<uint8_t>& out) override
+  {
+    const uint8_t hdr[4] = {0, 0, 0, 0};
+    out.insert(out.end(), hdr, hdr + 4);
+  }
+
+ private:
+  template <typename T>
+  void appendFrame(std::vector<uint8_t>& out, const T& msg)
+  {
+    SbeMdCodec::encode(msg, scratch_);
+    const size_t n = scratch_.size();
+    const uint8_t hdr[4] = {static_cast<uint8_t>(n >> 24), static_cast<uint8_t>(n >> 16),
+                            static_cast<uint8_t>(n >> 8), static_cast<uint8_t>(n)};
+    out.insert(out.end(), hdr, hdr + 4);
+    out.insert(out.end(), scratch_.begin(), scratch_.end());
+  }
+
+  std::vector<uint8_t> scratch_;
+};
+
+}  // namespace flox::venue

--- a/venue/include/flox-venue/md_recovery.h
+++ b/venue/include/flox-venue/md_recovery.h
@@ -161,6 +161,26 @@ class MdRecoveryServer
     {
       return;
     }
+    // Current trading status and derivatives layer BEFORE the book body: a
+    // consumer that reconnects into a halted or paused instrument must not have
+    // to guess it from the absence of increments (SnapshotBegin's orderCount
+    // still counts only the AddOrder body).
+    if (snap.hasStatus)
+    {
+      SbeMdCodec::encode(snap.status, buf);
+      if (!net::writeFrame(fd, buf.data(), buf.size()))
+      {
+        return;
+      }
+    }
+    if (snap.hasDerivatives)
+    {
+      SbeMdCodec::encode(snap.derivatives, buf);
+      if (!net::writeFrame(fd, buf.data(), buf.size()))
+      {
+        return;
+      }
+    }
     for (const MdMessage& m : snap.orders)
     {
       SbeMdCodec::encode(m, buf);
@@ -210,6 +230,12 @@ class MdRecoveryClient
     std::vector<MdMessage> messages;  // replayed increments, or AddOrder body records (seq=0)
     MdSnapshotBegin begin{};          // valid when `snapshot`
     MdSnapshotEnd end{};              // valid when `snapshot`
+    // Instrument state carried by a snapshot, kept OUT of `messages` so that
+    // vector stays exactly what it has always been -- the book body.
+    bool hasStatus{false};
+    MdMessage status{};
+    bool hasDerivatives{false};
+    MdMessage derivatives{};
     // Resume point: the incremental feed continues at lastSeq + 1. On the
     // snapshot path these come from SnapshotEnd; on a replay, from the last
     // increment. An EMPTY replay (fromSeq ahead of the stream) keeps the
@@ -302,7 +328,24 @@ class MdRecoveryClient
           {
             return Status::ProtocolError;
           }
-          out.messages.push_back(m);
+          // Inside a snapshot these two are the instrument's CURRENT state
+          // (seq=0), not book records, so they are lifted out of the body. On a
+          // replay they are ordinary sequenced increments and must stay in the
+          // stream -- diverting them there would punch a hole in the seq run.
+          if (out.snapshot && m.type == MdType::TradingStatus)
+          {
+            out.hasStatus = true;
+            out.status = m;
+          }
+          else if (out.snapshot && m.type == MdType::DerivativesUpdate)
+          {
+            out.hasDerivatives = true;
+            out.derivatives = m;
+          }
+          else
+          {
+            out.messages.push_back(m);
+          }
           break;
         }
       }
@@ -382,12 +425,21 @@ class RecoveringMdSubscriber
   using SnapshotFn = std::function<void(SymbolId symbol, const MdSnapshotBegin& begin,
                                         const std::vector<MdMessage>& orders)>;
 
+  // Instrument state carried by the same snapshot: the CURRENT trading status
+  // and derivatives layer (null when the publisher has not published one yet).
+  // Separate from SnapshotFn because these are not book records -- a consumer
+  // that only rebuilds a book ignores them, one that tracks halts or values a
+  // perp position takes them before applying the body.
+  using SnapshotStateFn =
+      std::function<void(SymbolId symbol, const MdMessage* status, const MdMessage* derivatives)>;
+
   RecoveringMdSubscriber(UdpMdSubscriber& sub, Config cfg, GapDetector::Config gdCfg = {})
       : sub_(sub), cfg_(std::move(cfg)), gd_(gdCfg)
   {
   }
 
   void onSnapshot(SnapshotFn fn) { onSnapshot_ = std::move(fn); }
+  void onSnapshotState(SnapshotStateFn fn) { onSnapshotState_ = std::move(fn); }
 
   // Receive the next IN-ORDER message; false on socket timeout / error with
   // no recovery pending (a pending recovery is serviced before giving up).
@@ -520,6 +572,11 @@ class RecoveringMdSubscriber
       // Server chose (or we requested) the snapshot path. Hand the book body
       // to the consumer, then fast-forward the sequencer: held datagrams past
       // lastSeq drain into the in-order stream immediately.
+      if (onSnapshotState_)
+      {
+        onSnapshotState_(sym, res.hasStatus ? &res.status : nullptr,
+                         res.hasDerivatives ? &res.derivatives : nullptr);
+      }
       if (onSnapshot_)
       {
         onSnapshot_(sym, res.begin, res.messages);
@@ -548,6 +605,7 @@ class RecoveringMdSubscriber
   Config cfg_;
   GapDetector gd_;
   SnapshotFn onSnapshot_;
+  SnapshotStateFn onSnapshotState_;
   std::deque<MdMessage> ready_;  // sequenced, deliverable messages
   std::unordered_map<SymbolId, Pending> pending_;
   uint64_t gaps_{0};

--- a/venue/include/flox-venue/messages.h
+++ b/venue/include/flox-venue/messages.h
@@ -138,6 +138,16 @@ enum class AdminAction : uint8_t
   HaltAndCancelAll,  // emergency: halt + cancel the entire resting book
   Halt,              // reject new orders
   Resume,            // clear halt
+  // Session boundary. Appended values (the enum is append-only: it rides an
+  // existing journal tag, so a reordering would reinterpret every AdminCmd
+  // record already on disk). Carried by AdminCmd rather than a command of its
+  // own on purpose: a session transition is the same KIND of state as a halt or
+  // an auction phase -- an operator action that mutates matchable state and must
+  // replay at its exact point in the stream -- so it belongs in the record that
+  // already carries those, and costs no new journal tag, no expectedBodySize
+  // entry and no snapshot-format change.
+  CloseSession,  // close the session: new orders rejected (MarketClosed), the book stands
+  OpenSession,   // reopen the session; the halt/auction state underneath is untouched
 };
 
 struct AdminCmd
@@ -213,6 +223,24 @@ struct SetStpGroup
 struct TimeTick
 {
   SymbolId symbol{};  // routing key
+};
+
+// Perp funding calendar as STATE rather than as a formula. Without it the next
+// funding boundary is derived from (now, SymbolConfig::fundingIntervalNs) -- a
+// computation over startup config, not a fact, which silently disagrees with
+// reality the moment an operator changes the interval or shifts a settlement.
+// This command makes the calendar an engine fact: journaled, so it replays;
+// hashed and checkpointed (RestoreFunding), so it survives a restart; and
+// published on the derivatives feed as the actual next boundary. ApplyFunding
+// then advances nextFundingNs by whole intervals.
+//
+// The engine still settles funding only when told to (ApplyFunding). This is
+// the calendar it publishes and advances, NOT a timer that fires payments.
+struct SetFundingSchedule
+{
+  SymbolId symbol{};
+  int64_t intervalNs{0};     // funding interval (<= 0 clears the schedule)
+  int64_t nextFundingNs{0};  // next settlement boundary, sequencer time (<= 0 clears)
 };
 
 // ---- Snapshot-only records ------------------------------------------------
@@ -386,6 +414,23 @@ struct RestoreMmpFills
   int64_t qtyRaw[kMmpFillBatch]{};
 };
 
+// Derivatives funding state: the last applied rate and the live funding
+// calendar. A snapshot-only record and not three more fields on SnapshotEnd,
+// because SnapshotEnd is a strictly-sized journal body -- widening it would
+// change its expectedBodySize and make every existing snapshot unreadable
+// (the loader stops at the first wrong-sized record). The same additive path
+// balances (RestoreBalance), MMP windows (RestoreMmpFills) and STP groups took.
+//
+// A snapshot written by an engine with no funding state at all does not carry
+// this record; a file without it restores rate 0 and no schedule, exactly as
+// before the record existed (read compatibility, pinned by a test).
+struct RestoreFunding
+{
+  int64_t fundingRateRaw{0};     // last applied rate, kFundingRateScale
+  int64_t nextFundingNs{0};      // next settlement boundary (0 = no schedule set)
+  int64_t fundingIntervalNs{0};  // schedule interval (0 = no schedule set)
+};
+
 struct SnapshotEnd
 {
   uint64_t stateHash{0};  // must equal the loader's recomputed hash, or the snapshot is corrupt
@@ -405,13 +450,14 @@ struct SnapshotEnd
 // (SetTriggerRef postdates TimeTick, hence its position at the tail; the
 // snapshot-only records postdate SetTriggerRef; RestoreBalance/RestoreMmpFills
 // and the live SetStpGroup command postdate the original snapshot block, so
-// live and snapshot-only tags interleave past tag 24.)
+// live and snapshot-only tags interleave past tag 24. SetFundingSchedule (live)
+// and RestoreFunding (snapshot-only) are the newest pair, tags 28 and 29.)
 using InboundCommand =
     std::variant<NewOrder, CancelOrder, ModifyOrder, MassCancel, Quote, LastLookDecision, SetMark,
                  ApplyFunding, AdminCmd, Deposit, Withdraw, ListInstrument, SetBands, TimeTick,
                  SetTriggerRef, SnapshotBegin, RestoreOrder, RestoreStop, RestorePeg, RestoreHeld,
                  RestorePosition, RestoreMmpCfg, RestoreClOrdIds, SnapshotEnd, RestoreReservation,
-                 RestoreBalance, RestoreMmpFills, SetStpGroup>;
+                 RestoreBalance, RestoreMmpFills, SetStpGroup, SetFundingSchedule, RestoreFunding>;
 
 inline constexpr size_t kFirstSnapshotTag = 15;
 inline constexpr size_t kLastContiguousSnapshotTag = 24;
@@ -431,7 +477,8 @@ inline bool isSnapshotRecord(const InboundCommand& c) noexcept
 {
   const size_t i = c.index();
   return (i >= kFirstSnapshotTag && i <= kLastContiguousSnapshotTag) ||
-         std::holds_alternative<RestoreBalance>(c) || std::holds_alternative<RestoreMmpFills>(c);
+         std::holds_alternative<RestoreBalance>(c) || std::holds_alternative<RestoreMmpFills>(c) ||
+         std::holds_alternative<RestoreFunding>(c);
 }
 
 // ---- Outbound events ------------------------------------------------------
@@ -599,11 +646,89 @@ struct BalanceUpdate
   BalanceReason reason{};
 };
 
+// ---- Instrument-wide outbound events --------------------------------------
+// These carry no account: they describe the instrument, not a client's order,
+// so the delivery layer routes them to nobody and the order-entry codecs have
+// no exec-report form for them (like MmpTriggered / FeeCharged / Liquidation).
+// Their consumer is the public market-data feed (market_data.h).
+
+// Trading state of the instrument. Exactly the states the engine HAS:
+// continuous matching, an operator halt, the timed limit-up/limit-down
+// volatility pause, pre-open accumulation, the uncross that ends it, and a
+// closed session.
+//
+// Closed and Halted are deliberately DIFFERENT states, not one state with two
+// names. A halt is an exception -- something went wrong and the operator
+// stopped the instrument; a closed session is the instrument's normal
+// out-of-hours condition. A subscriber that cannot tell them apart cannot tell
+// a broken market from a sleeping one, and the two reject an order with
+// different reasons (Halted vs MarketClosed). What the engine deliberately does
+// NOT own is the CALENDAR: it holds the state and the transitions, while the
+// schedule that fires them belongs to the operator / control plane (see
+// docs/venue/runtime.md).
+enum class TradingStatus : uint8_t
+{
+  Trading = 0,         // continuous matching
+  Halted = 1,          // operator halt: new orders rejected (no deadline)
+  LuldPause = 2,       // timed volatility pause after a band breach (untilNs = deadline)
+  AuctionPreOpen = 3,  // pre-open accumulation, no matching (a crossed book is legal)
+  AuctionUncross = 4,  // the uncross itself; the next transition ends the auction
+  // Appended value -- wire enums are append-only, so a decoder of the previous
+  // schema keeps reading every field of the message and sees only an unknown
+  // status code (which it must treat as "not tradeable", never as Trading).
+  Closed = 5,  // session closed: new orders rejected, the book stands
+};
+
+enum class TradingStatusReason : uint8_t
+{
+  None = 0,
+  Administrative = 1,    // operator action (AdminCmd Halt / Resume / HaltAndCancelAll)
+  LuldBreach = 2,        // a limit-up/limit-down band breach tripped the pause
+  LuldPauseElapsed = 3,  // the timed pause deadline passed and trading resumed
+  Auction = 4,           // an auction phase transition (pre-open, uncross, re-open)
+  Session = 5,           // a session boundary (AdminCmd CloseSession / OpenSession)
+};
+
+// Emitted on every trading-state TRANSITION of the symbol -- from the engine's
+// own state changes, never inferred downstream and never repeated periodically.
+// untilNs is the sequencer-ts the timed pause expires at (0 = no deadline), so
+// it replays identically.
+struct TradingStatusChanged
+{
+  SymbolId symbol{};
+  TradingStatus status{};
+  TradingStatusReason reason{};
+  int64_t untilNs{0};
+};
+
+// Funding rate fixed-point scale: the same power of ten prices and quantities
+// use, so a rate travels as a raw int64 like every other wire number and never
+// as a double. 0.0001 (1bp per interval) = 10'000 raw.
+inline constexpr int64_t kFundingRateScale = Price::Scale;
+
+// Derivatives state of the instrument, emitted when the engine LEARNS it: on a
+// sequenced SetMark and on a sequenced ApplyFunding. Both are journaled, so the
+// values reproduce on replay.
+//
+// openInterest is the long side of the open positions the engine tracks for
+// this symbol (equal to the short side, since every contract has both legs) --
+// a real sum over positions_, not an estimate. It is published with the mark
+// rather than on every fill: a per-trade open-interest message would multiply
+// the feed's message rate for a number consumers read at mark cadence.
+struct DerivativesUpdated
+{
+  SymbolId symbol{};
+  Price mark{};               // last mark price the engine was given (0 before the first SetMark)
+  int64_t fundingRateRaw{0};  // last applied rate, kFundingRateScale, per funding interval
+  int64_t nextFundingNs{0};   // next funding boundary (0 = no funding interval configured)
+  Quantity openInterest{};    // long side of open positions on this symbol
+};
+
 // Appended alternatives go at the END (wire codecs and the event hash key off
 // the alternative order).
 using OutboundEvent =
     std::variant<OrderAccepted, OrderRejected, Trade, OrderExecuted, OrderCanceled, OrderModified,
                  OrderTriggered, FillHeld, FillRejected, MmpTriggered, FeeCharged, Liquidation,
-                 BalanceUpdate>;
+                 BalanceUpdate, TradingStatusChanged, DerivativesUpdated>;
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/metrics.h
+++ b/venue/include/flox-venue/metrics.h
@@ -110,13 +110,18 @@ struct GatewayCounters
 };
 
 // Market-data feed counters. Atomics: sendDrops is bumped on the matching
-// thread (publish path), the recovery counters on MdRecoveryServer connection
-// threads.
+// thread (publish path), the recovery counters on MdRecoveryServer and
+// MdDistributionServer connection threads.
 struct MdCounters
 {
   std::atomic<uint64_t> sendDrops{0};        // sendto failed/partial: datagram never left the host
   std::atomic<uint64_t> resendServed{0};     // recovery requests answered by ring replay
   std::atomic<uint64_t> snapshotsServed{0};  // recovery requests answered by a full snapshot
+  // Unicast distribution (md_distribution.h).
+  std::atomic<uint64_t> subscribers{0};              // live distribution sessions (gauge)
+  std::atomic<uint64_t> slowConsumerDisconnects{0};  // outbound queue overflow -> subscriber dropped
+  std::atomic<uint64_t> idleDisconnects{0};          // no inbound traffic within the idle timeout
+  std::atomic<uint64_t> subscribeRejects{0};         // subscribe/resend refused (unknown symbol, ...)
 };
 
 // Point-in-time venue state that is NOT derivable from the outbound event

--- a/venue/include/flox-venue/reject_reason.h
+++ b/venue/include/flox-venue/reject_reason.h
@@ -40,6 +40,10 @@ enum class RejectReason : uint8_t
   MalformedMessage,  // frame did not decode to a valid command
   Unauthenticated,   // command before a successful logon
   SessionSeqGap,     // FIX: inbound MsgSeqNum gap -- session must resync
+  // The instrument's SESSION is closed -- distinct from Halted, which is an
+  // operator exception. A client retries after the next session opens; a halt
+  // has no such promise. Appended value (the wire enum is append-only).
+  MarketClosed,
 };
 
 enum class CancelReason : uint8_t

--- a/venue/include/flox-venue/sbe_md_codec.h
+++ b/venue/include/flox-venue/sbe_md_codec.h
@@ -59,15 +59,51 @@ struct MdSnapshotRequired
   uint64_t lastSeq{};
 };
 
+// Unicast distribution verbs (TCP, length-prefixed frames; see
+// md_distribution.h). The recovery channel serves one request per connection;
+// the distribution channel is a long-lived session, so it needs a way to say
+// "start streaming this symbol" and "stop". ResendRequest keeps its meaning on
+// both channels.
+struct MdSubscribeRequest
+{
+  SymbolId symbol{};
+  uint64_t fromSeq{};        // 0 = snapshot then increments; >0 = replay then increments
+  bool snapshotOnly{false};  // serve one snapshot and drop the subscription
+};
+
+struct MdUnsubscribeRequest
+{
+  SymbolId symbol{};
+};
+
+// Refusal of a Subscribe/ResendRequest that cannot be served at all (today:
+// an unknown symbol). A rejected request leaves no subscription behind.
+enum class MdSubscribeRejectReason : uint8_t
+{
+  UnknownSymbol = 0,
+  UnsupportedRequest = 1,
+};
+
+struct MdSubscribeReject
+{
+  SymbolId symbol{};
+  MdSubscribeRejectReason reason{};
+};
+
 class SbeMdCodec
 {
  public:
   static constexpr uint16_t kSchemaId = 91;
-  static constexpr uint16_t kVersion = 1;
+  static constexpr uint16_t kVersion = 3;
   static constexpr size_t kHeaderSize = sbe::kHeaderSize;
 
-  // Template ids 1..6 mirror MdType (order-preserving bijection):
-  // templateId = MdType+1. 7..10 are the recovery-channel messages.
+  // Template ids 1..6 mirror the ORDER-LEVEL MdTypes (templateId = MdType+1).
+  // 7..10 are the recovery-channel messages, 11..13 the unicast distribution
+  // verbs added in schema version 2, 14..15 the instrument-wide messages added
+  // in version 3 -- those two do NOT continue the arithmetic (7 is taken), so
+  // the mapping past Triggered is explicit. Versions 2 and 3 add templates and
+  // TRAILING fields only, so an older reader decodes every message it knew
+  // exactly as before.
   enum class Tmpl : uint16_t
   {
     AddOrder = 1,
@@ -80,24 +116,45 @@ class SbeMdCodec
     SnapshotBegin = 8,
     SnapshotEnd = 9,
     SnapshotRequired = 10,
+    Subscribe = 11,
+    Unsubscribe = 12,
+    SubscribeReject = 13,
+    TradingStatus = 14,
+    DerivativesUpdate = 15,
   };
 
   // Root-block lengths per template (bytes after the header). Must match the
   // field lists in md-sbe.xml. Version 1 appended a trailing epoch (u64) to
-  // every incremental template; a v0 reader skips it via blockLength, and this
-  // decoder accepts v0 frames (epoch reads as 0).
-  static constexpr uint16_t kBlockOrderV0 = 8 + 4 + 8 + 1 + 8 + 8;    // 37: seq,sym,id,side,px,qty
-  static constexpr uint16_t kBlockOrder = kBlockOrderV0 + 8;          // 45: + epoch
-  static constexpr uint16_t kBlockTradeV0 = kBlockOrderV0 + 8;        // 45: + makerId
-  static constexpr uint16_t kBlockTrade = kBlockTradeV0 + 8;          // 53: + epoch
-  static constexpr uint16_t kBlockTriggeredV0 = 8 + 4 + 8 + 8;        // 28: seq,sym,id,px
-  static constexpr uint16_t kBlockTriggered = kBlockTriggeredV0 + 8;  // 36: + epoch
-  static constexpr uint16_t kBlockResendRequest = 4 + 8;              // 12: sym,fromSeq
-  static constexpr uint16_t kBlockSnapshotBegin = 4 + 8 + 8 + 4;      // 24: sym,epoch,lastSeq,count
-  static constexpr uint16_t kBlockSnapshotEnd = 4 + 8 + 8;            // 20: sym,epoch,lastSeq
+  // every incremental template and version 3 appended engineTs+sendTs (2x i64)
+  // after it; an older reader skips them via blockLength, and this decoder
+  // accepts v0/v1/v2 frames (the absent trailing fields read as 0).
+  static constexpr uint16_t kBlockOrderV0 = 8 + 4 + 8 + 1 + 8 + 8;      // 37: seq,sym,id,side,px,qty
+  static constexpr uint16_t kBlockOrderV1 = kBlockOrderV0 + 8;          // 45: + epoch
+  static constexpr uint16_t kBlockOrder = kBlockOrderV1 + 16;           // 61: + engineTs,sendTs
+  static constexpr uint16_t kBlockTradeV0 = kBlockOrderV0 + 8;          // 45: + makerId
+  static constexpr uint16_t kBlockTradeV1 = kBlockTradeV0 + 8;          // 53: + epoch
+  static constexpr uint16_t kBlockTrade = kBlockTradeV1 + 16;           // 69: + engineTs,sendTs
+  static constexpr uint16_t kBlockTriggeredV0 = 8 + 4 + 8 + 8;          // 28: seq,sym,id,px
+  static constexpr uint16_t kBlockTriggeredV1 = kBlockTriggeredV0 + 8;  // 36: + epoch
+  static constexpr uint16_t kBlockTriggered = kBlockTriggeredV1 + 16;   // 52: + engineTs,sendTs
+  // seq,sym,epoch,engineTs,sendTs,status,reason,untilNs
+  static constexpr uint16_t kBlockTradingStatus = 8 + 4 + 8 + 8 + 8 + 1 + 1 + 8;  // 46
+  // seq,sym,epoch,engineTs,sendTs,mark,fundingRate,nextFundingNs,openInterest
+  static constexpr uint16_t kBlockDerivatives = 8 + 4 + 8 + 8 + 8 + 8 + 8 + 8 + 8;  // 68
+  static constexpr uint16_t kBlockResendRequest = 4 + 8;                            // 12: sym,fromSeq
+  static constexpr uint16_t kBlockSnapshotBegin = 4 + 8 + 8 + 4;                    // 24: sym,epoch,lastSeq,count
+  static constexpr uint16_t kBlockSnapshotEnd = 4 + 8 + 8;                          // 20: sym,epoch,lastSeq
   static constexpr uint16_t kBlockSnapshotRequired = kBlockSnapshotEnd;
+  static constexpr uint16_t kBlockSubscribe = 4 + 8 + 1;    // 13: sym,fromSeq,flags
+  static constexpr uint16_t kBlockUnsubscribe = 4;          // 4: sym
+  static constexpr uint16_t kBlockSubscribeReject = 4 + 1;  // 5: sym,reason
 
-  static constexpr size_t kMaxSize = kHeaderSize + kBlockTrade;  // largest framed message
+  static constexpr uint8_t kSubscribeSnapshotOnly = 0x01;  // Subscribe flags bit 0
+
+  // Largest framed message: the derivatives block is the widest fixed block
+  // after the trade block gained its timestamps.
+  static constexpr size_t kMaxSize =
+      kHeaderSize + (kBlockTrade > kBlockDerivatives ? kBlockTrade : kBlockDerivatives);
 
   static void encode(const MdMessage& m, std::vector<uint8_t>& out)
   {
@@ -109,27 +166,32 @@ class SbeMdCodec
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::AddOrder), kSchemaId, kVersion);
         putOrderBlock(out, m);
         sbe::putU64(out, m.epoch);
+        putTimes(out, m);
         break;
       case MdType::Trade:
         sbe::putHeader(out, kBlockTrade, tmpl(Tmpl::Trade), kSchemaId, kVersion);
         putOrderBlock(out, m);
         sbe::putU64(out, m.makerId);
         sbe::putU64(out, m.epoch);
+        putTimes(out, m);
         break;
       case MdType::Executed:
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::Executed), kSchemaId, kVersion);
         putOrderBlock(out, m);
         sbe::putU64(out, m.epoch);
+        putTimes(out, m);
         break;
       case MdType::Cancel:
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::Cancel), kSchemaId, kVersion);
         putOrderBlock(out, m);
         sbe::putU64(out, m.epoch);
+        putTimes(out, m);
         break;
       case MdType::Replace:
         sbe::putHeader(out, kBlockOrder, tmpl(Tmpl::Replace), kSchemaId, kVersion);
         putOrderBlock(out, m);
         sbe::putU64(out, m.epoch);
+        putTimes(out, m);
         break;
       case MdType::Triggered:
         sbe::putHeader(out, kBlockTriggered, tmpl(Tmpl::Triggered), kSchemaId, kVersion);
@@ -138,6 +200,28 @@ class SbeMdCodec
         sbe::putU64(out, m.id);
         sbe::putI64(out, m.price.raw());
         sbe::putU64(out, m.epoch);
+        putTimes(out, m);
+        break;
+      case MdType::TradingStatus:
+        sbe::putHeader(out, kBlockTradingStatus, tmpl(Tmpl::TradingStatus), kSchemaId, kVersion);
+        sbe::putU64(out, m.seq);
+        sbe::putU32(out, m.symbol);
+        sbe::putU64(out, m.epoch);
+        putTimes(out, m);
+        sbe::putU8(out, static_cast<uint8_t>(m.status));
+        sbe::putU8(out, static_cast<uint8_t>(m.reason));
+        sbe::putI64(out, m.untilNs);
+        break;
+      case MdType::DerivativesUpdate:
+        sbe::putHeader(out, kBlockDerivatives, tmpl(Tmpl::DerivativesUpdate), kSchemaId, kVersion);
+        sbe::putU64(out, m.seq);
+        sbe::putU32(out, m.symbol);
+        sbe::putU64(out, m.epoch);
+        putTimes(out, m);
+        sbe::putI64(out, m.price.raw());  // mark
+        sbe::putI64(out, m.fundingRateRaw);
+        sbe::putI64(out, m.nextFundingNs);
+        sbe::putI64(out, m.qty.raw());  // open interest
         break;
     }
   }
@@ -178,6 +262,66 @@ class SbeMdCodec
     sbe::putU32(out, s.symbol);
     sbe::putU64(out, s.epoch);
     sbe::putU64(out, s.lastSeq);
+  }
+
+  static void encode(const MdSubscribeRequest& s, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSubscribe, tmpl(Tmpl::Subscribe), kSchemaId, kVersion);
+    sbe::putU32(out, s.symbol);
+    sbe::putU64(out, s.fromSeq);
+    sbe::putU8(out, s.snapshotOnly ? kSubscribeSnapshotOnly : 0);
+  }
+
+  static void encode(const MdUnsubscribeRequest& u, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockUnsubscribe, tmpl(Tmpl::Unsubscribe), kSchemaId, kVersion);
+    sbe::putU32(out, u.symbol);
+  }
+
+  static void encode(const MdSubscribeReject& r, std::vector<uint8_t>& out)
+  {
+    out.clear();
+    sbe::putHeader(out, kBlockSubscribeReject, tmpl(Tmpl::SubscribeReject), kSchemaId, kVersion);
+    sbe::putU32(out, r.symbol);
+    sbe::putU8(out, static_cast<uint8_t>(r.reason));
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdSubscribeRequest& s)
+  {
+    const uint8_t* b = checkFrame(p, n, Tmpl::Subscribe, kBlockSubscribe);
+    if (b == nullptr)
+    {
+      return false;
+    }
+    s.symbol = static_cast<SymbolId>(sbe::getU32(b + 0));
+    s.fromSeq = sbe::getU64(b + 4);
+    s.snapshotOnly = (b[12] & kSubscribeSnapshotOnly) != 0;
+    return true;
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdUnsubscribeRequest& u)
+  {
+    const uint8_t* b = checkFrame(p, n, Tmpl::Unsubscribe, kBlockUnsubscribe);
+    if (b == nullptr)
+    {
+      return false;
+    }
+    u.symbol = static_cast<SymbolId>(sbe::getU32(b + 0));
+    return true;
+  }
+
+  static bool decode(const uint8_t* p, size_t n, MdSubscribeReject& r)
+  {
+    const uint8_t* b = checkFrame(p, n, Tmpl::SubscribeReject, kBlockSubscribeReject);
+    if (b == nullptr)
+    {
+      return false;
+    }
+    r.symbol = static_cast<SymbolId>(sbe::getU32(b + 0));
+    r.reason = static_cast<MdSubscribeRejectReason>(b[4]);
+    return true;
   }
 
   static bool decode(const uint8_t* p, size_t n, MdResendRequest& r)
@@ -275,10 +419,11 @@ class SbeMdCodec
         m = MdMessage{};
         m.type = tmplToType(static_cast<Tmpl>(h.templateId));
         getOrderBlock(b, m);
-        if (h.blockLength >= kBlockOrder)
+        if (h.blockLength >= kBlockOrderV1)
         {
           m.epoch = sbe::getU64(b + kBlockOrderV0);  // v1 trailing field; v0 frame -> 0
         }
+        getTimes(b, h.blockLength, kBlockOrderV1, m);  // v3 trailing fields
         return true;
       case Tmpl::Trade:
         if (h.blockLength < kBlockTradeV0)
@@ -289,10 +434,11 @@ class SbeMdCodec
         m.type = MdType::Trade;
         getOrderBlock(b, m);
         m.makerId = sbe::getU64(b + kBlockOrderV0);
-        if (h.blockLength >= kBlockTrade)
+        if (h.blockLength >= kBlockTradeV1)
         {
           m.epoch = sbe::getU64(b + kBlockTradeV0);
         }
+        getTimes(b, h.blockLength, kBlockTradeV1, m);
         return true;
       case Tmpl::Triggered:
         if (h.blockLength < kBlockTriggeredV0)
@@ -305,23 +451,82 @@ class SbeMdCodec
         m.symbol = static_cast<SymbolId>(sbe::getU32(b + 8));
         m.id = sbe::getU64(b + 12);
         m.price = Price::fromRaw(sbe::getI64(b + 20));
-        if (h.blockLength >= kBlockTriggered)
+        if (h.blockLength >= kBlockTriggeredV1)
         {
           m.epoch = sbe::getU64(b + kBlockTriggeredV0);
         }
+        getTimes(b, h.blockLength, kBlockTriggeredV1, m);
+        return true;
+      case Tmpl::TradingStatus:
+        if (h.blockLength < kBlockTradingStatus)
+        {
+          return false;
+        }
+        m = MdMessage{};
+        m.type = MdType::TradingStatus;
+        m.seq = sbe::getU64(b + 0);
+        m.symbol = static_cast<SymbolId>(sbe::getU32(b + 8));
+        m.epoch = sbe::getU64(b + 12);
+        m.engineTsNs = sbe::getI64(b + 20);
+        m.sendTsNs = sbe::getI64(b + 28);
+        m.status = static_cast<flox::venue::TradingStatus>(b[36]);
+        m.reason = static_cast<TradingStatusReason>(b[37]);
+        m.untilNs = sbe::getI64(b + 38);
+        return true;
+      case Tmpl::DerivativesUpdate:
+        if (h.blockLength < kBlockDerivatives)
+        {
+          return false;
+        }
+        m = MdMessage{};
+        m.type = MdType::DerivativesUpdate;
+        m.seq = sbe::getU64(b + 0);
+        m.symbol = static_cast<SymbolId>(sbe::getU32(b + 8));
+        m.epoch = sbe::getU64(b + 12);
+        m.engineTsNs = sbe::getI64(b + 20);
+        m.sendTsNs = sbe::getI64(b + 28);
+        m.price = Price::fromRaw(sbe::getI64(b + 36));
+        m.fundingRateRaw = sbe::getI64(b + 44);
+        m.nextFundingNs = sbe::getI64(b + 52);
+        m.qty = Quantity::fromRaw(sbe::getI64(b + 60));
         return true;
       case Tmpl::ResendRequest:
       case Tmpl::SnapshotBegin:
       case Tmpl::SnapshotEnd:
       case Tmpl::SnapshotRequired:
-        return false;  // recovery-channel messages, not MdMessage frames
+      case Tmpl::Subscribe:
+      case Tmpl::Unsubscribe:
+      case Tmpl::SubscribeReject:
+        return false;  // session/recovery messages, not MdMessage frames
     }
     return false;  // unknown template
   }
 
  private:
   static uint16_t tmpl(Tmpl t) { return static_cast<uint16_t>(t); }
+  // Only the order-level templates (1..6) carry the arithmetic mapping; the
+  // instrument-wide ones are decoded by their own cases.
   static MdType tmplToType(Tmpl t) { return static_cast<MdType>(static_cast<uint16_t>(t) - 1); }
+
+  // Version-3 trailing timestamps, appended after the version-1 epoch on every
+  // incremental template.
+  static void putTimes(std::vector<uint8_t>& o, const MdMessage& m)
+  {
+    sbe::putI64(o, m.engineTsNs);
+    sbe::putI64(o, m.sendTsNs);
+  }
+
+  // Read them back when the sender's block is long enough to hold them; a
+  // pre-version-3 frame leaves both at 0 (the same skip-by-blockLength path the
+  // epoch field uses).
+  static void getTimes(const uint8_t* b, uint16_t blockLength, uint16_t at, MdMessage& m)
+  {
+    if (blockLength >= static_cast<uint16_t>(at + 16))
+    {
+      m.engineTsNs = sbe::getI64(b + at);
+      m.sendTsNs = sbe::getI64(b + at + 8);
+    }
+  }
 
   // Validate header + template + block bounds; return the root block, or null.
   static const uint8_t* checkFrame(const uint8_t* p, size_t n, Tmpl expected, uint16_t minBlock)

--- a/venue/include/flox-venue/sbe_order_entry_codec.h
+++ b/venue/include/flox-venue/sbe_order_entry_codec.h
@@ -361,7 +361,10 @@ class SbeOrderEntryCodec
       sbe::putU64(out, seq);
     }
     // Events without an order-entry exec-report mapping (MmpTriggered,
-    // FeeCharged, Liquidation) produce no frame.
+    // FeeCharged, Liquidation) produce no frame. TradingStatusChanged and
+    // DerivativesUpdated are instrument-wide, not account-scoped: they carry
+    // no account to route to and belong on the public market-data feed
+    // (market_data.h), not in a client's exec-report stream.
   }
 
   // Per-session seq of an outbound exec report (schema v1 trailing field).

--- a/venue/include/flox-venue/symbol_router.h
+++ b/venue/include/flox-venue/symbol_router.h
@@ -83,6 +83,14 @@ inline SymbolId symbolOf(const InboundCommand& c) noexcept
   {
     return tt->symbol;
   }
+  if (const auto* sg = std::get_if<SetStpGroup>(&c))
+  {
+    return sg->symbol;
+  }
+  if (const auto* fs = std::get_if<SetFundingSchedule>(&c))
+  {
+    return fs->symbol;
+  }
   return 0;  // snapshot-only records never route by symbol (recovery-path only)
 }
 

--- a/venue/schema/md-sbe.xml
+++ b/venue/schema/md-sbe.xml
@@ -30,11 +30,42 @@
     SnapshotBegin (8) + AddOrder body + SnapshotEnd (9) when fromSeq is older
     than the ring's tail. Snapshot body AddOrders carry seq=0 and the epoch;
     the incremental feed resumes at lastSeq+1.
+
+  Version 2 (unicast distribution):
+  - Templates ONLY -- no existing root block changed, so a version-1 reader
+    decodes every incremental and recovery message byte for byte as before.
+  - Subscribe (11) / Unsubscribe (12) / SubscribeReject (13) are the verbs of
+    the long-lived unicast distribution session (md_distribution.h). The
+    recovery channel serves one request per connection and needs no start/stop
+    verb; a distribution session does. ResendRequest (7) keeps its meaning on
+    both channels.
+
+  Version 3 (time, trading status, derivatives):
+  - Every incremental template gained TWO trailing fields (sinceVersion="3"),
+    appended to the END of the root block exactly as `epoch` was in version 1,
+    so a version-1/2 reader keeps decoding every existing field byte for byte
+    and skips these via the header blockLength:
+      engineTs -- sequencer-ts the ENGINE produced the event at. Journaled
+                  input, so a replay of the same journal reproduces it exactly.
+      sendTs   -- wall clock when the publisher SENT this copy. Deliberately
+                  not reproducible: a resend of the same message carries a
+                  later sendTs than the original, which is how a consumer
+                  tells a replay from live flow. Never hash it.
+  - New templates, no existing block touched:
+      TradingStatus (14)     -- halt, LULD volatility pause, auction phase,
+                                session close/open and their release, from the
+                                engine's own state transitions rather than
+                                inferred from silence.
+      DerivativesUpdate (15) -- mark price, funding rate + next funding time,
+                                open interest.
+    Both also travel INSIDE a snapshot (between SnapshotBegin and the AddOrder
+    body, seq=0), so a late joiner starts with the instrument's real status and
+    mark. SnapshotBegin's orderCount still counts AddOrder messages only.
 -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="flox.venue.md"
                    id="91"
-                   version="1"
+                   version="3"
                    semanticVersion="1.0"
                    description="Flox venue market-data feed"
                    byteOrder="littleEndian">
@@ -57,6 +88,41 @@
     <type name="QtyRaw"   primitiveType="int64"/>
     <type name="Epoch"   primitiveType="uint64"/>  <!-- publisher lifetime id -->
     <type name="Count"   primitiveType="uint32"/>
+    <type name="Flags"   primitiveType="uint8"/>   <!-- Subscribe: bit 0 = snapshotOnly -->
+    <type name="TimeNs"  primitiveType="int64"/>   <!-- nanoseconds; engine = sequencer time, send = wall clock -->
+    <!-- Funding rate as a raw fixed-point value at the SAME scale prices and
+         quantities use (1e-8): a rate never travels as a float. -->
+    <type name="RateRaw" primitiveType="int64"/>
+    <enum name="RejectReason" encodingType="uint8">
+      <validValue name="UnknownSymbol">0</validValue>
+      <validValue name="UnsupportedRequest">1</validValue>
+    </enum>
+    <!-- The trading states the engine HAS. Closed is a SESSION state and is
+         deliberately not the same value as Halted: a halt is an exception, a
+         closed session is the instrument's normal out-of-hours condition, and
+         they reject an order with different reasons. The engine holds the state
+         and the transitions; the CALENDAR that fires them belongs to the
+         operator / control plane.
+         Values are append-only: Closed sits at the end, so the root block is
+         unchanged and a reader of the previous version still decodes every
+         field -- it sees an unrecognised status code, which it must treat as
+         "not tradeable" rather than as Trading. -->
+    <enum name="TradingStatus" encodingType="uint8">
+      <validValue name="Trading">0</validValue>
+      <validValue name="Halted">1</validValue>
+      <validValue name="LuldPause">2</validValue>
+      <validValue name="AuctionPreOpen">3</validValue>
+      <validValue name="AuctionUncross">4</validValue>
+      <validValue name="Closed">5</validValue>
+    </enum>
+    <enum name="StatusReason" encodingType="uint8">
+      <validValue name="None">0</validValue>
+      <validValue name="Administrative">1</validValue>
+      <validValue name="LuldBreach">2</validValue>
+      <validValue name="LuldPauseElapsed">3</validValue>
+      <validValue name="Auction">4</validValue>
+      <validValue name="Session">5</validValue>
+    </enum>
   </types>
 
   <!-- A resting order was added to the book (displayed size). -->
@@ -68,6 +134,8 @@
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
     <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
+    <field name="engineTs" id="8" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"   id="9" type="TimeNs" sinceVersion="3"/>
   </sbe:message>
 
   <!-- A trade printed. orderId = taker, side = taker side, plus the maker id. -->
@@ -80,6 +148,8 @@
     <field name="qty"     id="6" type="QtyRaw"/>
     <field name="makerId" id="7" type="OrderId"/>
     <field name="epoch"   id="8" type="Epoch" sinceVersion="1"/>
+    <field name="engineTs" id="9" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"   id="10" type="TimeNs" sinceVersion="3"/>
   </sbe:message>
 
   <!-- A resting order was (partially) executed; qty = displayed leaves. -->
@@ -91,6 +161,8 @@
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
     <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
+    <field name="engineTs" id="8" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"   id="9" type="TimeNs" sinceVersion="3"/>
   </sbe:message>
 
   <!-- A resting order was canceled/expired off the book. -->
@@ -102,6 +174,8 @@
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
     <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
+    <field name="engineTs" id="8" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"   id="9" type="TimeNs" sinceVersion="3"/>
   </sbe:message>
 
   <!-- A resting order was repriced/replaced; qty = new displayed leaves. -->
@@ -113,6 +187,8 @@
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="qty"     id="6" type="QtyRaw"/>
     <field name="epoch"   id="7" type="Epoch" sinceVersion="1"/>
+    <field name="engineTs" id="8" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"   id="9" type="TimeNs" sinceVersion="3"/>
   </sbe:message>
 
   <!-- A conditional (stop/take-profit) order triggered; price = reference. -->
@@ -122,6 +198,8 @@
     <field name="orderId" id="3" type="OrderId"/>
     <field name="price"   id="5" type="PriceRaw"/>
     <field name="epoch"   id="6" type="Epoch" sinceVersion="1"/>
+    <field name="engineTs" id="7" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"   id="8" type="TimeNs" sinceVersion="3"/>
   </sbe:message>
 
   <!-- Recovery channel (TCP, length-prefixed frames): ask for increments with
@@ -157,5 +235,67 @@
     <field name="symbol"  id="1" type="Symbol" sinceVersion="1"/>
     <field name="epoch"   id="2" type="Epoch" sinceVersion="1"/>
     <field name="lastSeq" id="3" type="Seq" sinceVersion="1"/>
+  </sbe:message>
+
+  <!-- Unicast distribution session (TCP, length-prefixed frames): start
+       streaming `symbol` on this connection. fromSeq=0 asks for an atomic
+       snapshot followed by increments; fromSeq>0 asks to resume at that seq
+       (ring replay, or SnapshotRequired + snapshot when it is older than the
+       ring). flags bit 0 = snapshotOnly: serve one snapshot and drop the
+       subscription. -->
+  <sbe:message name="Subscribe" id="11" sinceVersion="2">
+    <field name="symbol"  id="1" type="Symbol" sinceVersion="2"/>
+    <field name="fromSeq" id="2" type="Seq" sinceVersion="2"/>
+    <field name="flags"   id="3" type="Flags" sinceVersion="2"/>
+  </sbe:message>
+
+  <!-- Stop streaming `symbol` on this connection. Other symbols keep flowing. -->
+  <sbe:message name="Unsubscribe" id="12" sinceVersion="2">
+    <field name="symbol" id="1" type="Symbol" sinceVersion="2"/>
+  </sbe:message>
+
+  <!-- A Subscribe / ResendRequest that cannot be served at all (unknown
+       symbol, unsupported request). No subscription is left behind. -->
+  <sbe:message name="SubscribeReject" id="13" sinceVersion="2">
+    <field name="symbol" id="1" type="Symbol" sinceVersion="2"/>
+    <field name="reason" id="2" type="RejectReason" sinceVersion="2"/>
+  </sbe:message>
+
+  <!-- Trading state transition of the instrument: halt, LULD volatility pause,
+       auction phase and their release. Emitted on the TRANSITION only, from the
+       engine's own state change -- a subscriber never has to infer a halt from
+       the absence of messages. untilNs is the sequencer-ts a timed pause
+       expires at (0 = the state has no deadline). Also carried inside a
+       snapshot, so a late joiner starts in the right state. -->
+  <sbe:message name="TradingStatus" id="14" sinceVersion="3">
+    <field name="seq"      id="1" type="Seq" sinceVersion="3"/>
+    <field name="symbol"   id="2" type="Symbol" sinceVersion="3"/>
+    <field name="epoch"    id="3" type="Epoch" sinceVersion="3"/>
+    <field name="engineTs" id="4" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"   id="5" type="TimeNs" sinceVersion="3"/>
+    <field name="status"   id="6" type="TradingStatus" sinceVersion="3"/>
+    <field name="reason"   id="7" type="StatusReason" sinceVersion="3"/>
+    <field name="untilNs"  id="8" type="TimeNs" sinceVersion="3"/>
+  </sbe:message>
+
+  <!-- Derivatives layer: the numbers a perp holder needs to value a position --
+       mark price, funding rate with the next funding time, open interest.
+       Published when the engine LEARNS them (a sequenced mark, funding or
+       schedule command), not on every fill. openInterest is the long side of
+       the open positions (equal to the short side). nextFundingNs is the
+       boundary the venue will actually settle on when an operator has set a
+       schedule (engine state, advanced by each settlement); with no schedule it
+       falls back to the interval configured for the instrument, and 0 means the
+       venue does not fund it at all. Also carried inside a snapshot. -->
+  <sbe:message name="DerivativesUpdate" id="15" sinceVersion="3">
+    <field name="seq"           id="1" type="Seq" sinceVersion="3"/>
+    <field name="symbol"        id="2" type="Symbol" sinceVersion="3"/>
+    <field name="epoch"         id="3" type="Epoch" sinceVersion="3"/>
+    <field name="engineTs"      id="4" type="TimeNs" sinceVersion="3"/>
+    <field name="sendTs"        id="5" type="TimeNs" sinceVersion="3"/>
+    <field name="mark"          id="6" type="PriceRaw" sinceVersion="3"/>
+    <field name="fundingRate"   id="7" type="RateRaw" sinceVersion="3"/>
+    <field name="nextFundingNs" id="8" type="TimeNs" sinceVersion="3"/>
+    <field name="openInterest"  id="9" type="QtyRaw" sinceVersion="3"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/venue/src/reject_reason.cpp
+++ b/venue/src/reject_reason.cpp
@@ -62,6 +62,8 @@ const char* toString(RejectReason r) noexcept
       return "Unauthenticated";
     case RejectReason::SessionSeqGap:
       return "SessionSeqGap";
+    case RejectReason::MarketClosed:
+      return "MarketClosed";
   }
   return "?";
 }

--- a/venue/tests/test_venue_control_plane.cpp
+++ b/venue/tests/test_venue_control_plane.cpp
@@ -170,7 +170,18 @@ TEST(ControlPlane, EngineSuite)
   CHECK(has(api2.handle(R"({"method":"setStpGroup","symbol":42,"account":11,"group":77})"),
             "unknown_symbol"));
 
-  CHECK(forwarded.size() == 5);  // failed halt / setTriggerRef / snapshotNow forwarded nothing
+  // session / setFundingSchedule: the operator's schedule surface. The engine
+  // owns the state; the CALENDAR lives out here, and both transitions ride the
+  // sequenced stream so they journal, snapshot and replay.
+  CHECK(has(api2.handle(R"({"method":"session","symbol":7,"open":false})"), "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"session","symbol":42,"open":false})"), "unknown_symbol"));
+  CHECK(has(api2.handle(
+                R"({"method":"setFundingSchedule","symbol":7,"intervalNs":28800000000000,"nextFundingNs":100})"),
+            "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"setFundingSchedule","symbol":42,"intervalNs":1,"nextFundingNs":2})"),
+            "unknown_symbol"));
+
+  CHECK(forwarded.size() == 7);  // failed halt / setTriggerRef / snapshotNow forwarded nothing
   CHECK(std::get_if<ListInstrument>(&forwarded[0]) != nullptr);
   CHECK(std::get_if<SetBands>(&forwarded[1]) != nullptr);
   const auto* trigCmd = std::get_if<SetTriggerRef>(&forwarded[2]);
@@ -179,6 +190,12 @@ TEST(ControlPlane, EngineSuite)
   CHECK(haltCmd != nullptr && haltCmd->action == AdminAction::Halt && haltCmd->symbol == 7);
   const auto* stpCmd = std::get_if<SetStpGroup>(&forwarded[4]);
   CHECK(stpCmd != nullptr && stpCmd->symbol == 7 && stpCmd->account == 11 && stpCmd->group == 77);
+  const auto* closeCmd = std::get_if<AdminCmd>(&forwarded[5]);
+  CHECK(closeCmd != nullptr && closeCmd->action == AdminAction::CloseSession &&
+        closeCmd->symbol == 7);
+  const auto* fundCmd = std::get_if<SetFundingSchedule>(&forwarded[6]);
+  CHECK(fundCmd != nullptr && fundCmd->symbol == 7 && fundCmd->intervalNs == 28'800'000'000'000LL &&
+        fundCmd->nextFundingNs == 100);
 
   // Replaying the forwarded commands into a FRESH registry reproduces the
   // configuration -- the stream is the configuration store.

--- a/venue/tests/test_venue_lastlook.cpp
+++ b/venue/tests/test_venue_lastlook.cpp
@@ -310,7 +310,7 @@ void test_md_equals_book()
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
                                    {
                                      cap.ev.push_back(e);
-                                     pub.onEvent(e); });
+                                     pub.onEvent(e, eng.engineTimeNs()); });
 
   auto feedMatchesBook = [&](std::vector<double> prices)
   {

--- a/venue/tests/test_venue_marketdata.cpp
+++ b/venue/tests/test_venue_marketdata.cpp
@@ -83,7 +83,7 @@ void test_l2_and_codec()
   MarketDataPublisher<> md([&](const MdMessage& m)
                            { feed.push_back(m); }, px(0.01), SYM);
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
-                                   { md.onEvent(e); });
+                                   { md.onEvent(e, eng.engineTimeNs()); });
 
   eng.submit(limit(1, Side::SELL, 100, 5));
   eng.submit(limit(2, Side::SELL, 101, 3));
@@ -146,7 +146,7 @@ void test_book_agreement()
   std::printf("test_book_agreement\n");
   MarketDataPublisher<> md([](const MdMessage&) {}, px(0.01), SYM);
   MatchingEngine<LadderBook> eng(cfg(), [&](const OutboundEvent& e)
-                                 { md.onEvent(e); }, LadderBook{ladderCfg()});
+                                 { md.onEvent(e, eng.engineTimeNs()); }, LadderBook{ladderCfg()});
 
   workload::Params p;
   p.symbol = SYM;
@@ -209,7 +209,7 @@ void test_iceberg_hidden_from_md()
                                      {
                                        execs.push_back(*x);
                                      }
-                                     md.onEvent(e);
+                                     md.onEvent(e, eng.engineTimeNs());
                                    });
 
   NewOrder ice = limit(1, Side::SELL, 100, 20, 1);

--- a/venue/tests/test_venue_md_completeness.cpp
+++ b/venue/tests/test_venue_md_completeness.cpp
@@ -1,0 +1,762 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Market-data feed completeness: the two timestamps, the trading-status
+ * message and the derivatives layer -- on every path (live increment, resend,
+ * snapshot) and in both encodings, without breaking a reader of the previous
+ * schema version.
+ */
+#include "flox-venue/fix_md_codec.h"
+#include "flox-venue/ledger.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/md_encoder.h"
+#include "flox-venue/sbe_md_codec.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 999;
+constexpr int64_t SEC = 1'000'000'000LL;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+Amount quote(double v) { return amountOf(Volume::fromDouble(v)); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  return c;
+}
+
+SymbolConfig perpCfg()
+{
+  SymbolConfig c = cfg();
+  c.quoteAsset = QUOTE;
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;      // 10x
+  c.fundingIntervalNs = 8 * SEC;  // a funding calendar the feed can publish
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// A publisher wired to an engine, collecting everything it emits.
+struct Feed
+{
+  std::vector<MdMessage> out;
+  MarketDataPublisher<> md;
+  MatchingEngine<MatchingBook> eng;
+
+  explicit Feed(SymbolConfig c = cfg())
+      : md([this](const MdMessage& m)
+           { out.push_back(m); }, px(0.01), SYM),
+        eng(c, [this](const OutboundEvent& e)
+            { md.onEvent(e, eng.engineTimeNs()); })
+  {
+  }
+
+  const MdMessage* firstOf(MdType t) const
+  {
+    for (const MdMessage& m : out)
+    {
+      if (m.type == t)
+      {
+        return &m;
+      }
+    }
+    return nullptr;
+  }
+  const MdMessage* lastOf(MdType t) const
+  {
+    const MdMessage* found = nullptr;
+    for (const MdMessage& m : out)
+    {
+      if (m.type == t)
+      {
+        found = &m;
+      }
+    }
+    return found;
+  }
+  size_t countOf(MdType t) const
+  {
+    size_t n = 0;
+    for (const MdMessage& m : out)
+    {
+      n += m.type == t ? 1 : 0;
+    }
+    return n;
+  }
+};
+
+// ---------------------------------------------------------------- timestamps
+
+// Every message on the live path carries both times: the engine's sequencer-ts
+// (exactly the ts the causing command was submitted at) and a wall clock that
+// is at or after it. Neither is left at zero, on any message type.
+void test_timestamps_on_every_message()
+{
+  std::printf("test_timestamps_on_every_message\n");
+  Feed f;
+  f.eng.submit(limit(1, Side::SELL, 100, 5), 1000);
+  f.eng.submit(limit(2, Side::BUY, 100, 2), 2000);  // trade + executed
+  f.eng.submit(CancelOrder{1, SYM, 1}, 3000);
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Halt}}, 4000);
+
+  CHECK(!f.out.empty());
+  int64_t prevEngine = 0;
+  int64_t prevSend = 0;
+  for (const MdMessage& m : f.out)
+  {
+    CHECK(m.engineTsNs != 0);
+    CHECK(m.sendTsNs != 0);
+    CHECK(m.engineTsNs >= prevEngine);  // sequencer time never goes backwards
+    CHECK(m.sendTsNs >= prevSend);      // nor does the latched send clock
+    prevEngine = m.engineTsNs;
+    prevSend = m.sendTsNs;
+  }
+  // The engine ts is the submit ts, not a clock read: it is exactly what the
+  // caller sequenced the command at.
+  CHECK(f.out.front().engineTsNs == 1000);
+  CHECK(f.out.back().engineTsNs == 4000);
+  CHECK(f.lastOf(MdType::Trade) != nullptr && f.lastOf(MdType::Trade)->engineTsNs == 2000);
+}
+
+// Replaying the same command stream reproduces every engineTsNs bit for bit;
+// sendTsNs is a wall-clock read and does not reproduce. That asymmetry is the
+// contract: engineTs may enter a determinism digest, sendTs may not.
+void test_engine_ts_replays_send_ts_does_not()
+{
+  std::printf("test_engine_ts_replays_send_ts_does_not\n");
+  const std::vector<std::pair<int64_t, InboundCommand>> stream{
+      {10, InboundCommand{limit(1, Side::SELL, 100, 5)}},
+      {20, InboundCommand{limit(2, Side::BUY, 101, 5, 2)}},
+      {30, InboundCommand{AdminCmd{SYM, AdminAction::Halt}}},
+      {40, InboundCommand{AdminCmd{SYM, AdminAction::Resume}}},
+  };
+
+  auto run = [&]
+  {
+    Feed f;
+    for (const auto& [ts, c] : stream)
+    {
+      f.eng.submit(c, ts);
+    }
+    return f.out;
+  };
+
+  const auto a = run();
+  const auto b = run();
+  CHECK(a.size() == b.size() && !a.empty());
+  bool engineIdentical = true;
+  bool anySendDiffers = false;
+  for (size_t i = 0; i < a.size() && i < b.size(); ++i)
+  {
+    engineIdentical = engineIdentical && a[i].engineTsNs == b[i].engineTsNs;
+    anySendDiffers = anySendDiffers || a[i].sendTsNs != b[i].sendTsNs;
+  }
+  CHECK(engineIdentical);
+  CHECK(anySendDiffers);  // a wall clock advanced between the two runs
+}
+
+// A snapshot states when each resting order arrived, and a resend restamps the
+// send time while leaving the event's own time alone -- which is how a
+// consumer tells a replayed copy from the original.
+void test_snapshot_and_resend_timestamps()
+{
+  std::printf("test_snapshot_and_resend_timestamps\n");
+  Feed f;
+  f.eng.submit(limit(1, Side::SELL, 100, 5), 1'000);
+  f.eng.submit(limit(2, Side::SELL, 101, 3), 2'000);
+
+  const MdSnapshot snap = f.md.snapshotAtomic();
+  CHECK(snap.orders.size() == 2);
+  for (const MdMessage& m : snap.orders)
+  {
+    CHECK(m.engineTsNs == (m.id == 1 ? 1'000 : 2'000));  // the accept time, not "now"
+    CHECK(m.sendTsNs >= f.out.back().sendTsNs);          // the snapshot went out later
+  }
+
+  const auto replay = f.md.resendFrom(1);
+  CHECK(replay.has_value() && replay->size() == f.out.size());
+  for (size_t i = 0; i < replay->size(); ++i)
+  {
+    CHECK((*replay)[i].engineTsNs == f.out[i].engineTsNs);  // the event's own time survives
+    CHECK((*replay)[i].sendTsNs >= f.out[i].sendTsNs);      // this transmission is later
+  }
+}
+
+// -------------------------------------------------------------- trading status
+
+// Halt and resume reach the wire as transitions, with the state the engine is
+// actually in -- not inferred from a silent feed.
+void test_halt_and_resume_visible()
+{
+  std::printf("test_halt_and_resume_visible\n");
+  Feed f;
+  f.eng.submit(limit(1, Side::SELL, 100, 5), 10);
+  CHECK(f.countOf(MdType::TradingStatus) == 0);  // nothing has changed yet
+
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Halt}}, 20);
+  const MdMessage* halted = f.lastOf(MdType::TradingStatus);
+  CHECK(halted != nullptr);
+  CHECK(halted->status == TradingStatus::Halted);
+  CHECK(halted->reason == TradingStatusReason::Administrative);
+  CHECK(halted->untilNs == 0);  // an operator halt has no deadline
+  CHECK(halted->seq != 0 && halted->epoch == f.md.epoch());
+
+  // Halting an already halted symbol is not a transition: no duplicate.
+  const size_t afterHalt = f.countOf(MdType::TradingStatus);
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Halt}}, 30);
+  CHECK(f.countOf(MdType::TradingStatus) == afterHalt);
+
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Resume}}, 40);
+  CHECK(f.lastOf(MdType::TradingStatus)->status == TradingStatus::Trading);
+  CHECK(f.lastOf(MdType::TradingStatus)->engineTsNs == 40);
+}
+
+// The timed volatility pause is its own state, carries its deadline, and its
+// expiry is published too -- a subscriber never has to time it out itself.
+void test_luld_pause_visible()
+{
+  std::printf("test_luld_pause_visible\n");
+  SymbolConfig c = cfg();
+  c.luldBps = 500;       // +/- 5%
+  c.luldHaltNs = 1'000;  // short pause
+  Feed f(c);
+  f.eng.submit(limit(1, Side::SELL, 100, 5), 100);
+  f.eng.submit(limit(2, Side::BUY, 100, 5, 2), 200);  // last price = 100 -> band [95, 105]
+
+  NewOrder sweep = limit(3, Side::SELL, 0, 5, 2);
+  sweep.type = OrderType::MARKET;
+  f.eng.submit(limit(4, Side::BUY, 90, 5, 3), 300);  // a bid well below the band
+  f.eng.submit(sweep, 400);                          // market sell prints 90 -> breach
+
+  const MdMessage* pause = f.lastOf(MdType::TradingStatus);
+  CHECK(pause != nullptr);
+  CHECK(pause->status == TradingStatus::LuldPause);
+  CHECK(pause->reason == TradingStatusReason::LuldBreach);
+  CHECK(pause->untilNs == 400 + 1'000);  // the deadline in sequencer time
+  CHECK(pause->engineTsNs == 400);
+
+  // Past the deadline the engine resumes and says so.
+  f.eng.submit(InboundCommand{TimeTick{SYM}}, 400 + 1'001);
+  const MdMessage* back = f.lastOf(MdType::TradingStatus);
+  CHECK(back->status == TradingStatus::Trading);
+  CHECK(back->reason == TradingStatusReason::LuldPauseElapsed);
+}
+
+// An auction is three states, not one: accumulation, the uncross, and the
+// continuous session that follows.
+void test_auction_phases_visible()
+{
+  std::printf("test_auction_phases_visible\n");
+  Feed f;
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::BeginPreOpen}}, 10);
+  CHECK(f.lastOf(MdType::TradingStatus)->status == TradingStatus::AuctionPreOpen);
+
+  f.eng.submit(limit(1, Side::SELL, 100, 5), 20);
+  f.eng.submit(limit(2, Side::BUY, 100, 5, 2), 30);  // crossed, accumulating
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::OpenContinuous}}, 40);
+
+  std::vector<flox::venue::TradingStatus> seen;
+  for (const MdMessage& m : f.out)
+  {
+    if (m.type == MdType::TradingStatus)
+    {
+      seen.push_back(m.status);
+    }
+  }
+  CHECK(seen.size() == 3);
+  CHECK(seen[0] == TradingStatus::AuctionPreOpen);
+  CHECK(seen[1] == TradingStatus::AuctionUncross);
+  CHECK(seen[2] == TradingStatus::Trading);
+
+  // The uncross fills are bracketed by the uncross status and the resume, so a
+  // consumer can attribute them to the auction.
+  size_t uncrossAt = 0, tradeAt = 0, resumeAt = 0;
+  for (size_t i = 0; i < f.out.size(); ++i)
+  {
+    if (f.out[i].type == MdType::TradingStatus &&
+        f.out[i].status == TradingStatus::AuctionUncross)
+    {
+      uncrossAt = i;
+    }
+    if (f.out[i].type == MdType::Trade)
+    {
+      tradeAt = i;
+    }
+    if (f.out[i].type == MdType::TradingStatus && f.out[i].status == TradingStatus::Trading)
+    {
+      resumeAt = i;
+    }
+  }
+  CHECK(uncrossAt < tradeAt && tradeAt < resumeAt);
+}
+
+// ---------------------------------------------------------------- derivatives
+
+void test_mark_funding_and_open_interest_visible()
+{
+  std::printf("test_mark_funding_and_open_interest_visible\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(10'000));
+  led.deposit(2, QUOTE, quote(10'000));
+  Feed f(perpCfg());
+  f.eng.setLedger(&led, VENUE);
+
+  f.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 1 * SEC);
+  const MdMessage* first = f.lastOf(MdType::DerivativesUpdate);
+  CHECK(first != nullptr);
+  CHECK(first->price == px(100));          // mark
+  CHECK(first->qty == qty(0));             // no positions yet
+  CHECK(first->fundingRateRaw == 0);       // no funding applied yet
+  CHECK(first->nextFundingNs == 8 * SEC);  // 8s schedule, first boundary
+  CHECK(first->engineTsNs == 1 * SEC);
+
+  // Open a long/short pair: open interest is the long side, not the net.
+  f.eng.submit(limit(1, Side::SELL, 100, 4, 2), 2 * SEC);
+  f.eng.submit(limit(2, Side::BUY, 100, 4, 1), 3 * SEC);
+  f.eng.submit(InboundCommand{SetMark{SYM, px(101)}}, 4 * SEC);
+  const MdMessage* withOi = f.lastOf(MdType::DerivativesUpdate);
+  CHECK(withOi->price == px(101));
+  CHECK(withOi->qty == qty(4));
+  CHECK(f.eng.openInterest() == qty(4));
+
+  // A funding settlement publishes the rate that was applied, as fixed point.
+  f.eng.submit(InboundCommand{ApplyFunding{SYM, 0.0001, px(101)}}, 9 * SEC);
+  const MdMessage* funded = f.lastOf(MdType::DerivativesUpdate);
+  CHECK(funded->fundingRateRaw == kFundingRateScale / 10'000);  // 1bp
+  CHECK(funded->nextFundingNs == 16 * SEC);                     // next boundary of the schedule
+  CHECK(funded->qty == qty(4));
+
+  // The rate persists onto later mark updates: a consumer that joins between
+  // settlements still learns what it is paying.
+  f.eng.submit(InboundCommand{SetMark{SYM, px(102)}}, 10 * SEC);
+  CHECK(f.lastOf(MdType::DerivativesUpdate)->fundingRateRaw == kFundingRateScale / 10'000);
+
+  // Without a configured funding interval there is no calendar to publish, and
+  // the feed says 0 rather than inventing one.
+  Feed spot(cfg());
+  spot.eng.submit(InboundCommand{SetMark{SYM, px(50)}}, 1 * SEC);
+  CHECK(spot.lastOf(MdType::DerivativesUpdate)->nextFundingNs == 0);
+}
+
+// ------------------------------------------------------------- late joiner
+
+// The snapshot is a startable state: status and derivatives come with the book.
+void test_late_joiner_snapshot_carries_state()
+{
+  std::printf("test_late_joiner_snapshot_carries_state\n");
+  Feed f(perpCfg());
+  f.eng.submit(limit(1, Side::SELL, 100, 5), 1 * SEC);
+  f.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 2 * SEC);
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Halt}}, 3 * SEC);
+
+  const MdSnapshot snap = f.md.snapshotAtomic();
+  CHECK(snap.hasStatus);
+  CHECK(snap.status.status == TradingStatus::Halted);
+  CHECK(snap.status.seq == 0);  // body record, like the orders
+  CHECK(snap.status.engineTsNs == 3 * SEC);
+  CHECK(snap.hasDerivatives);
+  CHECK(snap.derivatives.price == px(100));
+  CHECK(snap.orders.size() == 1);
+
+  // And it survives the SBE snapshot encoding used by the distribution server:
+  // begin, state, book, end -- with orderCount still counting orders only.
+  SbeMdEncoder enc;
+  std::vector<uint8_t> wire;
+  enc.snapshot(SYM, snap, wire);
+
+  std::vector<uint16_t> tmpls;
+  MdSnapshotBegin begin{};
+  MdMessage status{};
+  MdMessage derivatives{};
+  bool sawStatus = false, sawDerivatives = false;
+  size_t orders = 0;
+  size_t off = 0;
+  while (off + 4 <= wire.size())
+  {
+    const uint32_t len = (static_cast<uint32_t>(wire[off]) << 24) |
+                         (static_cast<uint32_t>(wire[off + 1]) << 16) |
+                         (static_cast<uint32_t>(wire[off + 2]) << 8) |
+                         static_cast<uint32_t>(wire[off + 3]);
+    const uint8_t* p = wire.data() + off + 4;
+    const uint16_t t = SbeMdCodec::templateId(p, len);
+    tmpls.push_back(t);
+    if (static_cast<SbeMdCodec::Tmpl>(t) == SbeMdCodec::Tmpl::SnapshotBegin)
+    {
+      CHECK(SbeMdCodec::decode(p, len, begin));
+    }
+    else if (static_cast<SbeMdCodec::Tmpl>(t) == SbeMdCodec::Tmpl::TradingStatus)
+    {
+      sawStatus = SbeMdCodec::decode(p, len, status);
+    }
+    else if (static_cast<SbeMdCodec::Tmpl>(t) == SbeMdCodec::Tmpl::DerivativesUpdate)
+    {
+      sawDerivatives = SbeMdCodec::decode(p, len, derivatives);
+    }
+    else if (static_cast<SbeMdCodec::Tmpl>(t) == SbeMdCodec::Tmpl::AddOrder)
+    {
+      ++orders;
+    }
+    off += 4 + len;
+  }
+  CHECK(sawStatus && status.status == TradingStatus::Halted);
+  CHECK(sawDerivatives && derivatives.price == px(100));
+  CHECK(begin.orderCount == 1 && orders == 1);
+  // State frames sit between SnapshotBegin and the body, so the subscriber is
+  // told the instrument is halted before it applies a single order.
+  CHECK(tmpls.size() >= 5);
+  CHECK(static_cast<SbeMdCodec::Tmpl>(tmpls[0]) == SbeMdCodec::Tmpl::SnapshotBegin);
+  CHECK(static_cast<SbeMdCodec::Tmpl>(tmpls[1]) == SbeMdCodec::Tmpl::TradingStatus);
+  CHECK(static_cast<SbeMdCodec::Tmpl>(tmpls[2]) == SbeMdCodec::Tmpl::DerivativesUpdate);
+  CHECK(static_cast<SbeMdCodec::Tmpl>(tmpls.back()) == SbeMdCodec::Tmpl::SnapshotEnd);
+}
+
+// ------------------------------------------------------------------ encodings
+
+void test_sbe_round_trip_new_fields()
+{
+  std::printf("test_sbe_round_trip_new_fields\n");
+  std::vector<uint8_t> buf;
+
+  MdMessage st{};
+  st.type = MdType::TradingStatus;
+  st.seq = 7;
+  st.symbol = SYM;
+  st.epoch = 4242;
+  st.engineTsNs = 111;
+  st.sendTsNs = 222;
+  st.status = TradingStatus::LuldPause;
+  st.reason = TradingStatusReason::LuldBreach;
+  st.untilNs = 333;
+  SbeMdCodec::encode(st, buf);
+  MdMessage back{};
+  CHECK(SbeMdCodec::decode(buf.data(), buf.size(), back));
+  CHECK(back.type == MdType::TradingStatus && back.seq == 7 && back.epoch == 4242);
+  CHECK(back.engineTsNs == 111 && back.sendTsNs == 222 && back.untilNs == 333);
+  CHECK(back.status == TradingStatus::LuldPause);
+  CHECK(back.reason == TradingStatusReason::LuldBreach);
+
+  MdMessage dv{};
+  dv.type = MdType::DerivativesUpdate;
+  dv.seq = 8;
+  dv.symbol = SYM;
+  dv.epoch = 4242;
+  dv.engineTsNs = 444;
+  dv.sendTsNs = 555;
+  dv.price = px(101.25);
+  dv.qty = qty(12.5);
+  dv.fundingRateRaw = -1234;  // a negative rate: shorts pay
+  dv.nextFundingNs = 8 * SEC;
+  SbeMdCodec::encode(dv, buf);
+  CHECK(SbeMdCodec::decode(buf.data(), buf.size(), back));
+  CHECK(back.type == MdType::DerivativesUpdate);
+  CHECK(back.price == px(101.25) && back.qty == qty(12.5));
+  CHECK(back.fundingRateRaw == -1234 && back.nextFundingNs == 8 * SEC);
+  CHECK(back.engineTsNs == 444 && back.sendTsNs == 555);
+
+  MdMessage tr{MdType::Trade, 9, SYM, 42, Side::SELL, px(100), qty(3), 41, 4242};
+  tr.engineTsNs = 666;
+  tr.sendTsNs = 777;
+  SbeMdCodec::encode(tr, buf);
+  CHECK(SbeMdCodec::decode(buf.data(), buf.size(), back));
+  CHECK(back.engineTsNs == 666 && back.sendTsNs == 777 && back.makerId == 41);
+}
+
+// A reader built against schema version 2 knows nothing about engineTs/sendTs.
+// It must still decode every field it does know out of a version-3 frame, by
+// bounding itself with the header's blockLength exactly as SBE prescribes.
+// This is the previous version's decoder, transcribed against its own offsets.
+bool decodeAsV2(const uint8_t* p, size_t n, MdMessage& m)
+{
+  if (n < SbeMdCodec::kHeaderSize)
+  {
+    return false;
+  }
+  const sbe::Header h = sbe::readHeader(p);
+  if (h.schemaId != SbeMdCodec::kSchemaId || n < SbeMdCodec::kHeaderSize + h.blockLength)
+  {
+    return false;
+  }
+  const uint8_t* b = p + SbeMdCodec::kHeaderSize;
+  const uint16_t v2Order = 37;  // seq,sym,id,side,px,qty as version 2 knew it
+  if (h.templateId == 2)        // Trade
+  {
+    if (h.blockLength < v2Order + 8)
+    {
+      return false;
+    }
+    m.type = MdType::Trade;
+    m.makerId = sbe::getU64(b + v2Order);
+    m.epoch = h.blockLength >= v2Order + 16 ? sbe::getU64(b + v2Order + 8) : 0;
+  }
+  else if (h.templateId >= 1 && h.templateId <= 5)  // AddOrder / Executed / Cancel / Replace
+  {
+    if (h.blockLength < v2Order)
+    {
+      return false;
+    }
+    m.type = static_cast<MdType>(h.templateId - 1);
+    m.epoch = h.blockLength >= v2Order + 8 ? sbe::getU64(b + v2Order) : 0;
+  }
+  else
+  {
+    return false;  // version 2 has no template 14/15: it skips the frame
+  }
+  m.seq = sbe::getU64(b + 0);
+  m.symbol = static_cast<SymbolId>(sbe::getU32(b + 8));
+  m.id = sbe::getU64(b + 12);
+  m.side = static_cast<Side>(b[20]);
+  m.price = Price::fromRaw(sbe::getI64(b + 21));
+  m.qty = Quantity::fromRaw(sbe::getI64(b + 29));
+  return true;
+}
+
+void test_previous_schema_version_still_reads()
+{
+  std::printf("test_previous_schema_version_still_reads\n");
+  Feed f;
+  f.eng.submit(limit(1, Side::SELL, 100, 5), 1'000);
+  f.eng.submit(limit(2, Side::BUY, 100, 2, 2), 2'000);
+  f.eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Halt}}, 3'000);
+  CHECK(f.countOf(MdType::TradingStatus) == 1);
+
+  std::vector<uint8_t> buf;
+  size_t decoded = 0;
+  size_t skipped = 0;
+  for (const MdMessage& m : f.out)
+  {
+    SbeMdCodec::encode(m, buf);
+    MdMessage old{};
+    if (!decodeAsV2(buf.data(), buf.size(), old))
+    {
+      ++skipped;  // a template version 2 never knew: skipped, not corrupting
+      continue;
+    }
+    ++decoded;
+    CHECK(old.seq == m.seq);
+    CHECK(old.symbol == m.symbol);
+    CHECK(old.price == m.price);
+    CHECK(old.qty == m.qty);
+    CHECK(old.epoch == m.epoch);  // the version-1 trailing field still lands
+    CHECK(old.engineTsNs == 0);   // version 2 simply does not see the new ones
+  }
+  CHECK(decoded > 0);
+  CHECK(skipped == 1);  // exactly the new TradingStatus message
+
+  // And the reverse: this decoder accepts a frame that stops after the
+  // version-2 fields (an older PUBLISHER), leaving the timestamps at zero.
+  MdMessage m{MdType::AddOrder, 5, SYM, 9, Side::BUY, px(100), qty(1), 0, 77};
+  SbeMdCodec::encode(m, buf);
+  buf[0] = static_cast<uint8_t>(SbeMdCodec::kBlockOrderV1 & 0xFF);  // blockLength -> v1
+  buf[1] = static_cast<uint8_t>(SbeMdCodec::kBlockOrderV1 >> 8);
+  buf.resize(SbeMdCodec::kHeaderSize + SbeMdCodec::kBlockOrderV1);
+  MdMessage back{};
+  CHECK(SbeMdCodec::decode(buf.data(), buf.size(), back));
+  CHECK(back.seq == 5 && back.epoch == 77 && back.qty == qty(1));
+  CHECK(back.engineTsNs == 0 && back.sendTsNs == 0);
+}
+
+// The FIX encoding carries the same information in standard fields: 273
+// MDEntryTime and 60 TransactTime for the engine time, 52 SendingTime for the
+// send time, 35=f SecurityStatus for the halt, and standard MDEntryTypes for
+// the mark and open interest.
+void test_fix_carries_time_status_and_derivatives()
+{
+  std::printf("test_fix_carries_time_status_and_derivatives\n");
+  FixMdEncoder enc;
+  std::vector<uint8_t> out;
+  std::vector<MdRequest> reqs;
+  std::vector<uint8_t> reply;
+  size_t consumed = 0;
+
+  auto feedIn = [&](const std::string& msg)
+  {
+    reqs.clear();
+    reply.clear();
+    consumed = 0;
+    const std::string framed = FixCodec::frame(msg);
+    return enc.parse(reinterpret_cast<const uint8_t*>(framed.data()), framed.size(), consumed, reqs,
+                     reply);
+  };
+
+  std::string logon;
+  FixMdCodec::add(logon, 35, "A");
+  FixMdCodec::add(logon, 34, "1");
+  FixMdCodec::add(logon, 49, "CLIENT");
+  FixMdCodec::add(logon, 56, "VENUE");
+  FixMdCodec::add(logon, 52, FixMdCodec::nowStamp());
+  FixMdCodec::add(logon, 108, "30");
+  CHECK(feedIn(logon) == MdEncoder::Parse::Ok);
+
+  std::string req;
+  FixMdCodec::add(req, 35, "V");
+  FixMdCodec::add(req, 34, "2");
+  FixMdCodec::add(req, 49, "CLIENT");
+  FixMdCodec::add(req, 56, "VENUE");
+  FixMdCodec::add(req, 52, FixMdCodec::nowStamp());
+  FixMdCodec::add(req, 262, "REQ1");
+  FixMdCodec::add(req, 263, "1");
+  FixMdCodec::add(req, 55, std::to_string(SYM));
+  CHECK(feedIn(req) == MdEncoder::Parse::Ok);
+  CHECK(!reqs.empty() && reqs[0].kind == MdRequestKind::Subscribe);
+
+  const int64_t engineTs = 1'700'000'000LL * SEC;
+
+  MdMessage add{MdType::AddOrder, 1, SYM, 42, Side::BUY, px(100), qty(5), 0, 9};
+  add.engineTsNs = engineTs;
+  add.sendTsNs = engineTs + 1'000;
+  out.clear();
+  enc.increment(add, out);
+  const std::string inc(out.begin(), out.end());
+  CHECK(inc.find("\x01"
+                 "273=") != std::string::npos);  // MDEntryTime
+  CHECK(inc.find("\x01"
+                 "60=") != std::string::npos);  // TransactTime
+  CHECK(inc.find("\x01"
+                 "35=X") != std::string::npos);
+
+  MdMessage st{};
+  st.type = MdType::TradingStatus;
+  st.seq = 2;
+  st.symbol = SYM;
+  st.engineTsNs = engineTs;
+  st.sendTsNs = engineTs;
+  st.status = TradingStatus::Halted;
+  st.reason = TradingStatusReason::Administrative;
+  out.clear();
+  enc.increment(st, out);
+  const std::string status(out.begin(), out.end());
+  CHECK(status.find("\x01"
+                    "35=f") != std::string::npos);  // SecurityStatus
+  CHECK(status.find("\x01"
+                    "326=2") != std::string::npos);  // Trading Halt
+  CHECK(status.find("\x01"
+                    "60=") != std::string::npos);
+
+  MdMessage pause = st;
+  pause.status = TradingStatus::LuldPause;
+  pause.reason = TradingStatusReason::LuldBreach;
+  pause.untilNs = engineTs + 5 * SEC;
+  out.clear();
+  enc.increment(pause, out);
+  const std::string paused(out.begin(), out.end());
+  CHECK(paused.find("\x01"
+                    "326=2") != std::string::npos);
+  CHECK(paused.find("LULD") != std::string::npos);
+  CHECK(paused.find("\x01"
+                    "5003=") != std::string::npos);  // the pause deadline
+
+  MdMessage dv{};
+  dv.type = MdType::DerivativesUpdate;
+  dv.seq = 3;
+  dv.symbol = SYM;
+  dv.engineTsNs = engineTs;
+  dv.sendTsNs = engineTs;
+  dv.price = px(101.5);
+  dv.qty = qty(4);
+  dv.fundingRateRaw = kFundingRateScale / 10'000;
+  dv.nextFundingNs = engineTs + 8 * SEC;
+  out.clear();
+  enc.increment(dv, out);
+  const std::string deriv(out.begin(), out.end());
+  CHECK(deriv.find("\x01"
+                   "269=6") != std::string::npos);  // SettlementPrice = mark
+  CHECK(deriv.find("\x01"
+                   "269=C") != std::string::npos);  // OpenInterest
+  CHECK(deriv.find("\x01"
+                   "270=101.5") != std::string::npos);
+  CHECK(deriv.find("\x01"
+                   "5001=0.0001") != std::string::npos);  // funding rate, exact decimal
+  CHECK(deriv.find("\x01"
+                   "5002=") != std::string::npos);  // next funding time
+
+  // A snapshot leads with the status, so a FIX consumer joining a halted
+  // instrument is told so before it receives the book.
+  MdSnapshot snap;
+  snap.epoch = 9;
+  snap.lastSeq = 3;
+  snap.hasStatus = true;
+  snap.status = st;
+  snap.hasDerivatives = true;
+  snap.derivatives = dv;
+  snap.orders.push_back(add);
+  snap.orders.back().seq = 0;
+  out.clear();
+  enc.snapshot(SYM, snap, out);
+  const std::string full(out.begin(), out.end());
+  CHECK(full.find("\x01"
+                  "35=f") < full.find("\x01"
+                                      "35=W"));
+  CHECK(full.find("\x01"
+                  "35=W") != std::string::npos);
+  CHECK(full.find("\x01"
+                  "273=") != std::string::npos);  // per-entry engine time in the refresh
+}
+
+}  // namespace
+
+TEST(MdCompleteness, EngineSuite)
+{
+  test_timestamps_on_every_message();
+  test_engine_ts_replays_send_ts_does_not();
+  test_snapshot_and_resend_timestamps();
+  test_halt_and_resume_visible();
+  test_luld_pause_visible();
+  test_auction_phases_visible();
+  test_mark_funding_and_open_interest_visible();
+  test_late_joiner_snapshot_carries_state();
+  test_sbe_round_trip_new_fields();
+  test_previous_schema_version_still_reads();
+  test_fix_carries_time_status_and_derivatives();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_md_distribution.cpp
+++ b/venue/tests/test_venue_md_distribution.cpp
@@ -1,0 +1,1135 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Unicast market-data distribution over real loopback sockets: a subscriber
+ * that joins mid-stream converges on the book of a consumer that watched from
+ * the first message; a subscriber that stops reading is dropped by the bounded
+ * queue while a healthy one alongside it keeps up and the publisher never
+ * waits; a gap is filled from the resend ring, or answered with the explicit
+ * "you need a snapshot" when it has been trimmed; a publisher restart surfaces
+ * as an epoch change; the FIX encoding runs the request/snapshot/incremental/
+ * reject round trip; and both encodings run on one server at the same time.
+ */
+#include "flox-venue/fix_md_codec.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/md_distribution.h"
+#include "flox-venue/metrics.h"
+#include "flox-venue/sbe_md_codec.h"
+
+#include "flox/util/transport.h"
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <map>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr SymbolId OTHER = 2;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(50.0);
+  c.maxPrice = px(150.0);
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// Per-order consumer book driven by the public feed, folded to
+// (side, price) -> aggregate for comparisons. Same shape as the multicast
+// consumer in test_venue_md_recovery.
+struct ConsumerBook
+{
+  struct O
+  {
+    Side side{};
+    Price price{};
+    Quantity qty{};
+  };
+  std::unordered_map<OrderId, O> orders;
+
+  void clear() { orders.clear(); }
+
+  void apply(const MdMessage& m)
+  {
+    switch (m.type)
+    {
+      case MdType::AddOrder:
+        orders[m.id] = O{m.side, m.price, m.qty};
+        break;
+      case MdType::Executed:
+      {
+        auto it = orders.find(m.id);
+        if (it != orders.end())
+        {
+          it->second.qty = m.qty;
+          if (m.qty.raw() == 0)
+          {
+            orders.erase(it);
+          }
+        }
+        break;
+      }
+      case MdType::Cancel:
+        orders.erase(m.id);
+        break;
+      case MdType::Replace:
+        orders[m.id] = O{m.side, m.price, m.qty};
+        break;
+      case MdType::Trade:
+      case MdType::Triggered:
+      case MdType::TradingStatus:
+      case MdType::DerivativesUpdate:
+        break;
+    }
+  }
+
+  std::map<std::pair<int, int64_t>, int64_t> levels() const
+  {
+    std::map<std::pair<int, int64_t>, int64_t> lv;
+    for (const auto& [id, o] : orders)
+    {
+      if (o.qty.raw() > 0)
+      {
+        lv[{static_cast<int>(o.side), o.price.raw()}] += o.qty.raw();
+      }
+    }
+    return lv;
+  }
+};
+
+bool sameBook(const ConsumerBook& a, const ConsumerBook& b) { return a.levels() == b.levels(); }
+
+int dialLoopback(int port, int recvTimeoutMs, int recvBufBytes = 0)
+{
+  const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0)
+  {
+    return -1;
+  }
+  if (recvBufBytes > 0)
+  {
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &recvBufBytes, sizeof recvBufBytes);
+  }
+  sockaddr_in a{};
+  a.sin_family = AF_INET;
+  a.sin_port = htons(static_cast<uint16_t>(port));
+  a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  if (::connect(fd, reinterpret_cast<const sockaddr*>(&a), sizeof a) != 0)
+  {
+    ::close(fd);
+    return -1;
+  }
+  int one = 1;
+  ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
+  timeval tv{recvTimeoutMs / 1000, (recvTimeoutMs % 1000) * 1000};
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+  return fd;
+}
+
+// Binary-encoding subscriber: the same SBE templates the multicast consumer
+// decodes, carried in the same length-prefixed frames.
+struct SbeClient
+{
+  int fd{-1};
+
+  bool open(int port, int recvTimeoutMs = 700, int recvBufBytes = 0)
+  {
+    fd = dialLoopback(port, recvTimeoutMs, recvBufBytes);
+    return fd >= 0;
+  }
+
+  void close()
+  {
+    if (fd >= 0)
+    {
+      ::close(fd);
+      fd = -1;
+    }
+  }
+  ~SbeClient() { close(); }
+
+  bool subscribe(SymbolId s, uint64_t fromSeq = 0, bool snapshotOnly = false)
+  {
+    std::vector<uint8_t> b;
+    SbeMdCodec::encode(MdSubscribeRequest{s, fromSeq, snapshotOnly}, b);
+    return net::writeFrame(fd, b.data(), b.size());
+  }
+
+  bool unsubscribe(SymbolId s)
+  {
+    std::vector<uint8_t> b;
+    SbeMdCodec::encode(MdUnsubscribeRequest{s}, b);
+    return net::writeFrame(fd, b.data(), b.size());
+  }
+
+  bool resend(SymbolId s, uint64_t fromSeq)
+  {
+    std::vector<uint8_t> b;
+    SbeMdCodec::encode(MdResendRequest{s, fromSeq}, b);
+    return net::writeFrame(fd, b.data(), b.size());
+  }
+
+  // Next non-empty frame (an empty frame is the server's heartbeat).
+  bool next(std::vector<uint8_t>& f)
+  {
+    while (net::readFrame(fd, f))
+    {
+      if (!f.empty())
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  SbeMdCodec::Tmpl tmpl(const std::vector<uint8_t>& f) const
+  {
+    return static_cast<SbeMdCodec::Tmpl>(SbeMdCodec::templateId(f.data(), f.size()));
+  }
+};
+
+// Read one whole SBE snapshot (Begin, body, End) into `book`; returns the
+// SnapshotBegin. `expectRequired` demands the explicit "you need a snapshot"
+// message in front of it.
+// Instrument state a snapshot carried alongside the book (absent when the
+// publisher has published none).
+struct SnapshotState
+{
+  bool hasStatus{false};
+  MdMessage status{};
+  bool hasDerivatives{false};
+  MdMessage derivatives{};
+  size_t beforeFirstOrder{0};  // state frames seen ahead of the book body
+};
+
+bool readSnapshot(SbeClient& c, ConsumerBook& book, MdSnapshotBegin& begin,
+                  bool expectRequired = false, SnapshotState* state = nullptr)
+{
+  std::vector<uint8_t> f;
+  if (expectRequired)
+  {
+    if (!c.next(f) || c.tmpl(f) != SbeMdCodec::Tmpl::SnapshotRequired)
+    {
+      return false;
+    }
+  }
+  if (!c.next(f) || c.tmpl(f) != SbeMdCodec::Tmpl::SnapshotBegin ||
+      !SbeMdCodec::decode(f.data(), f.size(), begin))
+  {
+    return false;
+  }
+  book.clear();
+  size_t got = 0;
+  while (c.next(f))
+  {
+    if (c.tmpl(f) == SbeMdCodec::Tmpl::SnapshotEnd)
+    {
+      MdSnapshotEnd end{};
+      return SbeMdCodec::decode(f.data(), f.size(), end) && end.lastSeq == begin.lastSeq &&
+             got == begin.orderCount;
+    }
+    MdMessage m;
+    if (!SbeMdCodec::decode(f.data(), f.size(), m))
+    {
+      return false;
+    }
+    // The instrument's current state travels in the body too, ahead of the
+    // orders; it is not part of orderCount.
+    if (m.type == MdType::TradingStatus || m.type == MdType::DerivativesUpdate)
+    {
+      if (state != nullptr)
+      {
+        if (m.type == MdType::TradingStatus)
+        {
+          state->hasStatus = true;
+          state->status = m;
+        }
+        else
+        {
+          state->hasDerivatives = true;
+          state->derivatives = m;
+        }
+        state->beforeFirstOrder += got == 0 ? 1 : 0;
+      }
+      continue;
+    }
+    book.apply(m);
+    ++got;
+  }
+  return false;
+}
+
+// ---- FIX subscriber ----
+
+struct FixClient
+{
+  int fd{-1};
+  uint64_t outSeq{1};
+  std::vector<uint8_t> in;
+
+  bool open(int port, int recvTimeoutMs = 700)
+  {
+    fd = dialLoopback(port, recvTimeoutMs);
+    return fd >= 0;
+  }
+
+  void close()
+  {
+    if (fd >= 0)
+    {
+      ::close(fd);
+      fd = -1;
+    }
+  }
+  ~FixClient() { close(); }
+
+  bool send(const std::string& body)
+  {
+    const std::string msg = FixCodec::frame(body);
+    return net::writeAll(fd, reinterpret_cast<const uint8_t*>(msg.data()), msg.size());
+  }
+
+  std::string header(const char* msgType)
+  {
+    std::string b;
+    FixMdCodec::add(b, 35, msgType);
+    FixMdCodec::add(b, 34, std::to_string(outSeq++));
+    FixMdCodec::add(b, 49, "CLIENT");
+    FixMdCodec::add(b, 56, "VENUE");
+    FixMdCodec::add(b, 52, FixMdCodec::nowStamp());
+    return b;
+  }
+
+  bool logon()
+  {
+    std::string b = header("A");
+    FixMdCodec::add(b, 98, "0");
+    FixMdCodec::add(b, 108, "30");
+    return send(b);
+  }
+
+  // MarketDataRequest. subType: "0" snapshot, "1" snapshot+updates, "2" unsubscribe.
+  bool request(const std::string& reqId, const char* subType, const std::vector<SymbolId>& syms,
+               const std::vector<const char*>& entryTypes = {"0", "1", "2"},
+               const char* depth = "0")
+  {
+    std::string b = header("V");
+    FixMdCodec::add(b, 262, reqId);
+    FixMdCodec::add(b, 263, subType);
+    if (depth != nullptr)
+    {
+      FixMdCodec::add(b, 264, depth);
+    }
+    FixMdCodec::add(b, 267, std::to_string(entryTypes.size()));
+    for (const char* e : entryTypes)
+    {
+      FixMdCodec::add(b, 269, e);
+    }
+    FixMdCodec::add(b, 146, std::to_string(syms.size()));
+    for (SymbolId s : syms)
+    {
+      FixMdCodec::add(b, 55, std::to_string(s));
+    }
+    return send(b);
+  }
+
+  // Next complete FIX message, or empty on timeout.
+  std::string next()
+  {
+    while (true)
+    {
+      size_t len = 0;
+      if (!in.empty())
+      {
+        const int st = FixMdCodec::messageLength(in.data(), in.size(), len);
+        if (st < 0)
+        {
+          return {};
+        }
+        if (st == 1)
+        {
+          std::string msg(reinterpret_cast<const char*>(in.data()), len);
+          in.erase(in.begin(), in.begin() + static_cast<long>(len));
+          return msg;
+        }
+      }
+      uint8_t chunk[4096];
+      const ssize_t r = ::recv(fd, chunk, sizeof chunk, 0);
+      if (r <= 0)
+      {
+        return {};
+      }
+      in.insert(in.end(), chunk, chunk + r);
+    }
+  }
+
+  // Next message whose MsgType is `type`, skipping heartbeats. Empty on timeout.
+  std::string nextOf(const char* type)
+  {
+    for (int i = 0; i < 64; ++i)
+    {
+      const std::string m = next();
+      if (m.empty())
+      {
+        return {};
+      }
+      if (FixMdCodec::first(FixMdCodec::parseOrdered(m), 35) == type)
+      {
+        return m;
+      }
+    }
+    return {};
+  }
+};
+
+bool hasField(const std::string& msg, const std::string& field)
+{
+  const std::string needle = std::string(1, FixCodec::SOH) + field + FixCodec::SOH;
+  return msg.find(needle) != std::string::npos;
+}
+
+MdDistributionConfig testConfig()
+{
+  MdDistributionConfig c;
+  c.readTimeoutMs = 40;
+  c.idleTimeoutMs = 60000;  // the liveness policy has its own case
+  c.heartbeatMs = 60000;
+  return c;
+}
+
+// A subscriber that joins after the market has been trading sees an atomic
+// snapshot and then the increments that follow it, and converges on the book
+// of a consumer that watched from the very first message. The subscribe is
+// deliberately raced against live traffic: orders are submitted while the
+// snapshot is being taken.
+void test_subscribe_midstream()
+{
+  std::printf("test_subscribe_midstream\n");
+  MdCounters counters;
+  ConsumerBook refBook;
+  MdDistributionServer dist(&counters, testConfig());
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           {
+                             refBook.apply(m);
+                             dist.publish(m); },
+                           px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+  dist.addPublisher(md);
+  CHECK(dist.start(0) > 0);
+
+  // Phase A: nobody is listening yet.
+  for (int i = 1; i <= 5; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i, i));
+    eng.submit(limit(static_cast<OrderId>(5 + i), Side::BUY, 100 - i, i));
+  }
+  eng.submit(limit(11, Side::BUY, 101, 0.5, 2));  // partial fill against id 1
+  const uint64_t beforeJoin = md.seq();
+  CHECK(beforeJoin >= 11);
+
+  SbeClient c;
+  CHECK(c.open(dist.port()));
+  CHECK(c.subscribe(SYM));
+
+  // Phase B: the market keeps moving while the snapshot is being served.
+  eng.submit(CancelOrder{2, SYM, 1});
+  eng.submit(ModifyOrder{3, SYM, px(106), qty(2), 1});
+  eng.submit(limit(12, Side::SELL, 107, 3));
+  eng.submit(limit(13, Side::BUY, 94, 2));
+  eng.submit(limit(14, Side::BUY, 103, 10, 2));  // sweeps the 101 remainder, rests at 103
+  const uint64_t target = md.seq();
+  CHECK(target > beforeJoin);
+
+  ConsumerBook joined;
+  MdSnapshotBegin begin{};
+  CHECK(readSnapshot(c, joined, begin));
+  CHECK(begin.epoch == md.epoch());
+  CHECK(begin.lastSeq >= beforeJoin);
+
+  uint64_t applied = begin.lastSeq;
+  std::vector<uint8_t> f;
+  while (applied < target && c.next(f))
+  {
+    MdMessage m;
+    CHECK(SbeMdCodec::decode(f.data(), f.size(), m));
+    CHECK(m.seq == applied + 1);  // strictly in order, no hole across the handover
+    CHECK(m.epoch == md.epoch());
+    joined.apply(m);
+    applied = m.seq;
+  }
+  CHECK(applied == target);
+  CHECK(sameBook(joined, refBook));
+  CHECK(counters.snapshotsServed.load() == 1);
+  CHECK(counters.subscribers.load() == 1);
+
+  c.close();
+  dist.stop();
+}
+
+// A subscriber that stops reading fills its bounded queue and is dropped; a
+// healthy subscriber alongside it keeps receiving, and the publishing thread
+// never waits on either socket.
+void test_slow_consumer_disconnected()
+{
+  std::printf("test_slow_consumer_disconnected\n");
+  MdCounters counters;
+  ConsumerBook refBook;
+  MdDistributionConfig dcfg = testConfig();
+  dcfg.queueCapacity = 512;
+  dcfg.pendingCapacity = 512;
+  dcfg.sendBufferBytes = 4096;  // do not let the kernel hide the backlog
+  MdDistributionServer dist(&counters, dcfg);
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           {
+                             refBook.apply(m);
+                             dist.publish(m); },
+                           px(0.01), SYM, 0, /*resendCapacity*/ 1u << 16);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+  dist.addPublisher(md);
+  CHECK(dist.start(0) > 0);
+
+  SbeClient slow;
+  SbeClient healthy;
+  CHECK(slow.open(dist.port(), 700, /*recvBuf*/ 2048));
+  CHECK(healthy.open(dist.port(), 700));
+  CHECK(slow.subscribe(SYM));
+  CHECK(healthy.subscribe(SYM));
+
+  // Let both subscriptions arm before the flood.
+  ConsumerBook healthyBook;
+  MdSnapshotBegin begin{};
+  CHECK(readSnapshot(healthy, healthyBook, begin));
+
+  // The healthy subscriber drains continuously, exactly as a real consumer
+  // would; the slow one never reads a byte.
+  std::atomic<uint64_t> applied{begin.lastSeq};
+  std::atomic<bool> stopReader{false};
+  std::thread reader(
+      [&]
+      {
+        std::vector<uint8_t> f;
+        while (!stopReader.load(std::memory_order_relaxed))
+        {
+          if (!healthy.next(f))
+          {
+            continue;  // read timeout tick
+          }
+          MdMessage m;
+          if (!SbeMdCodec::decode(f.data(), f.size(), m))
+          {
+            continue;
+          }
+          healthyBook.apply(m);
+          applied.store(m.seq, std::memory_order_relaxed);
+        }
+      });
+
+  // Publish until the queue verdict lands, timing the worst single publish:
+  // the matching thread must never be parked on the wedged socket.
+  uint64_t worstNs = 0;
+  OrderId id = 1;
+  for (int i = 0; i < 20000 && counters.slowConsumerDisconnects.load() == 0; ++i)
+  {
+    const double price = 90.0 + static_cast<double>(i % 20) * 0.01;
+    const auto t0 = std::chrono::steady_clock::now();
+    eng.submit(limit(id++, Side::BUY, price, 1));
+    const uint64_t ns = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - t0)
+            .count());
+    worstNs = ns > worstNs ? ns : worstNs;
+    if (i % 8 == 7)
+    {
+      // Pace the flood so the test measures the POLICY, not this machine's
+      // ability to outrun a single-threaded reader: the slow subscriber is
+      // slow because it never reads, not because the feed is faster than a
+      // socket. The healthy reader keeps up at any rate a real one would.
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+  CHECK(counters.slowConsumerDisconnects.load() >= 1);
+  CHECK(worstNs < 500'000'000);  // no submit ever waited on the wedged socket
+
+  // The healthy subscriber is untouched by its neighbour's fate and stays in
+  // step with the reference consumer.
+  const uint64_t target = md.seq();
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (applied.load() < target && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  stopReader.store(true);
+  reader.join();
+  CHECK(applied.load() == target);
+  CHECK(sameBook(healthyBook, refBook));
+
+  // The dropped one is the slow one: whatever the kernel had already buffered
+  // for it still reads out, and then the connection is simply gone.
+  std::vector<uint8_t> f;
+  bool slowClosed = false;
+  for (int i = 0; i < 100000; ++i)
+  {
+    if (!slow.next(f))
+    {
+      slowClosed = true;
+      break;
+    }
+  }
+  CHECK(slowClosed);
+  const auto settle = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (dist.subscriberCount() > 1 && std::chrono::steady_clock::now() < settle)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  CHECK(dist.subscriberCount() == 1);
+
+  slow.close();
+  healthy.close();
+  dist.stop();
+}
+
+// A gap inside the retained ring is replayed on the same connection; a gap
+// older than the ring is answered with the explicit "you need a snapshot"
+// followed by the book itself.
+void test_resend_and_snapshot_required()
+{
+  std::printf("test_resend_and_snapshot_required\n");
+  MdCounters counters;
+  ConsumerBook refBook;
+  MdDistributionServer dist(&counters, testConfig());
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           {
+                             refBook.apply(m);
+                             dist.publish(m); },
+                           px(0.01), SYM, /*epoch*/ 0, /*resendCapacity*/ 16);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+  dist.addPublisher(md);
+  CHECK(dist.start(0) > 0);
+
+  for (int i = 1; i <= 6; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i, i));
+  }
+
+  SbeClient c;
+  CHECK(c.open(dist.port()));
+  CHECK(c.subscribe(SYM));
+  ConsumerBook book;
+  MdSnapshotBegin begin{};
+  CHECK(readSnapshot(c, book, begin));
+  const uint64_t joinedAt = begin.lastSeq;
+
+  // A few more increments, all comfortably inside the 16-deep ring.
+  for (int i = 7; i <= 10; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i % 5 + 1, i));
+  }
+  const uint64_t head = md.seq();
+  std::vector<uint8_t> f;
+  uint64_t applied = joinedAt;
+  while (applied < head && c.next(f))
+  {
+    MdMessage m;
+    CHECK(SbeMdCodec::decode(f.data(), f.size(), m));
+    applied = m.seq;
+  }
+  CHECK(applied == head);
+
+  // Ask for a tail we already have: the ring serves it, byte for byte.
+  const uint64_t from = head - 2;
+  CHECK(c.resend(SYM, from));
+  uint64_t seen = from - 1;
+  for (uint64_t k = from; k <= head; ++k)
+  {
+    CHECK(c.next(f));
+    MdMessage m;
+    CHECK(SbeMdCodec::decode(f.data(), f.size(), m));
+    CHECK(m.seq == seen + 1);
+    seen = m.seq;
+  }
+  CHECK(seen == head);
+  CHECK(counters.resendServed.load() >= 1);
+
+  // Push the ring past seq 1, then ask for something that has been trimmed.
+  for (int i = 11; i <= 40; ++i)
+  {
+    eng.submit(limit(static_cast<OrderId>(i), Side::BUY, 90 + i % 5, 1));
+  }
+  while (c.next(f))
+  {
+    MdMessage m;
+    if (!SbeMdCodec::decode(f.data(), f.size(), m) || m.seq >= md.seq())
+    {
+      break;
+    }
+  }
+  const uint64_t snapshotsBefore = counters.snapshotsServed.load();
+  CHECK(c.resend(SYM, 1));
+  ConsumerBook rebuilt;
+  MdSnapshotBegin again{};
+  CHECK(readSnapshot(c, rebuilt, again, /*expectRequired*/ true));
+  CHECK(again.epoch == md.epoch());
+  CHECK(counters.snapshotsServed.load() == snapshotsBefore + 1);
+
+  // The rebuilt book plus whatever follows equals the reference.
+  applied = again.lastSeq;
+  const uint64_t target = md.seq();
+  while (applied < target && c.next(f))
+  {
+    MdMessage m;
+    if (!SbeMdCodec::decode(f.data(), f.size(), m))
+    {
+      continue;
+    }
+    if (m.seq <= applied)
+    {
+      continue;  // an in-flight duplicate from before the re-snapshot
+    }
+    rebuilt.apply(m);
+    applied = m.seq;
+  }
+  CHECK(sameBook(rebuilt, refBook));
+
+  // An unknown symbol is refused outright, with no subscription left behind.
+  CHECK(c.subscribe(OTHER));
+  CHECK(c.next(f));
+  CHECK(c.tmpl(f) == SbeMdCodec::Tmpl::SubscribeReject);
+  MdSubscribeReject rej{};
+  CHECK(SbeMdCodec::decode(f.data(), f.size(), rej));
+  CHECK(rej.symbol == OTHER);
+  CHECK(rej.reason == MdSubscribeRejectReason::UnknownSymbol);
+  CHECK(counters.subscribeRejects.load() == 1);
+
+  c.close();
+  dist.stop();
+}
+
+// A restarted publisher mints a new epoch and starts over at seq=1. The
+// subscriber must SEE that -- not have the restarted stream filtered out as
+// stale by a delivery position left over from the previous lifetime -- and
+// re-snapshot.
+void test_publisher_restart_epoch()
+{
+  std::printf("test_publisher_restart_epoch\n");
+  MdCounters counters;
+  MdDistributionServer dist(&counters, testConfig());
+  CHECK(dist.start(0) > 0);
+
+  ConsumerBook refBook;
+  auto sink = [&](const MdMessage& m)
+  {
+    refBook.apply(m);
+    dist.publish(m);
+  };
+
+  MarketDataPublisher<> first(sink, px(0.01), SYM, /*epoch*/ 1111);
+  MatchingEngine<MatchingBook> eng1(cfg(), [&](const OutboundEvent& e)
+                                    { first.onEvent(e, eng1.engineTimeNs()); });
+  dist.addPublisher(first);
+  for (int i = 1; i <= 8; ++i)
+  {
+    eng1.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i, i));
+  }
+
+  SbeClient c;
+  CHECK(c.open(dist.port()));
+  CHECK(c.subscribe(SYM));
+  ConsumerBook book;
+  MdSnapshotBegin begin{};
+  CHECK(readSnapshot(c, book, begin));
+  CHECK(begin.epoch == 1111);
+
+  std::vector<uint8_t> f;
+  uint64_t applied = begin.lastSeq;
+  const uint64_t head = first.seq();
+  while (applied < head && c.next(f))
+  {
+    MdMessage m;
+    CHECK(SbeMdCodec::decode(f.data(), f.size(), m));
+    applied = m.seq;
+  }
+
+  // Restart: a fresh publisher for the same symbol, new epoch, seq back to 1.
+  refBook.clear();
+  MarketDataPublisher<> second(sink, px(0.01), SYM, /*epoch*/ 2222);
+  MatchingEngine<MatchingBook> eng2(cfg(), [&](const OutboundEvent& e)
+                                    { second.onEvent(e, eng2.engineTimeNs()); });
+  dist.addPublisher(second);
+  eng2.submit(limit(101, Side::BUY, 95, 4));
+
+  CHECK(c.next(f));
+  MdMessage m;
+  CHECK(SbeMdCodec::decode(f.data(), f.size(), m));
+  CHECK(m.epoch == 2222);  // the restarted stream is delivered, not swallowed
+  CHECK(m.seq == 1);       // even though the old position was well past it
+
+  // Seeing the epoch change, the consumer re-snapshots.
+  CHECK(c.subscribe(SYM));
+  ConsumerBook rebuilt;
+  MdSnapshotBegin after{};
+  CHECK(readSnapshot(c, rebuilt, after));
+  CHECK(after.epoch == 2222);
+  CHECK(after.lastSeq >= 1);
+
+  eng2.submit(limit(102, Side::SELL, 120, 2));
+  applied = after.lastSeq;
+  const uint64_t target = second.seq();
+  while (applied < target && c.next(f))
+  {
+    MdMessage inc;
+    if (!SbeMdCodec::decode(f.data(), f.size(), inc) || inc.seq <= applied)
+    {
+      continue;
+    }
+    rebuilt.apply(inc);
+    applied = inc.seq;
+  }
+  CHECK(applied == target);
+  CHECK(sameBook(rebuilt, refBook));
+
+  c.close();
+  dist.stop();
+}
+
+// FIX round trip: Logon, MarketDataRequest, full refresh, incrementals,
+// unsubscribe, and a reject for a symbol the venue does not publish. Prices
+// and sizes print exactly, as they do on the order-entry side.
+void test_fix_market_data()
+{
+  std::printf("test_fix_market_data\n");
+  MdCounters counters;
+  MdDistributionServer dist(&counters, testConfig());
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { dist.publish(m); }, px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+  dist.addPublisher(md);
+  CHECK(dist.start(0) > 0);
+
+  eng.submit(limit(1, Side::SELL, 100.25, 1.5));
+  eng.submit(limit(2, Side::BUY, 99.75, 2));
+
+  FixClient c;
+  CHECK(c.open(dist.port()));
+  CHECK(c.logon());
+  const std::string logon = c.nextOf("A");
+  CHECK(!logon.empty());
+  CHECK(hasField(logon, "49=VENUE"));
+  CHECK(hasField(logon, "56=CLIENT"));
+
+  // 263=1: snapshot plus updates.
+  CHECK(c.request("REQ-1", "1", {SYM}));
+  const std::string refresh = c.nextOf("W");
+  CHECK(!refresh.empty());
+  CHECK(hasField(refresh, "262=REQ-1"));
+  CHECK(hasField(refresh, "55=1"));
+  CHECK(hasField(refresh, "268=2"));
+  CHECK(hasField(refresh, "269=1"));       // the resting offer
+  CHECK(hasField(refresh, "270=100.25"));  // exact decimal, never 100.250000
+  CHECK(hasField(refresh, "271=1.5"));
+  CHECK(hasField(refresh, "269=0"));  // the resting bid
+  CHECK(hasField(refresh, "270=99.75"));
+  CHECK(hasField(refresh, "278=1"));  // order-level entry ids
+
+  // A new resting order arrives as an incremental with MDUpdateAction New.
+  eng.submit(limit(3, Side::SELL, 101.5, 4.25));
+  const std::string add = c.nextOf("X");
+  CHECK(!add.empty());
+  CHECK(hasField(add, "262=REQ-1"));
+  CHECK(hasField(add, "268=1"));
+  CHECK(hasField(add, "279=0"));  // New
+  CHECK(hasField(add, "269=1"));  // Offer
+  CHECK(hasField(add, "55=1"));
+  CHECK(hasField(add, "270=101.5"));
+  CHECK(hasField(add, "271=4.25"));
+  CHECK(hasField(add, "278=3"));
+
+  // A cancel arrives as MDUpdateAction Delete.
+  eng.submit(CancelOrder{3, SYM, 1});
+  const std::string del = c.nextOf("X");
+  CHECK(!del.empty());
+  CHECK(hasField(del, "279=2"));  // Delete
+  CHECK(hasField(del, "278=3"));
+
+  // A trade prints as an MDEntryType Trade entry.
+  eng.submit(limit(4, Side::BUY, 100.25, 0.5, 2));
+  bool sawTrade = false;
+  for (int i = 0; i < 8 && !sawTrade; ++i)
+  {
+    const std::string x = c.nextOf("X");
+    if (x.empty())
+    {
+      break;
+    }
+    sawTrade = hasField(x, "269=2") && hasField(x, "270=100.25");
+  }
+  CHECK(sawTrade);
+
+  // 263=2 unsubscribes: the stream stops.
+  CHECK(c.request("REQ-1", "2", {SYM}));
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  while (!c.next().empty())
+  {
+  }
+  eng.submit(limit(5, Side::BUY, 98, 1));
+  eng.submit(limit(6, Side::BUY, 97, 1));
+  CHECK(c.nextOf("X").empty());  // nothing further arrives
+
+  // A symbol the venue does not publish is rejected, with a reason.
+  CHECK(c.request("REQ-2", "1", {OTHER}));
+  const std::string reject = c.nextOf("Y");
+  CHECK(!reject.empty());
+  CHECK(hasField(reject, "262=REQ-2"));
+  CHECK(hasField(reject, "281=0"));  // unknown symbol
+
+  // An unsupported request type is rejected before it reaches the feed.
+  CHECK(c.request("REQ-3", "9", {SYM}));
+  const std::string bad = c.nextOf("Y");
+  CHECK(!bad.empty());
+  CHECK(hasField(bad, "281=4"));  // unsupported SubscriptionRequestType
+
+  // Partial depth is not something the feed can honestly serve.
+  CHECK(c.request("REQ-4", "1", {SYM}, {"0", "1"}, "5"));
+  const std::string depth = c.nextOf("Y");
+  CHECK(!depth.empty());
+  CHECK(hasField(depth, "281=5"));
+
+  c.close();
+  dist.stop();
+}
+
+// One server, one port, two encodings at the same time: the first byte of the
+// connection picks the encoder and the distribution logic is the same for both.
+void test_both_encodings_one_server()
+{
+  std::printf("test_both_encodings_one_server\n");
+  MdCounters counters;
+  MdDistributionServer dist(&counters, testConfig());
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { dist.publish(m); }, px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+  dist.addPublisher(md);
+  CHECK(dist.start(0) > 0);
+
+  eng.submit(limit(1, Side::SELL, 105, 3));
+
+  SbeClient binary;
+  FixClient text;
+  CHECK(binary.open(dist.port()));
+  CHECK(text.open(dist.port()));
+  CHECK(binary.subscribe(SYM));
+  CHECK(text.logon());
+  CHECK(!text.nextOf("A").empty());
+  CHECK(text.request("BOTH", "1", {SYM}));
+
+  ConsumerBook book;
+  MdSnapshotBegin begin{};
+  CHECK(readSnapshot(binary, book, begin));
+  CHECK(begin.orderCount == 1);
+  const std::string refresh = text.nextOf("W");
+  CHECK(!refresh.empty());
+  CHECK(hasField(refresh, "268=1"));
+  CHECK(hasField(refresh, "270=105"));
+
+  CHECK(counters.subscribers.load() == 2);
+
+  // The same increment reaches both, each in its own encoding.
+  eng.submit(limit(2, Side::BUY, 95.5, 7));
+  std::vector<uint8_t> f;
+  CHECK(binary.next(f));
+  MdMessage m;
+  CHECK(SbeMdCodec::decode(f.data(), f.size(), m));
+  CHECK(m.type == MdType::AddOrder);
+  CHECK(m.id == 2);
+  CHECK(m.price.raw() == px(95.5).raw());
+
+  const std::string inc = text.nextOf("X");
+  CHECK(!inc.empty());
+  CHECK(hasField(inc, "278=2"));
+  CHECK(hasField(inc, "270=95.5"));
+  CHECK(hasField(inc, "271=7"));
+
+  binary.close();
+  text.close();
+  dist.stop();
+}
+
+// A subscriber that goes silent is not kept forever: the liveness policy is
+// the gateways' -- no inbound traffic within the idle window, connection gone.
+void test_idle_subscriber_dropped()
+{
+  std::printf("test_idle_subscriber_dropped\n");
+  MdCounters counters;
+  MdDistributionConfig dcfg = testConfig();
+  dcfg.idleTimeoutMs = 200;
+  dcfg.heartbeatMs = 60000;
+  MdDistributionServer dist(&counters, dcfg);
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { dist.publish(m); }, px(0.01), SYM);
+  dist.addPublisher(md);
+  CHECK(dist.start(0) > 0);
+
+  SbeClient c;
+  CHECK(c.open(dist.port(), 1500));
+  CHECK(c.subscribe(SYM));
+  ConsumerBook book;
+  MdSnapshotBegin begin{};
+  CHECK(readSnapshot(c, book, begin));
+
+  std::vector<uint8_t> f;
+  CHECK(!c.next(f));  // the server closed: read returns EOF, not a frame
+  CHECK(counters.idleDisconnects.load() >= 1);
+  CHECK(dist.subscriberCount() == 0);
+
+  c.close();
+  dist.stop();
+}
+
+// Trading status and the derivatives layer travel over the unicast channel
+// like any other message -- live, and inside the snapshot a late joiner gets.
+// A subscriber that connects into a halted instrument must be told it is
+// halted; one holding a perp must get a mark to value it with.
+void test_status_and_derivatives_over_unicast()
+{
+  std::printf("test_status_and_derivatives_over_unicast\n");
+  MdDistributionServer dist(nullptr, testConfig());
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { dist.publish(m); }, px(0.01), SYM);
+  SymbolConfig c = cfg();
+  c.fundingIntervalNs = 8'000'000'000LL;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+  dist.addPublisher(md);
+  CHECK(dist.start(0) > 0);
+
+  eng.submit(limit(1, Side::SELL, 100, 5), 1'000);
+  eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 2'000);
+  eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Halt}}, 3'000);
+
+  // Late joiner: the snapshot leads with the state, then the book.
+  SbeClient joiner;
+  CHECK(joiner.open(dist.port()));
+  CHECK(joiner.subscribe(SYM));
+  ConsumerBook book;
+  MdSnapshotBegin begin{};
+  SnapshotState state;
+  CHECK(readSnapshot(joiner, book, begin, /*expectRequired*/ false, &state));
+  CHECK(state.hasStatus);
+  CHECK(state.status.status == TradingStatus::Halted);
+  CHECK(state.status.engineTsNs == 3'000);
+  CHECK(state.hasDerivatives);
+  CHECK(state.derivatives.price == px(100));
+  CHECK(state.derivatives.nextFundingNs == 8'000'000'000LL);
+  CHECK(state.beforeFirstOrder == 2);  // both ahead of the book body
+  CHECK(begin.orderCount == 1);
+
+  // Live: the resume and a new mark reach the same subscriber as increments.
+  eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Resume}}, 4'000);
+  eng.submit(InboundCommand{SetMark{SYM, px(101)}}, 5'000);
+
+  bool sawResume = false;
+  bool sawMark = false;
+  std::vector<uint8_t> f;
+  while ((!sawResume || !sawMark) && joiner.next(f))
+  {
+    MdMessage m;
+    CHECK(SbeMdCodec::decode(f.data(), f.size(), m));
+    CHECK(m.engineTsNs != 0 && m.sendTsNs != 0);
+    if (m.type == MdType::TradingStatus && m.status == TradingStatus::Trading)
+    {
+      sawResume = true;
+    }
+    if (m.type == MdType::DerivativesUpdate && m.price == px(101))
+    {
+      sawMark = true;
+    }
+  }
+  CHECK(sawResume);
+  CHECK(sawMark);
+
+  joiner.close();
+  dist.stop();
+}
+
+}  // namespace
+
+TEST(MdDistribution, EngineSuite)
+{
+  test_status_and_derivatives_over_unicast();
+  test_subscribe_midstream();
+  test_slow_consumer_disconnected();
+  test_resend_and_snapshot_required();
+  test_publisher_restart_epoch();
+  test_fix_market_data();
+  test_both_encodings_one_server();
+  test_idle_subscriber_dropped();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_md_recovery.cpp
+++ b/venue/tests/test_venue_md_recovery.cpp
@@ -118,6 +118,8 @@ struct ConsumerBook
         break;
       case MdType::Trade:
       case MdType::Triggered:
+      case MdType::TradingStatus:
+      case MdType::DerivativesUpdate:
         break;  // no direct depth impact (depth moves via Executed)
     }
   }
@@ -206,7 +208,7 @@ void test_late_joiner_snapshot()
                              udpPub.publish(m); },
                            px(0.01), SYM, /*epoch*/ 0, /*resendCapacity*/ 8);
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
-                                   { md.onEvent(e); });
+                                   { md.onEvent(e, eng.engineTimeNs()); });
   MdRecoveryServer rec(&counters);
   rec.addPublisher(md);
   CHECK(rec.start(0) > 0);
@@ -321,7 +323,7 @@ void test_resend_served()
   MarketDataPublisher<> md([&](const MdMessage& m)
                            { sent.push_back(m); }, px(0.01), SYM);
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
-                                   { md.onEvent(e); });
+                                   { md.onEvent(e, eng.engineTimeNs()); });
   MdRecoveryServer rec(&counters);
   rec.addPublisher(md);
   CHECK(rec.start(0) > 0);
@@ -362,7 +364,7 @@ void test_resend_served()
   MdCounters counters2;
   MarketDataPublisher<> md2([](const MdMessage&) {}, px(0.01), SYM, 0, /*resendCapacity*/ 4);
   MatchingEngine<MatchingBook> eng2(cfg(), [&](const OutboundEvent& e)
-                                    { md2.onEvent(e); });
+                                    { md2.onEvent(e, eng2.engineTimeNs()); });
   MdRecoveryServer rec2(&counters2);
   rec2.addPublisher(md2);
   CHECK(rec2.start(0) > 0);
@@ -422,7 +424,7 @@ void test_publisher_restart_epoch()
   const uint64_t epoch1 = md1->epoch();
   {
     MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
-                                     { md1->onEvent(e); });
+                                     { md1->onEvent(e, eng.engineTimeNs()); });
     eng.submit(limit(1, Side::SELL, 101, 1));
     eng.submit(limit(2, Side::BUY, 99, 2));
     const uint64_t t1 = md1->seq();
@@ -451,7 +453,7 @@ void test_publisher_restart_epoch()
   md1.reset();
   CHECK(md2->epoch() != epoch1);
   MatchingEngine<MatchingBook> eng2(cfg(), [&](const OutboundEvent& e)
-                                    { md2->onEvent(e); });
+                                    { md2->onEvent(e, eng2.engineTimeNs()); });
   eng2.submit(limit(1, Side::SELL, 105, 3));  // ids restart too: a different book
   eng2.submit(limit(2, Side::BUY, 95, 4));
   eng2.submit(limit(3, Side::SELL, 106, 1));
@@ -520,7 +522,7 @@ void test_recovery_backoff_bounded()
                              } },
                            px(0.01), SYM, /*epoch*/ 7);
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
-                                   { md.onEvent(e); });
+                                   { md.onEvent(e, eng.engineTimeNs()); });
   MdRecoveryServer rec(&counters);
   rec.addPublisher(md);
   const int port = rec.start(0);
@@ -587,7 +589,7 @@ void test_recovery_server_bind_address()
   MdCounters counters;
   MarketDataPublisher<> md([](const MdMessage&) {}, px(0.01), SYM);
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
-                                   { md.onEvent(e); });
+                                   { md.onEvent(e, eng.engineTimeNs()); });
   for (int i = 1; i <= 3; ++i)
   {
     eng.submit(limit(static_cast<OrderId>(i), Side::SELL, 100 + i, i));
@@ -632,6 +634,75 @@ void test_send_drop_counted()
   CHECK(got.seq == 1 && got.epoch == 1);
 }
 
+// The new message types are ordinary feed messages: they cross the datagram
+// transport intact, and the recovery channel's snapshot carries the CURRENT
+// status and derivatives so a consumer that reconnects into a halted
+// instrument is not left reading an idle book.
+void test_status_and_derivatives_over_multicast_and_recovery()
+{
+  std::printf("test_status_and_derivatives_over_multicast_and_recovery\n");
+  MdCounters counters;
+  UdpMdPublisher udpPub;
+  UdpMdSubscriber sub;
+  CHECK(setupUdp(udpPub, sub, "239.7.8.4"));
+
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { udpPub.publish(m); }, px(0.01), SYM);
+  SymbolConfig c = cfg();
+  c.fundingIntervalNs = 8'000'000'000LL;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+  MdRecoveryServer rec(&counters);
+  rec.addPublisher(md);
+  CHECK(rec.start(0) > 0);
+
+  eng.submit(limit(1, Side::SELL, 100, 5), 1'000);
+  eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 2'000);
+  eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Halt}}, 3'000);
+
+  // Multicast: both new types arrive decoded, with both timestamps.
+  bool sawStatus = false;
+  bool sawDerivatives = false;
+  MdMessage m;
+  while (sub.recv(m))
+  {
+    CHECK(m.engineTsNs != 0 && m.sendTsNs != 0);
+    if (m.type == MdType::TradingStatus)
+    {
+      sawStatus = m.status == TradingStatus::Halted && m.engineTsNs == 3'000;
+    }
+    if (m.type == MdType::DerivativesUpdate)
+    {
+      sawDerivatives = m.price == px(100) && m.nextFundingNs == 8'000'000'000LL;
+    }
+  }
+  CHECK(sawStatus);
+  CHECK(sawDerivatives);
+
+  // Recovery channel: a late joiner (fromSeq = 0) gets the state alongside the
+  // book, kept out of the order body.
+  MdRecoveryClient::Result res;
+  CHECK(client(rec.port()).recover(SYM, 0, res) == MdRecoveryClient::Status::Ok);
+  CHECK(res.snapshot);
+  CHECK(res.hasStatus && res.status.status == TradingStatus::Halted);
+  CHECK(res.hasDerivatives && res.derivatives.price == px(100));
+  CHECK(res.messages.size() == res.begin.orderCount);  // body is orders only
+
+  // A RESEND is a different case: there they are sequenced increments and must
+  // stay in the stream, or the replay would have a hole in it.
+  MdRecoveryClient::Result replay;
+  CHECK(client(rec.port()).recover(SYM, 1, replay) == MdRecoveryClient::Status::Ok);
+  CHECK(!replay.snapshot);
+  CHECK(replay.messages.size() == md.seq());
+  CHECK(replay.lastSeq == md.seq());
+  bool statusInStream = false;
+  for (const MdMessage& r : replay.messages)
+  {
+    statusInStream = statusInStream || r.type == MdType::TradingStatus;
+  }
+  CHECK(statusInStream);
+}
+
 }  // namespace
 
 TEST(MdRecovery, EngineSuite)
@@ -644,6 +715,7 @@ TEST(MdRecovery, EngineSuite)
   test_recovery_backoff_bounded();
   test_recovery_server_bind_address();
   test_send_drop_counted();
+  test_status_and_derivatives_over_multicast_and_recovery();
   std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
   EXPECT_EQ(g_failures, 0);
 }

--- a/venue/tests/test_venue_multi_symbol_soak.cpp
+++ b/venue/tests/test_venue_multi_symbol_soak.cpp
@@ -107,10 +107,12 @@ void test_soak()
   for (int s = 0; s < NSYM; ++s)
   {
     MarketDataPublisher<>* md = mds[s].get();
-    auto& eng = router.addSymbol(cfg(SYMS[s], BASES[s]), [&metrics, md](const OutboundEvent& e)
+    // engines[] is filled below and outlives the lambda; the engine's own
+    // sequencer time is what stamps the feed.
+    auto& eng = router.addSymbol(cfg(SYMS[s], BASES[s]), [&metrics, md, &engines, s](const OutboundEvent& e)
                                  {
                                    metrics.observe(e);
-                                   md->onEvent(e); });
+                                   md->onEvent(e, engines[s] != nullptr ? engines[s]->engineTimeNs() : 0); });
     flox::FeeSchedule fs;
     fs.addTier(0.0, -1.0, 2.0);  // maker rebate / taker fee -> venue nets fees
     eng.setFeeSchedule(fs);

--- a/venue/tests/test_venue_network.cpp
+++ b/venue/tests/test_venue_network.cpp
@@ -485,7 +485,7 @@ void test_md_snapshot()
   std::printf("test_md_snapshot\n");
   MarketDataPublisher<> md([](const MdMessage&) {}, Price::fromDouble(0.01), SYM);
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
-                                   { md.onEvent(e); });
+                                   { md.onEvent(e, eng.engineTimeNs()); });
   eng.submit(mk(1, Side::SELL, 100, 5));
   eng.submit(mk(2, Side::SELL, 101, 3));
   eng.submit(mk(3, Side::BUY, 99, 4));

--- a/venue/tests/test_venue_session_and_funding.cpp
+++ b/venue/tests/test_venue_session_and_funding.cpp
@@ -1,0 +1,714 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ *
+ * Session state and the funding calendar as ENGINE STATE: a closed session that
+ * is not a halt, a funding rate that survives a checkpoint, and a next-funding
+ * boundary that is a fact the operator sets rather than a formula over config.
+ * Each of the three is driven through all four paths it has to hold on --
+ * live command, published transition, journal replay, checkpoint -- plus the
+ * wire, where the new status value must not disturb a reader of the previous
+ * schema.
+ */
+#include "flox-venue/event_hash.h"
+#include "flox-venue/fix_md_codec.h"
+#include "flox-venue/journal.h"
+#include "flox-venue/market_data.h"
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox-venue/sbe_md_codec.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr int64_t SEC = 1'000'000'000LL;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  return c;
+}
+
+SymbolConfig perpCfg()
+{
+  SymbolConfig c = cfg();
+  c.linearPerp = true;
+  c.initialMarginBps = 1000;
+  c.fundingIntervalNs = 8 * SEC;  // the config-derived calendar, kept as fallback
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct = 1)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+InboundCommand admin(AdminAction a) { return InboundCommand{AdminCmd{SYM, a}}; }
+
+// Engine plus everything it emitted, folded into the determinism digest as it
+// goes -- the same digest the reproducibility tests compare on.
+struct Eng
+{
+  std::vector<OutboundEvent> out;
+  uint64_t hash{0};
+  MatchingEngine<MatchingBook> eng;
+
+  explicit Eng(SymbolConfig c = cfg())
+      : eng(c, [this](const OutboundEvent& e)
+            {
+              out.push_back(e);
+              hash = hashEvent(hash, e); })
+  {
+  }
+
+  const TradingStatusChanged* lastStatus() const
+  {
+    const TradingStatusChanged* found = nullptr;
+    for (const OutboundEvent& e : out)
+    {
+      if (const auto* s = std::get_if<TradingStatusChanged>(&e))
+      {
+        found = s;
+      }
+    }
+    return found;
+  }
+  const DerivativesUpdated* lastDerivatives() const
+  {
+    const DerivativesUpdated* found = nullptr;
+    for (const OutboundEvent& e : out)
+    {
+      if (const auto* d = std::get_if<DerivativesUpdated>(&e))
+      {
+        found = d;
+      }
+    }
+    return found;
+  }
+  size_t statusCount() const
+  {
+    size_t n = 0;
+    for (const OutboundEvent& e : out)
+    {
+      n += std::holds_alternative<TradingStatusChanged>(e) ? 1 : 0;
+    }
+    return n;
+  }
+  const OrderRejected* lastReject() const
+  {
+    const OrderRejected* found = nullptr;
+    for (const OutboundEvent& e : out)
+    {
+      if (const auto* r = std::get_if<OrderRejected>(&e))
+      {
+        found = r;
+      }
+    }
+    return found;
+  }
+};
+
+// Write a snapshot of `src` and load it into a fresh engine; returns the loader
+// (every record must apply, SnapshotEnd re-verifies the state hash) and the
+// records, so a test can assert what the file does and does not carry.
+struct Restored
+{
+  std::vector<std::pair<int64_t, InboundCommand>> records;
+  bool allApplied{true};
+};
+
+Restored roundTrip(const MatchingEngine<MatchingBook>& src, MatchingEngine<MatchingBook>& dst,
+                   const std::string& path)
+{
+  std::remove(path.c_str());
+  {
+    Journal out(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    src.writeSnapshot(out);
+    out.flush();
+  }
+  Restored r;
+  r.records = Journal::loadTimed(path);
+  for (const auto& [ts, cmd] : r.records)
+  {
+    r.allApplied = dst.applySnapshotRecord(cmd, ts) && r.allApplied;
+  }
+  std::remove(path.c_str());
+  return r;
+}
+
+bool carriesFunding(const Restored& r)
+{
+  for (const auto& [ts, cmd] : r.records)
+  {
+    (void)ts;
+    if (std::holds_alternative<RestoreFunding>(cmd))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ------------------------------------------------------------------- session
+
+// A closed session rejects with its own reason. Halted stays what it was: the
+// two states are not interchangeable, and a client can tell "come back next
+// session" from "something is wrong with this instrument".
+void test_closed_rejects_with_its_own_reason()
+{
+  std::printf("test_closed_rejects_with_its_own_reason\n");
+  Eng e;
+  e.eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5)}, 10);
+  CHECK(e.eng.tradingStatus() == TradingStatus::Trading);
+
+  e.eng.submit(admin(AdminAction::CloseSession), 20);
+  CHECK(e.eng.tradingStatus() == TradingStatus::Closed);
+  CHECK(e.eng.sessionClosed());
+
+  e.eng.submit(InboundCommand{limit(2, Side::BUY, 99, 1, 2)}, 30);
+  CHECK(e.lastReject() != nullptr && e.lastReject()->reason == RejectReason::MarketClosed);
+
+  // A conditional order takes the same door.
+  NewOrder stop = limit(3, Side::SELL, 0, 1, 2);
+  stop.type = OrderType::STOP_MARKET;
+  stop.triggerPrice = px(95);
+  e.eng.submit(InboundCommand{stop}, 40);
+  CHECK(e.lastReject()->id == 3 && e.lastReject()->reason == RejectReason::MarketClosed);
+
+  // A halt is still a halt: the two reject reasons stay distinct.
+  Eng h;
+  h.eng.submit(admin(AdminAction::Halt), 10);
+  h.eng.submit(InboundCommand{limit(1, Side::BUY, 99, 1)}, 20);
+  CHECK(h.lastReject() != nullptr && h.lastReject()->reason == RejectReason::Halted);
+
+  // Closing does NOT pull the book, and a cancel still works while closed --
+  // a client must be able to get out of a position it cannot add to.
+  CHECK(e.eng.book().find(1) != nullptr);
+  e.eng.submit(InboundCommand{CancelOrder{1, SYM, 1}}, 50);
+  CHECK(e.eng.book().find(1) == nullptr);
+
+  // Reopening restores matching.
+  e.eng.submit(admin(AdminAction::OpenSession), 60);
+  CHECK(e.eng.tradingStatus() == TradingStatus::Trading);
+  e.eng.submit(InboundCommand{limit(4, Side::BUY, 99, 1, 2)}, 70);
+  CHECK(e.eng.book().find(4) != nullptr);
+}
+
+// The transition reaches the feed, once per transition, with the session
+// reason -- and the halt underneath a close survives it.
+void test_close_is_a_published_transition()
+{
+  std::printf("test_close_is_a_published_transition\n");
+  Eng e;
+  e.eng.submit(admin(AdminAction::CloseSession), 10);
+  CHECK(e.statusCount() == 1);
+  CHECK(e.lastStatus()->status == TradingStatus::Closed);
+  CHECK(e.lastStatus()->reason == TradingStatusReason::Session);
+  CHECK(e.lastStatus()->untilNs == 0);  // a session close has no deadline
+
+  e.eng.submit(admin(AdminAction::CloseSession), 20);
+  CHECK(e.statusCount() == 1);  // not a transition: no duplicate
+
+  e.eng.submit(admin(AdminAction::OpenSession), 30);
+  CHECK(e.statusCount() == 2 && e.lastStatus()->status == TradingStatus::Trading);
+
+  // Halt, then close over it: the feed shows the outermost state, and the halt
+  // is still there when the session reopens.
+  Eng g;
+  g.eng.submit(admin(AdminAction::Halt), 10);
+  CHECK(g.lastStatus()->status == TradingStatus::Halted);
+  g.eng.submit(admin(AdminAction::CloseSession), 20);
+  CHECK(g.lastStatus()->status == TradingStatus::Closed);
+  g.eng.submit(admin(AdminAction::OpenSession), 30);
+  CHECK(g.lastStatus()->status == TradingStatus::Halted);
+  CHECK(g.eng.config().halted);
+}
+
+// Replay reproduces the session state and the event stream bit for bit, and
+// the closed state changes the state hash (it is state, not a memo).
+void test_session_replays_through_the_journal()
+{
+  std::printf("test_session_replays_through_the_journal\n");
+  const std::string path = "/tmp/flox_test_venue_session_replay.journal";
+  std::remove(path.c_str());
+
+  const std::vector<std::pair<int64_t, InboundCommand>> stream{
+      {10, InboundCommand{limit(1, Side::SELL, 100, 5)}},
+      {20, admin(AdminAction::CloseSession)},
+      {30, InboundCommand{limit(2, Side::BUY, 100, 5, 2)}},  // rejected: MarketClosed
+      {40, admin(AdminAction::OpenSession)},
+      {50, InboundCommand{limit(3, Side::BUY, 100, 5, 2)}},  // trades
+  };
+
+  Eng live;
+  {
+    Journal j(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    for (const auto& [ts, c] : stream)
+    {
+      j.append(c, ts);
+      live.eng.submit(c, ts);
+    }
+    j.flush();
+  }
+
+  Eng replayed;
+  for (const auto& [ts, c] : Journal::loadTimed(path))
+  {
+    replayed.eng.submit(c, ts);
+  }
+  CHECK(replayed.hash == live.hash);
+  CHECK(replayed.eng.stateHash() == live.eng.stateHash());
+  CHECK(replayed.eng.tradingStatus() == TradingStatus::Trading);
+  CHECK(replayed.eng.tradesGenerated() == 1);  // only the post-reopen order matched
+
+  // The same stream without the close is a different run: the session state is
+  // hashed, so a divergence here cannot hide.
+  Eng noClose;
+  for (const auto& [ts, c] : stream)
+  {
+    if (std::holds_alternative<AdminCmd>(c))
+    {
+      continue;
+    }
+    noClose.eng.submit(c, ts);
+  }
+  CHECK(noClose.hash != live.hash);
+  std::remove(path.c_str());
+}
+
+// A checkpoint carries the session state: an engine that went down closed comes
+// back closed, and still refuses orders for the right reason.
+void test_session_survives_a_checkpoint()
+{
+  std::printf("test_session_survives_a_checkpoint\n");
+  Eng src;
+  src.eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5)}, 10);
+  src.eng.submit(admin(AdminAction::CloseSession), 20);
+
+  Eng dst;
+  const Restored r = roundTrip(src.eng, dst.eng, "/tmp/flox_test_venue_session_ckpt.snap");
+  CHECK(r.allApplied);  // SnapshotEnd re-verified the state hash
+  CHECK(dst.eng.stateHash() == src.eng.stateHash());
+  CHECK(dst.eng.tradingStatus() == TradingStatus::Closed);
+  CHECK(dst.eng.book().find(1) != nullptr);  // the book stood through the close
+
+  dst.eng.submit(InboundCommand{limit(2, Side::BUY, 99, 1, 2)}, 30);
+  CHECK(dst.lastReject() != nullptr && dst.lastReject()->reason == RejectReason::MarketClosed);
+
+  // Halt underneath a close survives the round trip too, in the right order.
+  Eng halted;
+  halted.eng.submit(admin(AdminAction::Halt), 10);
+  halted.eng.submit(admin(AdminAction::CloseSession), 20);
+  Eng back;
+  CHECK(roundTrip(halted.eng, back.eng, "/tmp/flox_test_venue_session_ckpt2.snap").allApplied);
+  CHECK(back.eng.stateHash() == halted.eng.stateHash());
+  CHECK(back.eng.tradingStatus() == TradingStatus::Closed);
+  back.eng.submit(admin(AdminAction::OpenSession), 30);
+  CHECK(back.eng.tradingStatus() == TradingStatus::Halted);
+}
+
+// ------------------------------------------------------------------- funding
+
+// The rate is a fact the venue published; it must not evaporate on a restart.
+void test_funding_rate_survives_a_checkpoint()
+{
+  std::printf("test_funding_rate_survives_a_checkpoint\n");
+  Eng src(perpCfg());
+  src.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 1 * SEC);
+  src.eng.submit(InboundCommand{ApplyFunding{SYM, 0.0001, px(100)}}, 2 * SEC);
+  CHECK(src.eng.fundingRateRaw() == kFundingRateScale / 10'000);
+
+  Eng dst(perpCfg());
+  const Restored r = roundTrip(src.eng, dst.eng, "/tmp/flox_test_venue_funding_ckpt.snap");
+  CHECK(r.allApplied);
+  CHECK(carriesFunding(r));
+  CHECK(dst.eng.stateHash() == src.eng.stateHash());
+  CHECK(dst.eng.fundingRateRaw() == src.eng.fundingRateRaw());
+
+  // And the restored engine PUBLISHES it: the first mark after recovery carries
+  // the real rate, not a zero placeholder that lies until the next settlement.
+  dst.eng.submit(InboundCommand{SetMark{SYM, px(101)}}, 3 * SEC);
+  CHECK(dst.lastDerivatives() != nullptr);
+  CHECK(dst.lastDerivatives()->fundingRateRaw == kFundingRateScale / 10'000);
+}
+
+// Read compatibility: a snapshot from an engine with no funding state at all
+// carries no RestoreFunding record -- the exact file shape that existed before
+// the record did -- and still loads, restoring rate 0 and the config fallback.
+void test_snapshot_without_funding_record_still_loads()
+{
+  std::printf("test_snapshot_without_funding_record_still_loads\n");
+  Eng src(perpCfg());
+  src.eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5)}, 1 * SEC);
+
+  Eng dst(perpCfg());
+  const Restored r = roundTrip(src.eng, dst.eng, "/tmp/flox_test_venue_funding_old.snap");
+  CHECK(r.allApplied);
+  CHECK(!carriesFunding(r));  // nothing to record -> the pre-record file shape
+  CHECK(dst.eng.stateHash() == src.eng.stateHash());
+  CHECK(dst.eng.fundingRateRaw() == 0);
+  CHECK(dst.eng.book().find(1) != nullptr);
+
+  // The calendar falls back to the configured interval, exactly as before.
+  dst.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 1 * SEC);
+  CHECK(dst.lastDerivatives()->nextFundingNs == 8 * SEC);
+}
+
+// The calendar is state, not a formula: what the operator set is what the feed
+// publishes, even when it disagrees with the configured interval.
+void test_funding_schedule_is_state_not_a_formula()
+{
+  std::printf("test_funding_schedule_is_state_not_a_formula\n");
+  Eng e(perpCfg());
+  e.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 1 * SEC);
+  CHECK(e.lastDerivatives()->nextFundingNs == 8 * SEC);  // config-derived, pre-schedule
+
+  // A settlement that does not sit on the config grid: 10s intervals, next at 25s.
+  e.eng.submit(InboundCommand{SetFundingSchedule{SYM, 10 * SEC, 25 * SEC}}, 2 * SEC);
+  CHECK(e.eng.nextFundingNs() == 25 * SEC);
+  CHECK(e.eng.fundingIntervalNs() == 10 * SEC);
+  // Setting it is news on the feed (the engine has a mark), not a silent change.
+  CHECK(e.lastDerivatives()->nextFundingNs == 25 * SEC);
+
+  e.eng.submit(InboundCommand{SetMark{SYM, px(101)}}, 3 * SEC);
+  CHECK(e.lastDerivatives()->nextFundingNs == 25 * SEC);  // survives an unrelated mark
+
+  // The settlement moves the calendar on by one whole interval.
+  e.eng.submit(InboundCommand{ApplyFunding{SYM, 0.0002, px(101)}}, 25 * SEC);
+  CHECK(e.eng.nextFundingNs() == 35 * SEC);
+  CHECK(e.lastDerivatives()->nextFundingNs == 35 * SEC);
+  CHECK(e.lastDerivatives()->fundingRateRaw == 2 * (kFundingRateScale / 10'000));
+
+  // A settlement run late (an operator catching up after an outage) skips whole
+  // intervals rather than leaving a boundary in the past.
+  e.eng.submit(InboundCommand{ApplyFunding{SYM, 0.0002, px(101)}}, 68 * SEC);
+  CHECK(e.eng.nextFundingNs() == 75 * SEC);
+
+  // Clearing the schedule falls back to the config derivation.
+  e.eng.submit(InboundCommand{SetFundingSchedule{SYM, 0, 0}}, 69 * SEC);
+  CHECK(e.eng.nextFundingNs() == 72 * SEC);  // 8s grid, first boundary past 69s
+}
+
+// An engine that never learned a schedule behaves exactly as it did before the
+// command existed -- including publishing 0 when the venue funds nothing.
+void test_no_schedule_falls_back_to_config()
+{
+  std::printf("test_no_schedule_falls_back_to_config\n");
+  Eng withInterval(perpCfg());
+  withInterval.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 9 * SEC);
+  CHECK(withInterval.lastDerivatives()->nextFundingNs == 16 * SEC);
+
+  Eng spot(cfg());
+  spot.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 9 * SEC);
+  CHECK(spot.lastDerivatives()->nextFundingNs == 0);
+
+  // A schedule set before the first mark publishes nothing (the feed's standing
+  // promise: no mark, no derivatives message) but is in force when one arrives.
+  Eng early(perpCfg());
+  early.eng.submit(InboundCommand{SetFundingSchedule{SYM, 10 * SEC, 25 * SEC}}, 1 * SEC);
+  CHECK(early.lastDerivatives() == nullptr);
+  early.eng.submit(InboundCommand{SetMark{SYM, px(100)}}, 2 * SEC);
+  CHECK(early.lastDerivatives()->nextFundingNs == 25 * SEC);
+}
+
+// The schedule replays from the journal and survives a checkpoint, like every
+// other piece of engine state.
+void test_funding_schedule_replays_and_checkpoints()
+{
+  std::printf("test_funding_schedule_replays_and_checkpoints\n");
+  const std::string path = "/tmp/flox_test_venue_funding_schedule.journal";
+  std::remove(path.c_str());
+
+  const std::vector<std::pair<int64_t, InboundCommand>> stream{
+      {1 * SEC, InboundCommand{SetMark{SYM, px(100)}}},
+      {2 * SEC, InboundCommand{SetFundingSchedule{SYM, 10 * SEC, 25 * SEC}}},
+      {25 * SEC, InboundCommand{ApplyFunding{SYM, 0.0001, px(100)}}},
+      {26 * SEC, InboundCommand{SetMark{SYM, px(101)}}},
+  };
+
+  Eng live(perpCfg());
+  {
+    Journal j(path, Journal::Sync::Off, Journal::OpenMode::Truncate);
+    for (const auto& [ts, c] : stream)
+    {
+      j.append(c, ts);
+      live.eng.submit(c, ts);
+    }
+    j.flush();
+  }
+  CHECK(live.eng.nextFundingNs() == 35 * SEC);
+
+  Eng replayed(perpCfg());
+  for (const auto& [ts, c] : Journal::loadTimed(path))
+  {
+    replayed.eng.submit(c, ts);
+  }
+  CHECK(replayed.hash == live.hash);  // the published calendar is in the digest
+  CHECK(replayed.eng.stateHash() == live.eng.stateHash());
+  CHECK(replayed.eng.nextFundingNs() == 35 * SEC);
+  std::remove(path.c_str());
+
+  Eng restored(perpCfg());
+  const Restored r =
+      roundTrip(live.eng, restored.eng, "/tmp/flox_test_venue_funding_schedule.snap");
+  CHECK(r.allApplied);
+  CHECK(carriesFunding(r));
+  CHECK(restored.eng.stateHash() == live.eng.stateHash());
+  CHECK(restored.eng.nextFundingNs() == 35 * SEC);
+  CHECK(restored.eng.fundingIntervalNs() == 10 * SEC);
+  CHECK(restored.eng.fundingRateRaw() == kFundingRateScale / 10'000);
+
+  // The restored calendar keeps advancing from where it was, not from config.
+  restored.eng.submit(InboundCommand{ApplyFunding{SYM, 0.0001, px(101)}}, 35 * SEC);
+  CHECK(restored.eng.nextFundingNs() == 45 * SEC);
+}
+
+// ---------------------------------------------------------------------- wire
+
+// A pre-Closed SBE reader, transcribed against its own offsets: it knows the
+// TradingStatus template but only status values 0..4. Returns the fields it
+// decodes plus whether the status code was one it recognises.
+struct OldStatusRead
+{
+  bool ok{false};
+  bool statusKnown{false};
+  uint8_t statusRaw{0};
+  uint64_t seq{0};
+  SymbolId symbol{0};
+  uint64_t epoch{0};
+  int64_t engineTs{0};
+  int64_t sendTs{0};
+  uint8_t reason{0};
+  int64_t untilNs{0};
+};
+
+OldStatusRead decodeStatusPreClosed(const uint8_t* p, size_t n)
+{
+  OldStatusRead r;
+  if (n < SbeMdCodec::kHeaderSize)
+  {
+    return r;
+  }
+  const sbe::Header h = sbe::readHeader(p);
+  const uint16_t preClosedBlock = 46;  // seq,sym,epoch,engineTs,sendTs,status,reason,untilNs
+  if (h.schemaId != SbeMdCodec::kSchemaId || h.templateId != 14 ||
+      h.blockLength < preClosedBlock || n < SbeMdCodec::kHeaderSize + h.blockLength)
+  {
+    return r;
+  }
+  const uint8_t* b = p + SbeMdCodec::kHeaderSize;
+  r.ok = true;
+  r.seq = sbe::getU64(b + 0);
+  r.symbol = static_cast<SymbolId>(sbe::getU32(b + 8));
+  r.epoch = sbe::getU64(b + 12);
+  r.engineTs = sbe::getI64(b + 20);
+  r.sendTs = sbe::getI64(b + 28);
+  r.statusRaw = b[36];
+  r.statusKnown = r.statusRaw <= 4;
+  r.reason = b[37];
+  r.untilNs = sbe::getI64(b + 38);
+  return r;
+}
+
+void test_closed_on_the_sbe_wire()
+{
+  std::printf("test_closed_on_the_sbe_wire\n");
+  MdMessage m{};
+  m.type = MdType::TradingStatus;
+  m.seq = 11;
+  m.symbol = SYM;
+  m.epoch = 4242;
+  m.engineTsNs = 111;
+  m.sendTsNs = 222;
+  m.status = TradingStatus::Closed;
+  m.reason = TradingStatusReason::Session;
+
+  std::vector<uint8_t> buf;
+  SbeMdCodec::encode(m, buf);
+  MdMessage back{};
+  CHECK(SbeMdCodec::decode(buf.data(), buf.size(), back));
+  CHECK(back.status == TradingStatus::Closed);
+  CHECK(back.reason == TradingStatusReason::Session);
+  CHECK(back.seq == 11 && back.epoch == 4242 && back.engineTsNs == 111);
+
+  // The frame is byte-identical in LAYOUT to a pre-Closed one: the enum grew at
+  // the end, no root block changed. So the previous reader decodes every field
+  // it knows and sees only an unrecognised status code -- which it must treat
+  // as "not tradeable", never as Trading.
+  CHECK(buf.size() == SbeMdCodec::kHeaderSize + SbeMdCodec::kBlockTradingStatus);
+  const OldStatusRead old = decodeStatusPreClosed(buf.data(), buf.size());
+  CHECK(old.ok);
+  CHECK(old.seq == 11 && old.symbol == SYM && old.epoch == 4242);
+  CHECK(old.engineTs == 111 && old.sendTs == 222 && old.untilNs == 0);
+  CHECK(old.statusRaw == 5 && !old.statusKnown);
+
+  // A value the old reader DOES know still decodes as it always did, out of a
+  // frame produced by the new encoder.
+  m.status = TradingStatus::Halted;
+  m.reason = TradingStatusReason::Administrative;
+  m.untilNs = 999;
+  SbeMdCodec::encode(m, buf);
+  const OldStatusRead halted = decodeStatusPreClosed(buf.data(), buf.size());
+  CHECK(halted.ok && halted.statusKnown && halted.statusRaw == 1);
+  CHECK(halted.reason == 1 && halted.untilNs == 999);
+}
+
+void test_closed_on_the_fix_wire()
+{
+  std::printf("test_closed_on_the_fix_wire\n");
+  FixMdEncoder enc;
+  std::vector<MdRequest> reqs;
+  std::vector<uint8_t> reply;
+  size_t consumed = 0;
+
+  auto feedIn = [&](const std::string& msg)
+  {
+    reqs.clear();
+    reply.clear();
+    consumed = 0;
+    const std::string framed = FixCodec::frame(msg);
+    return enc.parse(reinterpret_cast<const uint8_t*>(framed.data()), framed.size(), consumed, reqs,
+                     reply);
+  };
+
+  std::string logon;
+  FixMdCodec::add(logon, 35, "A");
+  FixMdCodec::add(logon, 34, "1");
+  FixMdCodec::add(logon, 49, "CLIENT");
+  FixMdCodec::add(logon, 56, "VENUE");
+  FixMdCodec::add(logon, 52, FixMdCodec::nowStamp());
+  FixMdCodec::add(logon, 108, "30");
+  CHECK(feedIn(logon) == MdEncoder::Parse::Ok);
+
+  std::string req;
+  FixMdCodec::add(req, 35, "V");
+  FixMdCodec::add(req, 34, "2");
+  FixMdCodec::add(req, 49, "CLIENT");
+  FixMdCodec::add(req, 56, "VENUE");
+  FixMdCodec::add(req, 52, FixMdCodec::nowStamp());
+  FixMdCodec::add(req, 262, "REQ1");
+  FixMdCodec::add(req, 263, "1");
+  FixMdCodec::add(req, 55, std::to_string(SYM));
+  CHECK(feedIn(req) == MdEncoder::Parse::Ok);
+
+  MdMessage st{};
+  st.type = MdType::TradingStatus;
+  st.seq = 1;
+  st.symbol = SYM;
+  st.engineTsNs = 1'700'000'000LL * SEC;
+  st.sendTsNs = st.engineTsNs;
+  st.status = TradingStatus::Closed;
+  st.reason = TradingStatusReason::Session;
+
+  std::vector<uint8_t> out;
+  enc.increment(st, out);
+  const std::string closed(out.begin(), out.end());
+  CHECK(closed.find("\x01"
+                    "35=f") != std::string::npos);
+  // 326=18 "Not available for trading" is the end-of-session value, NOT 2
+  // (Trading Halt): the distinction the state exists for survives to FIX.
+  CHECK(closed.find("\x01"
+                    "326=18") != std::string::npos);
+  CHECK(closed.find("Session closed") != std::string::npos);
+
+  st.status = TradingStatus::Halted;
+  st.reason = TradingStatusReason::Administrative;
+  out.clear();
+  enc.increment(st, out);
+  const std::string halted(out.begin(), out.end());
+  CHECK(halted.find("\x01"
+                    "326=2") != std::string::npos);
+}
+
+// End to end: the engine's own close reaches a market-data subscriber as a
+// Closed status message, and a late joiner's snapshot starts closed.
+void test_close_reaches_the_feed()
+{
+  std::printf("test_close_reaches_the_feed\n");
+  std::vector<MdMessage> feed;
+  MarketDataPublisher<> md([&](const MdMessage& m)
+                           { feed.push_back(m); }, px(0.01), SYM);
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { md.onEvent(e, eng.engineTimeNs()); });
+
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5)}, 1 * SEC);
+  eng.submit(admin(AdminAction::CloseSession), 2 * SEC);
+
+  const MdMessage* status = nullptr;
+  for (const MdMessage& m : feed)
+  {
+    if (m.type == MdType::TradingStatus)
+    {
+      status = &m;
+    }
+  }
+  CHECK(status != nullptr);
+  CHECK(status->status == TradingStatus::Closed);
+  CHECK(status->reason == TradingStatusReason::Session);
+  CHECK(status->engineTsNs == 2 * SEC);
+
+  const MdSnapshot snap = md.snapshotAtomic();
+  CHECK(snap.hasStatus && snap.status.status == TradingStatus::Closed);
+  CHECK(snap.orders.size() == 1);  // the book stands through a close
+}
+
+}  // namespace
+
+TEST(VenueSessionAndFunding, EngineSuite)
+{
+  test_closed_rejects_with_its_own_reason();
+  test_close_is_a_published_transition();
+  test_session_replays_through_the_journal();
+  test_session_survives_a_checkpoint();
+  test_funding_rate_survives_a_checkpoint();
+  test_snapshot_without_funding_record_still_loads();
+  test_funding_schedule_is_state_not_a_formula();
+  test_no_schedule_falls_back_to_config();
+  test_funding_schedule_replays_and_checkpoints();
+  test_closed_on_the_sbe_wire();
+  test_closed_on_the_fix_wire();
+  test_close_reaches_the_feed();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_venue.cpp
+++ b/venue/tests/test_venue_venue.cpp
@@ -240,7 +240,7 @@ TEST(Venue, EngineSuite)
   MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
                                    {
                                      metrics.observe(e);
-                                     md.onEvent(e);
+                                     md.onEvent(e, eng.engineTimeNs());
                                      registry.route(e);
                                      liveHash = hashEvent(liveHash, e); });
   flox::FeeSchedule fs;


### PR DESCRIPTION
The venue could publish market data exactly one way: SBE over UDP multicast. That works for consumers inside the same datacentre and is impossible for anyone else -- multicast does not survive a WAN hop, most cloud networks do not route it, and a client behind NAT cannot join a group. TCP existed only for recovery, not for the live feed, and the FIX codec had no market-data messages at all, so a FIX-speaking integration had no path in.

The feed was also incomplete in a way that is easy to miss: messages carried no timestamp at all, and nothing about instrument state ever reached the wire.

## Distribution over TCP

`MdDistributionServer` serves the live feed: subscribe per symbol on one connection, atomic snapshot followed by incrementals, resend from the ring with an explicit `SnapshotRequired` when the request predates the tail, plus an idle timeout. Sequencing is not reinvented -- ring, `snapshotAtomic` and epoch come from `MarketDataPublisher`, and the per-subscriber bounded queue with a slow-consumer disconnect is the order-entry session writer's shape. The multicast path is untouched and stays the right choice for colocated consumers.

Two details that took thought. The subscribe handover registers the symbol unarmed and parks encoded increments, takes the snapshot **outside** the session mutex -- the other lock order deadlocks against the publisher fan-out -- then queues snapshot frames followed by the parked ones past `lastSeq`, so nothing is lost or overtaken. And an epoch change resets the subscriber's position: without it a restarted feed beginning again at seq=1 is silently filtered by a subscriber still waiting at seq=500.

## Pluggable encodings

`MdEncoder` owns framing, so a binary and a text encoding share one port: the first byte is peeked (`0x00` begins an SBE length prefix, `8` begins a FIX BeginString) instead of inventing a preamble, which keeps an existing FIX engine usable without modification. A port can also be pinned to a single encoding.

`FixMdCodec` implements `MarketDataRequest` (V) with subscribe/snapshot/unsubscribe, `SnapshotFullRefresh` (W), `IncrementalRefresh` (X) with new/change/delete actions, and `MarketDataRequestReject` (Y) with honest reasons. Prices print through the shared decimal helpers, never a double. FIX market data runs its own light session (Logon/Heartbeat/TestRequest/Logout) rather than the order-entry session layer: market data is not account-scoped, and a gap is repaired with a fresh request, not a per-account replay.

## Feed completeness

Every message now carries two timestamps: the engine's sequencer time, which is reproducible on replay and folded into the determinism hash, and a send-time wall clock, which is restamped on resend and deliberately excluded from determinism checks.

Trading status reaches the wire for the first time -- halt, LULD pause and its expiry, auction phases -- sourced from real engine transitions rather than inferred, so a subscriber can distinguish a halted instrument from a dead connection. Derivatives consumers get mark price, funding rate, next funding time and open interest, the numbers needed to compute unrealized PnL and liquidation distance.

`Closed` became a state of its own rather than a halt in disguise: new orders reject with `MarketClosed` while the book stands and cancels keep working. The transition rides the existing `AdminCmd`, so no journal tag and no snapshot format changed. Session scheduling stays with the operator by design -- the engine holds state and transitions, not a calendar.

The funding rate and calendar now survive a checkpoint through a new snapshot-only record, and the next funding time is journaled state advanced by `ApplyFunding` (catching up whole intervals when late) instead of a formula over config, so it no longer drifts when a schedule moves.

## Compatibility

Schema evolution is backward compatible in both directions and tested that way: a transcribed previous-version decoder reads the new frames with the added fields invisible and unknown templates skipped, and a snapshot written before these records still loads and hashes identically -- new terms fold into `stateHash` only when non-zero.

Known consequences, documented rather than hidden: `Closed` masks an auction phase on the feed (a precedence choice); an older SBE consumer sees an unknown status code rather than `Closed`, which the docs address with a "treat unknown as not trading" contract; FIX has no status subscription (`35=e`), so status reaches only consumers with a market-data subscription.

## Verification

Tests run over real sockets: mid-stream subscribe reaching book equality against a consumer that read from the start, slow-consumer disconnect while a second subscriber keeps up and the engine never blocks, resend and snapshot-required, publisher restart seen as an epoch change, a full FIX round trip including reject reasons, both encodings on one port, idle drop, timestamps present and monotone on every path, halt/resume and LULD observed by a subscriber, a late joiner receiving current status and mark.

Full suite **194/194**, stable across repeated runs; format clean under the CI version, doc gates and derived artifacts in sync.

## Out of scope

Consuming external feeds (that is the connector side, which already exists), aggregating several sources into one book, conflation for slow consumers (v1 policy is a bounded queue plus disconnect), instrument reference data (conventionally fetched once over a control channel rather than streamed), and a client library for the unicast channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
