### PR TITLE
fix(venue): close the gate-bypass class of defect, and prove it structurally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -809,6 +809,42 @@ jobs:
   # The venue module must stay genuinely optional: a build with it OFF has to
   # configure, compile and pass its suite with no venue code involved. Cheap
   # job, but it is the only thing that stops the OFF path from rotting.
+  # Static proof that every handler reaching the matcher applies its pre-trade
+  # gates first. Property tests can only assert this for the paths someone
+  # enumerated; this asserts it over the code, so a new path cannot skip a
+  # check silently. Configure only -- the check reads compile_commands.json and
+  # never needs a compiled object.
+  venue-gate-reachability:
+    needs: [format-check, verify-docs-current]
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build clang-18 libgtest-dev libgmock-dev
+        pip install libclang
+
+    - name: Configure
+      run: |
+        cmake -B build -G Ninja \
+              -DCMAKE_CXX_COMPILER=clang++-18 \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DFLOX_BUILD_VENUE=ON \
+              -DFLOX_BUILD_TESTS=ON
+
+    - name: Prove every path into matching applies its gates
+      run: python3 scripts/check_gate_reachability.py
+
+    - name: Exhaustively check the checkpoint/recovery protocol
+      run: python3 scripts/check_recovery_model.py
+
   venue-optional:
     needs: [format-check, verify-docs-current]
     runs-on: ubuntu-24.04

--- a/docs/venue/clearing.md
+++ b/docs/venue/clearing.md
@@ -44,11 +44,31 @@ account; it is simply frozen. The fuzz therefore asserts a second property:
 after the book is drained, every account's `reserved` is zero. See
 [Verification](verification.md).
 
+Two rules keep step 3 from turning into step 2's problem:
+
+- **A removal resolves last-look holds first.** Every path that pulls an order
+  -- including the ones the matcher owns itself, self-trade prevention and a
+  fill-time risk block -- resolves that order's open holds before releasing its
+  reservation. Releasing first would hand the collateral back while a hold that
+  still has to settle from it is open.
+- **A leg that cannot pay does not settle.** `Ledger::debit` is all-or-nothing.
+  Both unreserved legs of a fill are funded before anything is credited, and if
+  either refuses the settlement is abandoned as a unit: nothing moves, the trade
+  is counted in `unsettledTrades()`, and the venue does not invent the
+  difference. That counter must read zero.
+
 ## Conservation
 
 Assets are only ever exchanged, so each asset's total across all accounts plus
 the venue account is invariant. The conservation fuzz checks this after every
-command over a random stream of all order types.
+command, over a random stream covering limits, market and stop orders, GTD,
+OCO, pegs, icebergs, modify and cancel, last look under every STP mode, and
+perp fills with liquidation and ADL.
+
+What the fuzz does NOT drive, so read its green run accordingly: mass cancel,
+market-maker protection, halt-and-cancel-all, Deposit/Withdraw commands,
+two-sided quote replace, and engine-level funding application. Those paths have
+point tests, not randomized ones.
 
 Cash and inventory are conserved exactly. Total mark-to-market equity moves
 with the last price, which is valuation, not a leak; the

--- a/docs/venue/market-data.md
+++ b/docs/venue/market-data.md
@@ -167,10 +167,10 @@ number consumers read at mark cadence.
 
 ### The funding calendar is state, not a formula
 
-`nextFundingNs` used to be derived from `(now, SymbolConfig::fundingIntervalNs)`
-— a computation over startup config rather than a fact, which drifts from
-reality the moment an operator changes the interval or shifts a settlement. It
-is now engine state:
+`nextFundingNs` is engine state, not a computation over
+`(now, SymbolConfig::fundingIntervalNs)`. Deriving it from startup config would
+drift from reality the moment an operator changes the interval or shifts a
+settlement:
 
 - **`SetFundingSchedule{symbol, intervalNs, nextFundingNs}`** — a sequenced,
   journaled command (control-plane verb of the same name). The operator owns the

--- a/docs/venue/matching.md
+++ b/docs/venue/matching.md
@@ -71,6 +71,61 @@ STP interacts with `FOK`: an all-or-none order cannot count liquidity it would
 never be allowed to trade with, so the precheck excludes same-scope resting
 size.
 
+STP also interacts with **last look**: the maker it pulls may have a hold open,
+so the hold is resolved (rejected, liquidity restored) before the order is
+removed -- the same order every engine-side cancel path follows. Removing first
+would release the collateral the hold still had to settle from.
+
+### Live risk limits
+
+The band, the fat-finger caps, the per-account order cap, the position cap and
+the margin requirement are changed with the sequenced `SetRiskLimits` command
+(control-plane verb `setRiskLimits`). A field mask says which limits the record
+carries, so raising one cannot zero another by omission.
+
+The direct setters on the engine remain for pre-start wiring. On a running
+engine they apply immediately and ride nothing: a restart reverts them and a
+replica replaying the journal never sees the change. Use the command.
+
+### Delisting
+
+`AdminAction::Delist` withdraws an instrument from trading and pulls the
+resting book with it. A halt promises the instrument comes back and a closed
+session promises the next one; delisting promises neither, so leaving orders
+resting would leave them waiting for an open that is not coming. New orders are
+rejected with `InstrumentDelisted`, which says that rather than promising a
+return.
+
+It outranks halt, session and auction state: reopening the session does not
+make a delisted instrument tradeable. `Relist` reverses it -- an irreversible
+operator action is one mistake away from needing a restart to undo.
+
+### Admission profiles
+
+Counterparties have different rights. One routes flow it manages itself and
+should never leave an order resting here; another posts and pulls quotes, where
+cancel/replace is the main operation. The rights are set per account and
+checked on entry.
+
+| Field | Meaning |
+|---|---|
+| `allowedTypes` | bitmask over `OrderType`; 0 = no restriction |
+| `allowedTif` | bitmask over `TimeInForce`; 0 = no restriction |
+| `deny` | `DenyResting`, `DenyAmend`, `DenyCancel`, `DenyQuote` |
+
+An absent profile permits everything, so an engine never given one behaves as
+before. `DenyResting` rejects GTC, GTD and post-only on admission rather than
+killing the residual afterwards: an order resting here that the sender does not
+track will not be reconciled, and nothing looks wrong until it fills. The
+rejection happens before the `clientOrderId` is consumed, so a corrected
+message can be resent under the same id.
+
+The profile arrives as the sequenced `SetAdmissionProfile` command
+(control-plane verb of the same name), so it journals, survives checkpoints,
+enters the state hash and replays. `MatchingEngine::admissionRejects()` counts
+the rejections; a non-zero value means a counterparty is sending something its
+profile does not allow.
+
 ## Order types and time in force
 
 `NewOrder` carries the full venue vocabulary:
@@ -84,7 +139,8 @@ size.
   submit boundary, tick-aligned, clamped so it never crosses.
 - **OCO.** `ocoGroup`; a fill on one leg cancels its siblings.
 - **Reduce-only.** Perp orders that may only reduce a position, re-capped on
-  submit, trigger, and modify.
+  submit, trigger, modify -- and re-measured at fill time against the position
+  as it is then (see [Risk](risk.md)).
 
 ## The engine
 
@@ -116,8 +172,8 @@ limits during volatility without a restart:
 
 | Control | Config | Live setter |
 |---|---|---|
-| Tick / lot / min quantity | `tickSize`, `lotSize`, `minQty` | — |
-| Price band (collar) | `minPrice`, `maxPrice` | — |
+| Tick / lot / min quantity | `tickSize`, `lotSize`, `minQty` | -- |
+| Price band (collar) | `minPrice`, `maxPrice` | -- |
 | Fat finger | `maxOrderQty`, `maxOrderNotional` | `setFatFinger` |
 | LULD volatility band | `luldBps`, `luldHaltNs` | `setLuldBps` |
 
@@ -231,3 +287,89 @@ Sequenced through `AdminCmd`, so they survive replay:
 - `ResumeAuction`: clear a halt into a re-opening auction.
 - `HaltAndCancelAll`: emergency halt that also pulls the resting book.
 - `Halt` / `Resume`.
+
+## Order paths and the gates on them
+
+Eight paths admit or re-admit an order into matching, and each applies the
+pre-trade checks itself. A stop that fires is not covered by the validation its
+submission passed: the instrument may have halted in between.
+
+```mermaid
+flowchart TD
+    NEW[NewOrder] --> DEDUP{clOrdId<br/>already used?}
+    DEDUP -->|yes| REJ[Reject]
+    DEDUP -->|no| COND{conditional?}
+
+    COND -->|yes| VC[validateConditional<br/>tick / band / lot on the trigger]
+    VC -->|fails| REJ
+    VC -->|ok| PARK[park in the stop book]
+
+    COND -->|no| CAP{maxOpenOrders}
+    CAP -->|exceeded| REJ
+    CAP -->|ok| PERP[perpRiskGate<br/>reduce-only, position cap]
+    PERP -->|fails| REJ
+    PERP -->|ok| VAL[validate<br/>state, tick, lot, band, LULD]
+    VAL -->|fails| REJ
+    VAL -->|ok| FUND[reserveFunds]
+
+    FUND --> CRED{credit hook<br/>external risk owner}
+    CRED -->|refuses| REJ
+    CRED -->|allows| RES[reserve collateral<br/>if a ledger is bound]
+    RES -->|insufficient| REJ
+    RES -->|ok| MATCH[matcher.cross]
+
+    MARK[mark / last price moves] --> TRIG{instrument<br/>trading?}
+    TRIG -->|halted, closed,<br/>paused, auction| STOPPED[no trigger]
+    TRIG -->|yes| POP[pop triggered stops]
+    POP --> PERP2[perpRiskGate] --> FUND2[reserveFunds] --> MATCH
+
+    MOD[ModifyOrder] --> HOLDS[resolve open holds] --> VM[tick / band / lot]
+    VM --> PERP3[perpRiskGate] --> FUND3[reserveFunds] --> MATCH
+
+    QUOTE[Quote] --> HOLDS2[resolve open holds] --> LEGS[each leg through NewOrder]
+    LEGS --> DEDUP
+
+    PEG[reference moves] --> HOLDS3[resolve open holds] --> FUND4[reserveFunds<br/>at the new price] --> BOOK[re-enter book]
+
+    MATCH --> FR{fill-time risk<br/>perp only}
+    FR -->|blocked| PULL[pull the blocked leg]
+    FR -->|ok| TRADE[Trade]
+
+    AUCT[auction uncross] --> FR
+    ACCEPT[hold accepted] --> FR
+```
+
+The table below is the same thing checked against the source, including gates
+inherited through delegation -- a quote runs every new-order gate because each
+leg goes through that path.
+
+| path | state | dedup | tick/lot/band | perp risk | credit hook | collateral | self-trade | fill-time risk | holds |
+|---|---|---|---|---|---|---|---|---|---|
+| new order | yes | yes | yes | yes | yes | yes | yes | - | - |
+| conditional (parked) | yes | - | yes | yes | yes | yes | - | - | - |
+| stop trigger | yes | - | yes | yes | yes | yes | yes | - | - |
+| modify | yes | - | yes | yes | yes | yes | yes | - | yes |
+| quote (per leg) | yes | yes | yes | yes | yes | yes | yes | - | yes |
+| peg reprice | - | - | yes | yes | yes | yes | yes | - | yes |
+| auction uncross | - | - | - | yes | - | - | yes | yes | - |
+| hold accept | - | - | - | - | - | - | - | yes | yes |
+
+Self-trade prevention applies under both matching policies and in the auction,
+and where it reads the mode from differs. In continuous trading it comes off
+the aggressor: pro-rata resolves every same-scope maker at the level before
+computing the split, price-time resolves each one as the sweep reaches it, and
+both call `applySelfTradePrevention`. A modify carries the mode of the order it
+replaces. An auction has no aggressor, so the mode comes off each resting order
+(the book stores it for that) and applies from its owner's side.
+
+Two blanks in the table are intentional. A peg reprice does not re-check
+instrument state: it only runs on a submit, and that submit is rejected first
+when trading is stopped. The auction uncross does not re-validate prices or
+take collateral, because every order in the book passed both on admission and
+the uncross only picks the clearing price. Both cases are covered by tests.
+
+`test_venue_gate_coverage.cpp` asserts these as properties rather than as a
+list: each admission path must ask the credit hook for the order it admits,
+nothing may print while the instrument is not trading (under both trigger
+references), and a conditional order must obey tick, band and lot. Removing any
+one guard makes it fail -- verified by mutation, one guard at a time.

--- a/docs/venue/risk.md
+++ b/docs/venue/risk.md
@@ -9,12 +9,27 @@ when liquidation is not enough.
 Set `SymbolConfig::linearPerp` and the engine clears a linear perpetual:
 
 - **Initial margin on entry.** `notional * initialMarginBps` is reserved in
-  quote collateral; insufficient margin rejects the order.
+  quote collateral; insufficient margin rejects the order. An order with no
+  price of its own (market, triggered stop) is margined at the top of the price
+  band on **both** sides -- a perp delivers nothing, so its notional grows with
+  price whether the account ends long or short.
 - **Netting positions** with an average entry price.
 - **Mark-to-market PnL** realised into collateral through the venue clearing
   pool: a long's profit is funded by a short's loss, so value is conserved.
-- **Reduce-only** orders are capped to the opposing position (they can never
-  open or flip), re-checked on submit, on stop trigger, and on modify.
+- **Reduce-only** orders are capped to the opposing position on submit, on stop
+  trigger and on modify -- and re-measured **at fill time**, against the position
+  as it is then. A resting order is sized against the position it saw when it
+  was admitted; by the time it trades that position may be smaller or gone, so
+  only the part that still reduces executes and the rest is canceled
+  (`ReduceOnlyNotReducing`). That is what makes "never opens or flips" true of
+  the fill and not just of the submit -- and it matters because a reduce-only
+  order reserves no margin, so any part of it that opened a position would open
+  one with none.
+- **`maxPositionQty`** is enforced against the **resulting** position at fill
+  time, not only against the incoming order: orders that each pass the cap
+  individually cannot settle into a position past it together. The bite that
+  would breach it is cut, and a maker with no room left is pulled
+  (`PositionLimitExceeded`).
 - **Maintenance sweep.** `setMarkPrice` walks every position; anything whose
   equity (posted margin + unrealised PnL, plus a negative wallet if the account
   is overdrawn) falls under the maintenance requirement is force-closed.
@@ -64,6 +79,34 @@ cm.openInterestRaw();       // venue-wide risk gauge
 
 `setLiquidationsPaused(true)` is the operator switch for an untrustworthy
 price feed; see the circuit breaker below.
+
+## Handing risk to an owner outside the engine
+
+Isolated margin is the engine's own business: it sees one instrument and the
+collateral behind it, so it can decide alone. Portfolio margin cannot work that
+way -- a hedge only nets across instruments, and the engines are per symbol. So
+the decision moves out and the engine executes it, over three seams.
+
+**Permission on entry.** `setCreditCheck` is asked before an order is funded,
+whether or not this engine posts collateral of its own. The request names the
+instrument (the owner serves many), the order type and whether it reduces
+exposure; the answer carries a reject reason, so a client refused by portfolio
+margin is told that, not a flat funds error.
+
+**Fills.** Every outbound event carries its owner account, so the risk layer
+rebuilds each account's basket by subscribing to the same stream everyone else
+reads. Nothing extra is needed.
+
+**Closing.** `ForceClosePosition` closes a position on the owner's decision,
+settling through exactly the path the engine's own sweep uses, so the events
+and the replay are identical either way. Pair it with
+`SymbolConfig::externalLiquidation`, which stops the engine liquidating on its
+own: two systems closing the same position from different numbers is worse than
+either doing it alone.
+
+What stays outside: how the requirement is computed, which positions net, what
+haircuts collateral takes, when to close and in what order. Those differ per
+venue and are the owner's to define.
 
 ## Multi-asset collateral
 

--- a/docs/venue/verification.md
+++ b/docs/venue/verification.md
@@ -1,8 +1,8 @@
 # Verification
 
 A venue moves real money, so on top of the unit suites the module is checked
-against invariants over random command streams. Each invariant below was added
-because it caught a class of defect the previous one missed.
+against invariants over random command streams. The invariants are layered:
+each one targets a failure the ones above it let through.
 
 Run it all:
 
@@ -28,32 +28,74 @@ index. Depth is CI-friendly by default; set `FLOX_FUZZ_OPS` for a deep run
 ## Conservation fuzz
 
 `test_venue_conservation_fuzz` asserts money properties over a random stream
-across five scenarios: spot, perp, perp with ADL, cross-margin, and multi-asset
-collateral.
+across six scenarios: spot, spot with last look, perp, perp with ADL,
+cross-margin, and multi-asset collateral.
 
 1. **Conservation of total.** Each asset's total across accounts plus the venue
    account never changes.
 2. **The reserved invariant.** After the book is drained, every account's
    `reserved` must be zero.
+3. **The position cap binds the result.** No account is ever carried past
+   `maxPositionQty` by fills, however many orders built the position.
+
+Features are fuzzed together, not one at a time: the last-look scenario also
+runs self-trade prevention (a maker can be pulled from inside the matcher with a
+hold open), and the perp scenario submits market, stop and reduce-only orders,
+not limits only -- a perp market order is margined against the price band, and a
+reduce-only order is re-measured when it fills.
 
 ## What each property catches
 
-Each of these defects passed the check above it in the table, and each round of
-hardening added the property that would have caught it:
+What each property catches, and the failure it rules out:
 
-| Property | Catches | Example defect it caught |
+| Property | Catches | Concrete failure it rules out |
 |---|---|---|
-| conservation of total | money created or destroyed in aggregate | ADL crediting a winner while the deficit vanished |
-| reserved invariant (drain, then `reserved == 0`) | buying power frozen: total is fine, the funds are stuck | residual reservations kept on IOC/FOK/reject paths |
-| per-order reservation consistency | one order over-releasing, masked by other orders in the same account's aggregate | iceberg modify releasing against the displayed peak instead of the full size |
-| per-account equity + insurance payout | mis-socialization: right total, wrong recipient | insurance paying out to an account that was solvent on total equity |
-| insertion-order independence | a replica making a different choice from the same logical state | ADL victim chosen by hash iteration order |
-| made-whole on non-fill | funds frozen when a fill does not happen | last-look reject stranding both sides' reservations |
+| conservation of total | money created or destroyed in aggregate | ADL crediting a winner while the deficit vanishes |
+| reserved invariant (drain, then `reserved == 0`) | buying power frozen: total is fine, the funds are stuck | a reservation surviving an IOC/FOK expiry or a reject |
+| per-order reservation consistency | one order over-releasing, masked by other orders in the same account's aggregate | an iceberg modify releasing against the displayed peak rather than the full size |
+| per-account equity + insurance payout | mis-socialization: right total, wrong recipient | insurance paying an account that is solvent on total equity |
+| insertion-order independence | a replica making a different choice from the same logical state | an ADL victim selected by hash iteration order |
+| made-whole on non-fill | funds frozen when a fill does not happen | a last-look reject stranding both sides' reservations |
 | positive-obligation netting | a debit balance masking a real custody shortfall | segregation reporting a short custody balance as fully backed |
+| feature interaction in one stream | a hazard that exists only where two features meet | STP pulling a last-look maker and freeing the collateral its open hold must settle from |
+| position cap over the result | limits enforced on the order instead of on the position | orders each under `maxPositionQty` settling into a position past it |
 
-Several of these compound: funding driving a wallet negative while a position
-kept the account alive made states reachable that the ADL and segregation
-defects then exploited. Finding one exposed the next.
+The fuzz runs features together rather than in isolation because these
+failures depend on each other. Funding can drive a wallet negative while an
+open position keeps the account alive, and that state is the precondition for
+the ADL and segregation failures above. A stream exercising one feature at a
+time never reaches it.
+
+## Static checks
+
+Two checks run against the code rather than against test cases, so they cover
+paths nobody wrote a test for.
+
+**Gate reachability.** `scripts/check_gate_reachability.py` reads the clang AST
+and checks two things for each handler that reaches the matcher: on every path
+from the handler's entry to the call, each gate it owes has already run
+(branches that return, continue, break or throw are excluded), and the gate's
+result is acted on rather than discarded. The set of functions calling into
+matching is pinned, so a new path fails the check until it declares its gates.
+It reads `compile_commands.json` and needs a configure, not a build.
+
+**Recovery model.** `scripts/check_recovery_model.py` enumerates every
+reachable state of a bounded model of the checkpoint protocol -- checkpoint,
+publish failure, snapshot corruption and pruning, in every interleaving -- and
+checks that recovery either reconstructs history back to zero or refuses to
+start. Crash points between file operations are hard to cover with tests and
+cheap to cover by enumeration. Run it with `--unguarded` to see the protocol
+without the exhaustion guard, and the four-step counterexample the guard
+removes.
+
+## Minimised counterexamples
+
+A divergence reported at command 47,213 is hard to act on. The command stream
+is deterministic and replayable, so on failure the harness binary-searches the
+shortest failing prefix and then removes chunks until no single command can be
+dropped (`venue/tests/support/counterexample.h`). It runs only after a failure,
+and it has its own test against a synthetic predicate with a known two-command
+witness.
 
 ## Sanitizers
 
@@ -61,8 +103,9 @@ defects then exploited. Finding one exposed the next.
 
 - **ASAN + UBSAN** over the parsers (hostile network input), both fuzzes, the
   venue harnesses, and the recovery/journal paths. UBSAN halts on the first
-  diagnostic; it caught a signed overflow in the LULD band computation on a
-  high-priced instrument.
+  diagnostic. That matters for the arithmetic: band and margin computations
+  multiply fixed-point raws, and a high-priced instrument can push an
+  intermediate past 64 bits with no visible symptom.
 - **TSAN** over the sequenced single-writer core and the multi-threaded
   gateways.
 
@@ -81,6 +124,6 @@ CI also runs the whole project, venue included, under all three sanitizers.
 ## Book agreement
 
 Market-data depth is compared against the engine's book over 300k commands,
-periodically at full depth. The full-depth comparison is what surfaced an
-iceberg's hidden reserve leaking into the public feed on a partial peak fill;
-top-of-book checks had passed.
+periodically at full depth. A top-of-book comparison would miss an iceberg's
+hidden reserve leaking into the public feed, or a level going stale below the
+touch.

--- a/scripts/check_dep_pins.py
+++ b/scripts/check_dep_pins.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Fail when CI installs a different dependency range than the package declares.
 
-flox-mcp shipped `mcp>=1.0` while CI installed `mcp>=1.0,<2`. CI was therefore
-green against 1.x forever, and the day the SDK released 2.0 -- which dropped the
-decorator API the server is built on -- every fresh `pip install flox-mcp`
-started crashing on startup. Nothing in the repo could notice: the tested range
-and the shipped range were simply different strings in different files.
+A tighter bound in CI than in the manifest means CI is green against versions
+users never get, and a new major release of the dependency breaks every fresh
+install with nothing in the repo able to notice -- the tested range and the
+shipped range are just different strings in different files.
 
 This gate reads the ranges out of the packaging manifests and out of the CI
 workflow and requires them to agree, so a bound can only be relaxed in both

--- a/scripts/check_gate_reachability.py
+++ b/scripts/check_gate_reachability.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Prove that every path into matching applies its pre-trade gates.
+
+An order reaches `Matcher::cross` through several handlers, and each one must
+apply the checks itself: a gate passed on submission does not cover a stop that
+fires later, because the instrument may have halted in between. Tests can only
+assert this for the paths someone thought to enumerate. This gate asserts it
+over the code, so a path added tomorrow cannot quietly skip a check.
+
+Two properties are checked against the clang AST:
+
+1. Domination. On every path from the handler's entry to the `cross` call, each
+   gate the handler owes has already executed. Branches that cannot reach the
+   call (they return, continue, break or throw) do not weaken the result.
+2. The result is honoured. A gate whose value is dropped is not a gate, so each
+   one must be called in the condition (or condition-init) of an `if` that has
+   a path-terminating branch.
+
+Plus drift control: the set of functions calling `cross` is pinned. A new
+caller fails the check until it is declared here with the gates it owes.
+
+Usage:
+    python3 scripts/check_gate_reachability.py            # uses ./build
+    python3 scripts/check_gate_reachability.py --build-dir out
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE_HEADER = "matching_engine.h"
+
+# The matching entry point every order must pass through, and the trade-emitting
+# helper behind it. Keyed by the method name on Matcher.
+MATCH_ENTRY = "cross"
+
+# Every handler that may call into matching, and the gates it owes before doing
+# so. Adding a caller without adding it here fails the check by design.
+#
+# onNew          full admission: instrument, size, price, buying power.
+# processTriggers a resting stop re-enters matching; it was validated when it
+#                was parked, so it re-runs the risk and funding gates and the
+#                instrument-state check that guards the whole sweep.
+# onModify       a modified order re-enters matching as a new aggressor.
+REQUIRED_GATES: dict[str, set[str]] = {
+    "onNew": {"admissionGate", "perpRiskGate", "validate", "reserveFunds"},
+    "processTriggers": {"perpRiskGate", "reserveFunds", "tradingStatus"},
+    "onModify": {"admissionDenies", "perpRiskGate", "reserveFunds"},
+}
+
+# Gates read for their value rather than called for a reject code. A guard on
+# `tradingStatus() != TradingStatus::Trading` returns early instead of
+# rejecting, so it is honoured by terminating the path, not by a reject sink.
+VALUE_GATES = {"tradingStatus", "admissionDenies"}
+
+TERMINATORS = {
+    "RETURN_STMT",
+    "CONTINUE_STMT",
+    "BREAK_STMT",
+    "CXX_THROW_EXPR",
+    "GOTO_STMT",
+}
+
+
+def _load_clang():
+    """Import libclang, trying the usual install locations."""
+    try:
+        import clang.cindex as ci
+    except ImportError:
+        print("libclang python bindings missing: pip install libclang", file=sys.stderr)
+        raise SystemExit(2)
+
+    import os
+
+    candidates = [os.environ.get("FLOX_LIBCLANG")]
+    candidates += [
+        "/opt/homebrew/opt/llvm/lib/libclang.dylib",
+        "/usr/local/opt/llvm/lib/libclang.dylib",
+        "/usr/lib/llvm-18/lib/libclang.so.1",
+        "/usr/lib/x86_64-linux-gnu/libclang-18.so.1",
+    ]
+    for cand in candidates:
+        if cand and Path(cand).exists():
+            ci.Config.set_library_file(cand)
+            break
+    return ci
+
+
+def _compile_args(build_dir: Path, ci) -> tuple[str, list[str]]:
+    """Compile flags for a TU that instantiates the engine template.
+
+    The engine is a header-only template, so its bodies only exist in the AST
+    of a TU that instantiates it. Any venue test does; the database says how to
+    compile one.
+    """
+    db = build_dir / "compile_commands.json"
+    if not db.exists():
+        print(f"{db} not found -- configure the build first (cmake -B {build_dir})", file=sys.stderr)
+        raise SystemExit(2)
+
+    entries = json.loads(db.read_text())
+    tu = None
+    for want in ("test_venue_gate_coverage.cpp", "test_venue_engine.cpp", "test_venue_venue.cpp"):
+        for e in entries:
+            if e["file"].endswith(want):
+                tu = e
+                break
+        if tu:
+            break
+    if tu is None:
+        print("no venue TU in compile_commands.json -- is the venue module configured?", file=sys.stderr)
+        raise SystemExit(2)
+
+    raw = shlex.split(tu.get("command") or " ".join(tu["arguments"]))
+    args: list[str] = []
+    skip = False
+    for a in raw[1:]:
+        if skip:
+            skip = False
+            continue
+        if a == "-o":
+            skip = True
+            continue
+        if a in ("-c", "-MD", "-MT", "-MF"):
+            continue
+        if a.endswith((".cpp", ".cc", ".o")):
+            continue
+        args.append(a)
+
+    return tu["file"], args
+
+
+def _env_variants() -> list[list[str]]:
+    """Extra flags to try, best first.
+
+    libclang is not the compiler driver: it does not infer the platform SDK or
+    its own builtin headers. Which of those it needs depends on the host, so
+    the variants are tried in order and the first that yields a usable AST
+    wins. Getting this wrong shows up as an empty AST, which the caller treats
+    as a broken check rather than a passing one.
+    """
+    extra: list[str] = []
+    for exe in ("/opt/homebrew/opt/llvm/bin/clang", "clang"):
+        try:
+            rd = subprocess.run([exe, "-print-resource-dir"], capture_output=True, text=True, timeout=20)
+            if rd.returncode == 0 and rd.stdout.strip():
+                extra = ["-resource-dir", rd.stdout.strip()]
+                break
+        except (OSError, subprocess.SubprocessError):
+            continue
+
+    sysroot: list[str] = []
+    if sys.platform == "darwin":
+        try:
+            sdk = subprocess.run(["xcrun", "--show-sdk-path"], capture_output=True, text=True, timeout=20)
+            if sdk.returncode == 0 and sdk.stdout.strip():
+                sysroot = ["-isysroot", sdk.stdout.strip()]
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+    variants = [extra + sysroot, sysroot, extra, []]
+    seen, out = set(), []
+    for v in variants:
+        key = tuple(v)
+        if key not in seen:
+            seen.add(key)
+            out.append(v)
+    return out
+
+
+_TOKEN_CACHE: dict[tuple, frozenset] = {}
+
+
+def _calls_in(node, ci) -> frozenset:
+    """Every function name called anywhere inside this subtree.
+
+    Read off the token stream rather than the resolved AST on purpose: the
+    engine is a template, so `matcher_.cross(...)` is a dependent call and
+    libclang leaves the callee unnamed. Tokens carry the name whatever the
+    instantiation state. Comments are excluded, so a gate named in prose does
+    not count as a gate applied.
+    """
+    ext = node.extent
+    key = (ext.start.file.name if ext.start.file else "", ext.start.offset, ext.end.offset)
+    hit = _TOKEN_CACHE.get(key)
+    if hit is not None:
+        return hit
+
+    names = set()
+    prev = None
+    for tok in node.get_tokens():
+        if tok.kind == ci.TokenKind.COMMENT:
+            continue
+        if tok.spelling == "(" and prev is not None:
+            names.add(prev)
+        prev = tok.spelling if tok.kind == ci.TokenKind.IDENTIFIER else None
+    out = frozenset(names)
+    _TOKEN_CACHE[key] = out
+    return out
+
+
+def _split_if(children, ci):
+    """Split an if-statement's children into (head, branches).
+
+    Head is everything evaluated unconditionally: an optional init-statement,
+    an optional condition variable, and the condition itself. Branches are the
+    then- and optional else-statement. The condition is the last expression
+    among the children, which separates the two halves without having to guess
+    from arity -- `if (const RejectReason r = f(); r != None)` has a
+    DECL_STMT before its condition, and a bare `if (!f())` does not.
+    """
+    expr_idx = [i for i, c in enumerate(children) if c.kind.is_expression()]
+    if expr_idx:
+        cut = expr_idx[-1] + 1
+    else:
+        # No expression child (e.g. `if (auto x = f())`): the trailing one or
+        # two statements are the branches.
+        cut = max(0, len(children) - 2) if len(children) >= 3 else max(0, len(children) - 1)
+    return children[:cut], children[cut:][:2]
+
+
+def _kind_name(node) -> str:
+    return node.kind.name
+
+
+class Analysis:
+    """Forward must-analysis over the statement tree.
+
+    State is the set of gates guaranteed to have run at a program point. The
+    walk returns that set at the end of a statement, or None when the statement
+    cannot fall through (every path out of it returns, continues, breaks or
+    throws) -- a branch that cannot reach the merge must not dilute it.
+
+    Findings are recorded when a `cross` call is reached: the gate set holding
+    at that exact point is the evidence.
+    """
+
+    def __init__(self, ci, gates: set[str]):
+        self.ci = ci
+        self.gates = gates
+        self.at_cross: list[set[str]] = []
+        self.honoured: set[str] = set()
+        self.saw_goto = False
+
+    # -- helpers ---------------------------------------------------------
+    def _record_gates(self, node, state: set[str]) -> set[str]:
+        for name in _calls_in(node, self.ci):
+            if name in self.gates:
+                state = state | {name}
+        return state
+
+    def _has_cross(self, node) -> bool:
+        return MATCH_ENTRY in _calls_in(node, self.ci)
+
+    def _terminates(self, node) -> bool:
+        """True when this subtree unconditionally leaves the enclosing path.
+
+        Runs on a throwaway analysis so probing a branch cannot record
+        findings: the evidence must come from the real walk only.
+        """
+        probe = Analysis(self.ci, self.gates)
+        return probe.walk(node, set()) is None
+
+    # -- the walk --------------------------------------------------------
+    def walk(self, node, state: set[str]) -> set[str] | None:
+        kind = _kind_name(node)
+
+        if kind == "GOTO_STMT":
+            self.saw_goto = True
+            return None
+        if kind in TERMINATORS:
+            # Operands still execute before the jump.
+            for ch in node.get_children():
+                state = self._record_gates(ch, state)
+            return None
+
+        if kind == "IF_STMT":
+            return self._walk_if(node, state)
+        if kind in ("FOR_STMT", "WHILE_STMT", "CXX_FOR_RANGE_STMT", "DO_STMT"):
+            return self._walk_loop(node, state)
+        if kind == "SWITCH_STMT":
+            return self._walk_switch(node, state)
+        if kind == "COMPOUND_STMT":
+            for ch in node.get_children():
+                nxt = self.walk(ch, state)
+                if nxt is None:
+                    return None
+                state = nxt
+            return state
+
+        # A leaf statement or expression: everything in it runs in order, and a
+        # cross call inside it is observed with the state that reached it.
+        state = self._record_gates(node, state)
+        if self._has_cross(node):
+            self.at_cross.append(set(state))
+        return state
+
+    def _walk_if(self, node, state: set[str]) -> set[str] | None:
+        children = list(node.get_children())
+        head, branches = _split_if(children, self.ci)
+        if not branches:
+            return state
+        for h in head:
+            state = self._record_gates(h, state)
+            if self._has_cross(h):
+                self.at_cross.append(set(state))
+
+        # A gate is honoured when its call sits in the head of an `if` that has
+        # a branch which cannot fall through.
+        head_gates = set().union(*[_calls_in(h, self.ci) for h in head]) & self.gates if head else set()
+        if head_gates and any(self._terminates(b) for b in branches):
+            self.honoured |= head_gates
+
+        then_state = self.walk(branches[0], set(state))
+        else_state = self.walk(branches[1], set(state)) if len(branches) > 1 else set(state)
+
+        if then_state is None and else_state is None:
+            return None
+        if then_state is None:
+            return else_state
+        if else_state is None:
+            return then_state
+        return then_state & else_state
+
+    def _walk_loop(self, node, state: set[str]) -> set[str] | None:
+        children = list(node.get_children())
+        body = children[-1] if children else None
+        for h in children[:-1]:
+            state = self._record_gates(h, state)
+
+        if body is not None:
+            # Inside the body the state carries what the entry guaranteed plus
+            # what this iteration has run so far. A `cross` inside the loop is
+            # observed with exactly that.
+            self.walk(body, set(state))
+
+        # A loop may run zero times, so nothing inside it is guaranteed after.
+        # (do-while runs once, but treating it conservatively can only make the
+        # check stricter, never weaker.)
+        return state
+
+    def _walk_switch(self, node, state: set[str]) -> set[str] | None:
+        children = list(node.get_children())
+        if not children:
+            return state
+        cond, body = children[0], children[-1]
+        state = self._record_gates(cond, state)
+        # Cases are not tracked individually: walking the body once with the
+        # entry state observes any cross inside it, and nothing inside a switch
+        # is treated as guaranteed afterwards.
+        self.walk(body, set(state))
+        return state
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--build-dir", default="build")
+    args = ap.parse_args()
+
+    ci = _load_clang()
+    build_dir = (ROOT / args.build_dir) if not Path(args.build_dir).is_absolute() else Path(args.build_dir)
+    tu_file, cargs = _compile_args(build_dir, ci)
+
+    index = ci.Index.create()
+    handlers: dict[str, object] = {}
+    other_callers: list[tuple[str, int]] = []
+    tu = None
+
+    def visit(node):
+        if node.kind == ci.CursorKind.CXX_METHOD and node.is_definition():
+            loc = node.location.file
+            if loc and ENGINE_HEADER in loc.name:
+                if MATCH_ENTRY in _calls_in(node, ci):
+                    if node.spelling in REQUIRED_GATES:
+                        handlers.setdefault(node.spelling, node)
+                    else:
+                        other_callers.append((node.spelling, node.location.line))
+                return
+        for ch in node.get_children():
+            visit(ch)
+
+    for extra in _env_variants():
+        _TOKEN_CACHE.clear()
+        handlers.clear()
+        del other_callers[:]
+        tu = index.parse(tu_file, args=cargs + extra)
+        visit(tu.cursor)
+        if handlers:
+            break
+
+    problems: list[str] = []
+
+    if not handlers:
+        print(
+            "no engine handler calling %s was found in the AST -- the parse did not "
+            "reach the engine template. This is a broken check, not a passing one." % MATCH_ENTRY,
+            file=sys.stderr,
+        )
+        for d in tu.diagnostics:
+            if d.severity >= 3:
+                print(f"  {d.spelling}", file=sys.stderr)
+        return 2
+
+    missing_handlers = set(REQUIRED_GATES) - set(handlers)
+    if missing_handlers:
+        problems.append(
+            f"declared handler(s) {sorted(missing_handlers)} no longer reach {MATCH_ENTRY}: "
+            f"either the path moved (update this file) or the call was lost")
+
+    for name, line in sorted(set(other_callers)):
+        problems.append(
+            f"{name} (matching_engine.h:{line}) calls {MATCH_ENTRY} but declares no gates. "
+            f"Add it to REQUIRED_GATES with the checks it owes.")
+
+    for name, node in sorted(handlers.items()):
+        gates = REQUIRED_GATES[name]
+        an = Analysis(ci, gates)
+        body = None
+        for ch in node.get_children():
+            if _kind_name(ch) == "COMPOUND_STMT":
+                body = ch
+        if body is None:
+            problems.append(f"{name}: no body in the AST")
+            continue
+        an.walk(body, set())
+
+        if an.saw_goto:
+            problems.append(f"{name}: contains goto -- the must-analysis is only sound for structured control flow")
+
+        if not an.at_cross:
+            problems.append(f"{name}: {MATCH_ENTRY} call not located by the walk (check is blind here)")
+            continue
+
+        for state in an.at_cross:
+            for missing in sorted(gates - state):
+                problems.append(
+                    f"{name}: reaches {MATCH_ENTRY} on a path where {missing}() has not run. "
+                    f"Every path into matching must apply it.")
+
+        for gate in sorted(gates - an.honoured - VALUE_GATES):
+            problems.append(
+                f"{name}: {gate}() is called but its result is not acted on "
+                f"(expected `if (<call>) {{ ... return/continue; }}`)")
+
+    if problems:
+        print("gate reachability check failed:")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+
+    total = sum(len(REQUIRED_GATES[h]) for h in handlers)
+    print(f"OK: {len(handlers)} path(s) into matching, {total} gate obligation(s), "
+          f"each dominating {MATCH_ENTRY} and acted on.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_recovery_model.py
+++ b/scripts/check_recovery_model.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Exhaustively check the checkpoint/recovery protocol over a bounded model.
+
+Recovery is where tests are weakest: the interesting states are crash points
+between file operations, and a test can only visit the ones someone imagined.
+This enumerates every reachable state of a bounded model instead -- every
+interleaving of checkpoint, publish failure, corruption and pruning, up to a
+small number of generations -- and checks one property on all of them.
+
+THE PROPERTY. If recovery reports success, the state it rebuilt covers the
+whole committed history. Silently rebuilding a truncated history is the worst
+possible outcome: the venue starts, serves traffic, and is wrong.
+
+THE MODEL mirrors sequenced_shard.h:
+
+  Checkpoint at ts   rotate the journal onto segment(ts) FIRST, then publish
+                     snapshot(ts) in the background; on success, prune.
+  Publish            may fail (a failed rename is logged and tolerated), which
+                     leaves a segment with no snapshot of its own.
+  Recovery           newest snapshot that validates end-to-end, plus every
+                     segment at or after it. With no valid snapshot: the
+                     legacy pre-checkpoint file plus every segment.
+  Pruning            keeps `retain` snapshot generations, deletes older
+                     snapshots AND their segments, and deletes the legacy file
+                     once `retain` generations exist.
+
+Coverage is the whole point of the model: a snapshot at ts stands for the
+history before ts, a segment at ts for the history from ts to the next
+checkpoint. Recovery is complete when the pieces it picked tile the history
+from 0 with no gap.
+
+Usage:
+    python3 scripts/check_recovery_model.py
+    python3 scripts/check_recovery_model.py --generations 5 --retain 2
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class State:
+    # Checkpoint timestamps taken so far, ascending. Also the segment boundaries.
+    taken: tuple[int, ...]
+    # Snapshot files present on disk, by ts.
+    snapshots: frozenset[int]
+    # Of those, the ones that still validate end-to-end.
+    valid: frozenset[int]
+    # Segment files present on disk, by ts.
+    segments: frozenset[int]
+    # The pre-checkpoint single journal file, holding history before taken[0].
+    legacy: bool
+
+
+def prune(st: State, retain: int) -> State:
+    """Delete generations beyond `retain`, exactly as pruneGenerations does."""
+    snaps = sorted(st.snapshots)
+    snapshots, segments, legacy = st.snapshots, st.segments, st.legacy
+    if len(snaps) > retain:
+        keep_from = snaps[len(snaps) - retain]
+        snapshots = frozenset(t for t in snapshots if t >= keep_from)
+        segments = frozenset(t for t in segments if t >= keep_from)
+    if len(snaps) >= retain:
+        legacy = False
+    return State(st.taken, snapshots, st.valid & snapshots, segments, legacy)
+
+
+def successors(st: State, retain: int, max_gen: int):
+    """Every next state: a checkpoint (publish ok or failed), or a corruption."""
+    if len(st.taken) < max_gen:
+        ts = (st.taken[-1] + 1) if st.taken else 1
+        taken = st.taken + (ts,)
+        # The journal rotates onto the new segment before the snapshot is
+        # published -- a crash in that window leaves the segment without one.
+        rotated = State(taken, st.snapshots, st.valid, st.segments | {ts}, st.legacy)
+        yield ("checkpoint-publish-failed", rotated)
+        published = State(taken, rotated.snapshots | {ts}, rotated.valid | {ts},
+                          rotated.segments, rotated.legacy)
+        yield ("checkpoint-published", prune(published, retain))
+
+    # A snapshot stops validating: a torn write, or a format/state-hash change
+    # that invalidates what is on disk. Systematic causes hit every generation,
+    # which is why more than one may go at once.
+    for ts in sorted(st.valid):
+        yield (f"snapshot-{ts}-no-longer-validates",
+               State(st.taken, st.snapshots, st.valid - {ts}, st.segments, st.legacy))
+
+
+def recover(st: State):
+    """Model of recoverAll. Returns (started, covered_from_zero)."""
+    chosen = max(st.valid) if st.valid else None
+
+    if chosen is not None:
+        # Snapshot covers [0, chosen); segments must tile [chosen, now).
+        needed = [t for t in st.taken if t >= chosen]
+        complete = all(t in st.segments for t in needed)
+        return True, complete
+
+    # No valid snapshot: the legacy file covers [0, taken[0]) and every segment
+    # must be present to tile the rest.
+    complete = st.legacy and all(t in st.segments for t in st.taken)
+    return True, complete
+
+
+def recover_guarded(st: State):
+    """Recovery with the guard this check exists to require.
+
+    Falling back a generation is bounded by what pruning kept. Once the
+    retained snapshots are exhausted, the remaining segments do not reach back
+    to the start of history, and replaying them yields a plausible-looking but
+    truncated state. Refusing to start is the only safe answer.
+    """
+    chosen = max(st.valid) if st.valid else None
+    if chosen is not None:
+        needed = [t for t in st.taken if t >= chosen]
+        if not all(t in st.segments for t in needed):
+            return False, False
+        return True, True
+
+    if not st.legacy and st.taken:
+        return False, False  # history was pruned; it cannot be replayed in full
+    complete = st.legacy and all(t in st.segments for t in st.taken)
+    return complete, complete
+
+
+def explore(retain: int, max_gen: int, recovery):
+    start = State((), frozenset(), frozenset(), frozenset(), True)
+    seen = {start: None}
+    queue = [start]
+    while queue:
+        st = queue.pop()
+        for label, nxt in successors(st, retain, max_gen):
+            if nxt not in seen:
+                seen[nxt] = (st, label)
+                queue.append(nxt)
+
+    violations = []
+    for st in seen:
+        started, complete = recovery(st)
+        if started and not complete:
+            trace, cur = [], st
+            while seen.get(cur):
+                prev, label = seen[cur]
+                trace.append(label)
+                cur = prev
+            violations.append((st, list(reversed(trace))))
+    return len(seen), violations
+
+
+def describe(st: State) -> str:
+    return (f"checkpoints={list(st.taken)} snapshots={sorted(st.snapshots)} "
+            f"valid={sorted(st.valid)} segments={sorted(st.segments)} legacy={st.legacy}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--generations", type=int, default=4)
+    ap.add_argument("--retain", type=int, default=2)
+    ap.add_argument("--unguarded", action="store_true",
+                    help="model recovery WITHOUT the exhaustion guard (should fail)")
+    args = ap.parse_args()
+
+    recovery = recover if args.unguarded else recover_guarded
+    states, violations = explore(args.retain, args.generations, recovery)
+
+    if states < 10:
+        print(f"model explored only {states} states -- the bound is wrong, this proves nothing",
+              file=sys.stderr)
+        return 2
+
+    if violations:
+        print(f"recovery model: {len(violations)} state(s) start on a truncated history")
+        st, trace = violations[0]
+        print(f"  shortest witness: {describe(st)}")
+        for step in trace:
+            print(f"    {step}")
+        print("\nRecovery must refuse to start when the retained generations cannot")
+        print("reconstruct history back to zero.")
+        return 1
+
+    print(f"OK: {states} reachable states, retain={args.retain}, "
+          f"{args.generations} generations. Recovery never starts on a truncated history.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/venue/README.md
+++ b/venue/README.md
@@ -55,7 +55,11 @@ behaviour emerge from the interaction.
 - **`LiquidationEngine` (backtest).** Positions and equity in `double`, driven
   by a mark tape. Built for simulation: fast, tolerant, models cascades,
   slippage, ADL ranking, and mark impact.
-- **`CrossMarginManager` (venue).** Portfolio margin backed by the `Ledger`
+- **`CrossMarginManager` (venue).** Portfolio margin over a `Ledger`, used
+  standalone -- the matching engine does not instantiate it, and it posts no
+  reservations of its own, so one account must be owned by one margin model:
+  isolated margin in the engine or portfolio margin here, not both on one
+  ledger. Backed by the `Ledger`
   (`__int128`), conservation-exact per asset, with multi-asset collateral
   haircuts and segregation. Built for a venue moving real balances, where a
   rounding drift is a money bug.

--- a/venue/include/flox-venue/cancel_on_disconnect.h
+++ b/venue/include/flox-venue/cancel_on_disconnect.h
@@ -94,6 +94,9 @@ class DisconnectCanceller
     {
       untrack(r->id);
     }
+    // CancelRejected is deliberately NOT untracked: a refused cancel leaves the
+    // order resting, and forgetting it here would leave an order this is
+    // supposed to pull on disconnect.
   }
 
   // On disconnect, cancel everything this session still has live.

--- a/venue/include/flox-venue/collateral.h
+++ b/venue/include/flox-venue/collateral.h
@@ -63,6 +63,9 @@ class CollateralSchedule
   }
 
   // Total haircut-adjusted collateral value of an account's whole basket.
+  // What the account OWNS, reserved balance included: collateral locked
+  // against an obligation is still owned. This is the basket's worth, not its
+  // spendable part -- see freeValue for that.
   Amount portfolioValue(const Ledger& led, uint64_t account) const
   {
     Amount t = 0;
@@ -70,6 +73,21 @@ class CollateralSchedule
     {
       (void)c;
       t += value(asset, led.total(account, asset));
+    }
+    return t;
+  }
+
+  // What the account can still commit: reserved balance excluded. Margin
+  // decisions need this one -- counting collateral already posted against
+  // another obligation as spendable is how an account gets to use the same
+  // money twice.
+  Amount freeValue(const Ledger& led, uint64_t account) const
+  {
+    Amount t = 0;
+    for (const auto& [asset, c] : cfg_)
+    {
+      (void)c;
+      t += value(asset, led.available(account, asset));
     }
     return t;
   }

--- a/venue/include/flox-venue/control_api.h
+++ b/venue/include/flox-venue/control_api.h
@@ -139,6 +139,106 @@ class ControlApi
       forward(InboundCommand{SetStpGroup{sym, u64Of(f, "account"), u64Of(f, "group")}});
       return ok();
     }
+    if (method == "setRiskLimits")
+    {
+      // Only the limits named in the request are touched. Replace-all
+      // semantics would let an operator raising a position cap silently zero
+      // the fat-finger cap by not mentioning it.
+      const SymbolId sym = symOf(f, "symbol");
+      if (!reg_.get(sym))
+      {
+        return err("unknown_symbol");
+      }
+      SetRiskLimits r;
+      r.symbol = sym;
+      if (f.count("luldBps") != 0 || f.count("luldHaltNs") != 0)
+      {
+        r.fields |= RiskLimitField::RiskLuld;
+        r.luldBps = static_cast<int32_t>(i64Of(f, "luldBps"));
+        r.luldHaltNs = i64Of(f, "luldHaltNs");
+      }
+      if (f.count("maxOrderQty") != 0 || f.count("maxOrderNotional") != 0)
+      {
+        r.fields |= RiskLimitField::RiskFatFinger;
+        r.maxOrderQty = qtyOf(f, "maxOrderQty");
+        r.maxOrderNotional = volOf(f, "maxOrderNotional");
+      }
+      if (f.count("maxOpenOrders") != 0)
+      {
+        r.fields |= RiskLimitField::RiskMaxOpenOrders;
+        r.maxOpenOrders = static_cast<uint32_t>(u64Of(f, "maxOpenOrders"));
+      }
+      if (f.count("maxPositionQty") != 0)
+      {
+        r.fields |= RiskLimitField::RiskMaxPosition;
+        r.maxPositionQty = qtyOf(f, "maxPositionQty");
+      }
+      if (f.count("initialMarginBps") != 0 || f.count("maintenanceMarginBps") != 0)
+      {
+        r.fields |= RiskLimitField::RiskMargin;
+        r.initialMarginBps = static_cast<int32_t>(u64Of(f, "initialMarginBps"));
+        r.maintenanceMarginBps = static_cast<int32_t>(u64Of(f, "maintenanceMarginBps"));
+      }
+      if (r.fields == 0)
+      {
+        return err("no_limits_named");
+      }
+      forward(InboundCommand{r});
+      return ok();
+    }
+    if (method == "delist")
+    {
+      // Withdraw from trading with no scheduled return: the resting book is
+      // pulled, unlike a halt or a session close. Reversible by delist=false.
+      const SymbolId sym = symOf(f, "symbol");
+      if (!reg_.get(sym))
+      {
+        return err("unknown_symbol");
+      }
+      const bool off = get(f, "delisted") != "false";
+      forward(InboundCommand{
+          AdminCmd{sym, off ? AdminAction::Delist : AdminAction::Relist}});
+      return ok();
+    }
+    if (method == "setAdmissionProfile")
+    {
+      // What a counterparty may send. Engine state on the same footing as the
+      // STP groups above: the forwarded command is sequenced and journaled, so
+      // an entitlement survives replay and recovery rather than living only in
+      // whatever process happened to set it.
+      //
+      // Omitted type/tif lists mean "no restriction on that axis", which is
+      // how an operator narrows one dimension without having to enumerate
+      // every value of the other.
+      const SymbolId sym = symOf(f, "symbol");
+      if (!reg_.get(sym))
+      {
+        return err("unknown_symbol");
+      }
+      AdmissionProfile p;
+      p.allowedTypes = static_cast<uint32_t>(u64Of(f, "allowedTypes"));
+      p.allowedTif = static_cast<uint32_t>(u64Of(f, "allowedTif"));
+      uint8_t deny = 0;
+      if (get(f, "denyResting") == "true")
+      {
+        deny |= AdmissionDeny::DenyResting;
+      }
+      if (get(f, "denyAmend") == "true")
+      {
+        deny |= AdmissionDeny::DenyAmend;
+      }
+      if (get(f, "denyCancel") == "true")
+      {
+        deny |= AdmissionDeny::DenyCancel;
+      }
+      if (get(f, "denyQuote") == "true")
+      {
+        deny |= AdmissionDeny::DenyQuote;
+      }
+      p.deny = deny;
+      forward(InboundCommand{SetAdmissionProfile{sym, u64Of(f, "account"), p}});
+      return ok();
+    }
     if (method == "snapshotNow")
     {
       const SymbolId sym = symOf(f, "symbol");
@@ -218,6 +318,14 @@ class ControlApi
   static Price priceOf(const std::unordered_map<std::string, std::string>& f, const char* k)
   {
     return Price::fromDouble(std::strtod(get(f, k).c_str(), nullptr));
+  }
+  static Quantity qtyOf(const std::unordered_map<std::string, std::string>& f, const char* k)
+  {
+    return Quantity::fromDouble(std::strtod(get(f, k).c_str(), nullptr));
+  }
+  static Volume volOf(const std::unordered_map<std::string, std::string>& f, const char* k)
+  {
+    return Volume::fromDouble(std::strtod(get(f, k).c_str(), nullptr));
   }
 
   static std::string parseString(const std::string& s, size_t& i)

--- a/venue/include/flox-venue/control_plane.h
+++ b/venue/include/flox-venue/control_plane.h
@@ -117,7 +117,9 @@ class InstrumentRegistry
       }
     }
     if (std::get_if<SetStpGroup>(&cmd) != nullptr ||
-        std::get_if<SetFundingSchedule>(&cmd) != nullptr)
+        std::get_if<SetFundingSchedule>(&cmd) != nullptr ||
+        std::get_if<SetAdmissionProfile>(&cmd) != nullptr ||
+        std::get_if<SetRiskLimits>(&cmd) != nullptr)
     {
       return true;  // engine-owned state: the shards consume it, no registry state
     }

--- a/venue/include/flox-venue/cross_margin.h
+++ b/venue/include/flox-venue/cross_margin.h
@@ -134,8 +134,12 @@ class CrossMarginManager
   // otherwise it is the single quote balance.
   Amount equity(uint64_t acct) const
   {
+    // Both branches mean the same thing: collateral this account can still
+    // commit. portfolioValue (which counts reserved balance) would have made
+    // attaching a schedule silently treat margin posted elsewhere -- isolated
+    // IM locked by a matching engine on the same ledger -- as free equity.
     const Amount wallet =
-        collat_ ? collat_->portfolioValue(led_, acct) : led_.available(acct, collateral_);
+        collat_ ? collat_->freeValue(led_, acct) : led_.available(acct, collateral_);
     return wallet + unrealizedPnl(acct);
   }
 

--- a/venue/include/flox-venue/event_hash.h
+++ b/venue/include/flox-venue/event_hash.h
@@ -50,6 +50,15 @@ inline uint64_t hashEvent(uint64_t h, const OutboundEvent& e) noexcept
     h = mix(h, static_cast<uint64_t>(x->reason));
     h = mix(h, x->account);
   }
+  else if (const auto* x = std::get_if<CancelRejected>(&e))
+  {
+    h = mix(h, 0xC17U);
+    h = mix(h, static_cast<uint64_t>(x->id));
+    h = mix(h, static_cast<uint64_t>(x->symbol));
+    h = mix(h, static_cast<uint64_t>(x->reason));
+    h = mix(h, x->account);
+    h = mix(h, x->wasReplace ? 1U : 0U);
+  }
   else if (const auto* x = std::get_if<Trade>(&e))
   {
     h = mix(h, 3);

--- a/venue/include/flox-venue/fix_codec.h
+++ b/venue/include/flox-venue/fix_codec.h
@@ -283,14 +283,23 @@ class FixCodec
     {
       return bare;
     }
-    // Re-frame: keep the body after 35=8, prepend the session header fields.
-    const std::string marker = std::string("35=8") + SOH;
-    const size_t p = bare.find(marker);
-    if (p == std::string::npos)
+    // Re-frame: keep the body after the message type, prepend the session
+    // header fields. The type is whatever encode() chose -- an execution report
+    // for most events, OrderCancelReject for a refused cancel -- so it is read
+    // off the message rather than assumed.
+    const std::string anchor = std::string(1, SOH) + "35=";
+    const size_t a = bare.find(anchor);
+    if (a == std::string::npos)
     {
       return {};
     }
-    const size_t bodyStart = p + marker.size();
+    const size_t tend = bare.find(SOH, a + anchor.size());
+    if (tend == std::string::npos)
+    {
+      return {};
+    }
+    const std::string marker = bare.substr(a + 1, tend - a);
+    const size_t bodyStart = tend + 1;
     const size_t csum = bare.rfind(std::string(1, SOH) + "10=");
     const std::string tail =
         bare.substr(bodyStart, (csum == std::string::npos ? bare.size() : csum + 1) - bodyStart);
@@ -353,6 +362,28 @@ class FixCodec
       decwire::append(s, q.raw());
       return s;
     };
+
+    // OrderCancelReject (35=9). FIX 4.4 answers a refused 35=F / 35=G with
+    // this, not with an execution report: an exec report describes the state of
+    // an ORDER, and a refused cancel changed no order state at all. Handled
+    // before the exec-report body below because it is a different message, not
+    // a variant of one.
+    if (const auto* cr = std::get_if<CancelRejected>(&ev))
+    {
+      add(35, "9");
+      add(37, std::to_string(cr->id));
+      add(11, std::to_string(cr->id));
+      add(41, std::to_string(cr->id));  // OrigClOrdID: the order being acted on
+      // OrdStatus: an order we never had is Rejected; anything else is still
+      // working, and 0 is the most this venue can substantiate without
+      // carrying the resting state onto the event.
+      const bool unknown = cr->reason == RejectReason::UnknownOrder;
+      add(39, unknown ? "8" : "0");
+      add(434, cr->wasReplace ? "2" : "1");  // CxlRejResponseTo
+      add(102, unknown ? "1" : "99");        // CxlRejReason: Unknown order / Other
+      add(58, std::string(toString(cr->reason)));
+      return frame(b);
+    }
 
     add(35, "8");  // ExecutionReport
     if (const auto* a = std::get_if<OrderAccepted>(&ev))

--- a/venue/include/flox-venue/fix_session.h
+++ b/venue/include/flox-venue/fix_session.h
@@ -424,15 +424,65 @@ class FixConnection
     {
       return Verdict::App;
     }
-    // Unknown / unsupported MsgType: consumed in sequence, answered with a
-    // session Reject (35=3) naming the offending seq and type -- never a
-    // silent swallow, never a session kill.
+    // Consumed in sequence and answered -- never a silent swallow, never a
+    // session kill. WHICH answer depends on what is wrong with the message,
+    // and the two are not interchangeable:
+    //
+    //   35=3 (session Reject) says the session layer could not process this.
+    //     Counterparties count these against session health and some drop the
+    //     connection on a run of them.
+    //   35=j (BusinessMessageReject) says the session is fine and the
+    //     application will not handle this message. That is the truth about a
+    //     well-formed FIX message we simply do not implement, and it leaves
+    //     the session healthy.
+    //
+    // Sending 35=3 for a message type the counterparty is entitled to send
+    // reads as our fault, not as a declined capability.
+    if (isApplicationMsgType(type))
+    {
+      sendAdmin("j",
+                {{45, std::to_string(seq)},
+                 {372, type},
+                 {380, "3"},  // BusinessRejectReason = Unsupported Message Type
+                 {58, "message type not supported by this venue"}},
+                nowNs);
+      return Verdict::Handled;
+    }
     sendAdmin("3",
               {{45, std::to_string(seq)},
                {372, type.empty() ? std::string("?") : type},
-               {58, "unsupported MsgType"}},
+               {373, "11"},  // SessionRejectReason = Invalid MsgType
+               {58, "invalid MsgType"}},
               nowNs);
     return Verdict::Handled;
+  }
+
+  // Is this a FIX 4.4 APPLICATION message type -- something a counterparty may
+  // legitimately send, that this venue does not implement? Those earn a
+  // business-level reject. Anything else (garbage, a session type out of
+  // place) is a session-level problem.
+  //
+  // Deliberately a list rather than "not one of the session types": an
+  // unrecognised byte is not a message we declined to support, it is a message
+  // we could not parse, and saying otherwise hides a framing bug behind a
+  // polite refusal.
+  static bool isApplicationMsgType(const std::string& t)
+  {
+    static const char* kAppTypes[] = {
+        "6", "7", "8", "9", "AB", "AC", "AD", "AE", "AF", "AG", "AH", "AI", "AJ", "AK",
+        "AL", "AM", "AN", "AO", "AP", "AQ", "AR", "AS", "AT", "AU", "AV", "AW", "AX", "AY",
+        "AZ", "B", "BA", "BB", "BC", "BD", "BE", "BF", "BG", "C", "D", "E", "F", "G",
+        "H", "J", "K", "L", "M", "N", "P", "Q", "R", "S", "T", "V", "W", "X",
+        "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
+        "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"};
+    for (const char* a : kAppTypes)
+    {
+      if (t == a)
+      {
+        return true;
+      }
+    }
+    return false;
   }
 
   // Timer pass on the gateway idle tick. False = liveness lost, disconnect.

--- a/venue/include/flox-venue/journal.h
+++ b/venue/include/flox-venue/journal.h
@@ -80,7 +80,13 @@ static_assert(std::is_trivially_copyable_v<SetStpGroup>, "SetStpGroup must be bl
 static_assert(std::is_trivially_copyable_v<SetFundingSchedule>,
               "SetFundingSchedule must be blittable");
 static_assert(std::is_trivially_copyable_v<RestoreFunding>, "RestoreFunding must be blittable");
-static_assert(std::variant_size_v<InboundCommand> == 30,
+static_assert(std::is_trivially_copyable_v<ForceClosePosition>,
+              "ForceClosePosition must be blittable");
+static_assert(std::is_trivially_copyable_v<RestoreOrderStp>, "RestoreOrderStp must be blittable");
+static_assert(std::is_trivially_copyable_v<SetAdmissionProfile>,
+              "SetAdmissionProfile must be blittable");
+static_assert(std::is_trivially_copyable_v<SetRiskLimits>, "SetRiskLimits must be blittable");
+static_assert(std::variant_size_v<InboundCommand> == 34,
               "new InboundCommand alternative: extend expectedBodySize/appendDecoded and the "
               "blittable asserts above");
 
@@ -317,6 +323,14 @@ class Journal
         return sizeof(SetFundingSchedule);
       case 29:
         return sizeof(RestoreFunding);
+      case 30:
+        return sizeof(ForceClosePosition);
+      case 31:
+        return sizeof(RestoreOrderStp);
+      case 32:
+        return sizeof(SetAdmissionProfile);
+      case 33:
+        return sizeof(SetRiskLimits);
       default:
         return 0;
     }
@@ -424,6 +438,18 @@ class Journal
         break;
       case 29:
         v.emplace_back(ts, fromBody<RestoreFunding>(body));
+        break;
+      case 30:
+        v.emplace_back(ts, fromBody<ForceClosePosition>(body));
+        break;
+      case 31:
+        v.emplace_back(ts, fromBody<RestoreOrderStp>(body));
+        break;
+      case 32:
+        v.emplace_back(ts, fromBody<SetAdmissionProfile>(body));
+        break;
+      case 33:
+        v.emplace_back(ts, fromBody<SetRiskLimits>(body));
         break;
     }
   }

--- a/venue/include/flox-venue/ledger.h
+++ b/venue/include/flox-venue/ledger.h
@@ -20,6 +20,7 @@
 
 #include "flox/common.h"
 
+#include <cassert>
 #include <cstdint>
 #include <unordered_map>
 
@@ -176,9 +177,16 @@ class Ledger
     Amount avail{0};
     Amount rsvd{0};
   };
+  // Account ids are packed into the top 48 bits. An id that does not fit would
+  // wrap and silently share a balance row with another account -- two customers
+  // spending one balance -- so it is a programming error, not a runtime case to
+  // recover from.
+  static constexpr uint64_t kMaxAccountId = (1ULL << 48) - 1;
+
   static uint64_t key(uint64_t account, AssetId asset)
   {
-    return (account << 16) | asset;  // account uses low 48 bits in practice
+    assert(account <= kMaxAccountId && "account id must fit 48 bits (ledger key packing)");
+    return (account << 16) | asset;
   }
   Bal& bal(uint64_t account, AssetId asset) { return bal_[key(account, asset)]; }
   const Bal* find(uint64_t account, AssetId asset) const

--- a/venue/include/flox-venue/matcher.h
+++ b/venue/include/flox-venue/matcher.h
@@ -37,6 +37,23 @@ struct MatchOutcome
   CancelReason residualCancelReason{CancelReason::UserRequested};
 };
 
+// How much of a prospective bite may actually trade, decided by the engine at
+// FILL time rather than at admission (see Matcher::setFillLimitHook). `qty` is
+// the allowed quantity (the tighter of the two legs), never more than the
+// requested one; when it is zero exactly one of the blocked flags says which
+// leg refused, and `reason` is the cancel reason that leg earns. The per-leg
+// limits are kept separately because pro-rata allocates a whole level at once:
+// it bounds each participant by `makerQty` and the level's total by `takerQty`.
+struct FillLimit
+{
+  Quantity qty{};
+  Quantity makerQty{};
+  Quantity takerQty{};
+  bool makerBlocked{false};
+  bool takerBlocked{false};
+  CancelReason reason{CancelReason::ReduceOnlyNotReducing};
+};
+
 namespace detail
 {
 inline Quantity qmin(Quantity a, Quantity b) noexcept { return (a < b) ? a : b; }
@@ -68,6 +85,29 @@ class Matcher
                                           const NewOrder& taker)>;
   void setLastLookHook(LastLookHook hook) { onLastLook_ = std::move(hook); }
 
+  // Called before the matcher itself removes a resting order (self-trade
+  // prevention, or a fill-time risk block). The engine resolves that order's
+  // open last-look holds and returns true if it resolved any, i.e. it may have
+  // put restored quantity back on the book and the level must be re-peeked.
+  // Every other path that removes an order resolves its holds first; the
+  // matcher-owned removals reach that discipline through this hook.
+  using RestingHoldHook = std::function<bool(OrderId resting)>;
+  void setRestingHoldHook(RestingHoldHook hook) { onRestingHolds_ = std::move(hook); }
+
+  // Called when a resting order is trimmed in place (STP decrement) with the
+  // quantity before and after. The matcher does not own reservations; the
+  // engine frees the part that no longer rests.
+  using RestingReducedHook = std::function<void(OrderId resting, int64_t fromQtyRaw, int64_t toQtyRaw)>;
+  void setRestingReducedHook(RestingReducedHook hook) { onRestingReduced_ = std::move(hook); }
+
+  // Called for every prospective bite so the engine can re-check the risk
+  // limits that depend on state a resting order was NOT sized against (perp
+  // reduce-only and the position cap: the position moves while the order
+  // rests). Reads engine state only, so it reproduces on replay.
+  using FillLimitHook = std::function<FillLimit(const RestingOrder& maker, const NewOrder& taker,
+                                                Quantity want)>;
+  void setFillLimitHook(FillLimitHook hook) { onFillLimit_ = std::move(hook); }
+
   // Firm-group STP: map an account to a firm/group id so self-trade prevention
   // fires across all accounts of the same firm, not just the same account.
   // group 0 removes the membership (back to account-level STP), keeping the
@@ -91,6 +131,11 @@ class Matcher
   // (possible only when admission was bypassed) and skipped it instead of
   // filling it as firm. See crossProRata.
   uint64_t skippedLastLookProRata() const noexcept { return skippedLastLookProRata_; }
+
+  // Pro-rata allocation excluded a maker whose fill-time risk limit left it
+  // nothing to trade (perp reduce-only against a position that moved, or the
+  // position cap). See crossProRata.
+  uint64_t skippedRiskProRata() const noexcept { return skippedRiskProRata_; }
 
   MatchOutcome cross(const NewOrder& order, Book& book,
                      const std::function<uint64_t()>& nextTradeId, const EventSink& sink) const
@@ -154,6 +199,8 @@ class Matcher
 
     Quantity leaves = order.quantity;
     bool takerCanceledBySTP = false;
+    bool takerRiskBlocked = false;
+    CancelReason takerRiskReason = CancelReason::ReduceOnlyNotReducing;
 
     while (!leaves.isZero())
     {
@@ -163,71 +210,67 @@ class Matcher
         break;
       }
 
-      if (order.stp != STPMode::None && stpScope(m->accountId) == stpScope(order.accountId))
+      switch (applySelfTradePrevention(order, *m, book, leaves, sink))
       {
-        switch (order.stp)
-        {
-          case STPMode::CancelOldest:
-            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention,
-                               m->accountId});
-            book.cancel(m->id);
-            continue;
-          case STPMode::CancelNewest:
-            takerCanceledBySTP = true;
-            break;
-          case STPMode::CancelBoth:
-            sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention,
-                               m->accountId});
-            book.cancel(m->id);
-            takerCanceledBySTP = true;
-            break;
-          case STPMode::Decrement:
-          {
-            // Cancel the smaller leg fully; reduce the larger by the smaller qty.
-            // No trade occurs. (Iceberg reserve is ignored for STP.)
-            const Quantity restTotal = m->leaves;
-            const Quantity dec = qmin(leaves, restTotal);
-            if (!(dec < restTotal))  // resting <= incoming: resting fully removed
-            {
-              sink(OrderCanceled{m->id, order.symbol, CancelReason::SelfTradePrevention,
-                                 m->accountId});
-              book.cancel(m->id);
-            }
-            else  // incoming smaller: reduce resting, incoming fully decremented
-            {
-              book.reduce(m->id, Quantity::fromRaw(restTotal.raw() - dec.raw()));
-            }
-            leaves = Quantity::fromRaw(leaves.raw() - dec.raw());
-            if (leaves.isZero())
-            {
-              takerCanceledBySTP = true;
-              break;
-            }
-            continue;  // incoming still has qty: re-peek next maker
-          }
-          case STPMode::None:
-            break;
-        }
-        if (takerCanceledBySTP)
-        {
+        case StpOutcome::NotApplicable:
           break;
-        }
+        case StpOutcome::RePeek:
+          continue;  // the book changed under us: re-read the best maker
+        case StpOutcome::CancelTaker:
+          takerCanceledBySTP = true;
+          break;
+      }
+      if (takerCanceledBySTP)
+      {
+        break;
       }
 
       // Only the displayed peak is executable per bite; the book refills the
       // hidden reserve (and re-queues at the tail) inside fillBest.
+      const Quantity want = qmin(leaves, m->leaves);
+      Quantity allowed = want;
+      if (onFillLimit_)
+      {
+        // Fill-time risk re-check (perp reduce-only / position cap). A resting
+        // order was sized against the position it saw at admission; by the time
+        // it fills that position can be smaller, gone, or on the other side.
+        // The disallowed part of the bite simply does not trade.
+        const FillLimit lim = onFillLimit_(*m, order, want);
+        allowed = lim.qty;
+        if (allowed.isZero())
+        {
+          if (lim.makerBlocked)
+          {
+            // The maker can no longer trade at all: pull it, holds first (same
+            // discipline as the STP removal above).
+            const OrderId blockedId = m->id;
+            const uint64_t blockedAcct = m->accountId;
+            if (onRestingHolds_ && onRestingHolds_(blockedId))
+            {
+              continue;  // hook may have reshaped the book -- re-peek
+            }
+            sink(OrderCanceled{blockedId, order.symbol, lim.reason, blockedAcct});
+            book.cancel(blockedId);
+            continue;
+          }
+          takerRiskBlocked = true;  // the aggressor is the blocked leg: stop the sweep
+          takerRiskReason = lim.reason;
+          break;
+        }
+      }
+
       // Last look: the maker holds this fill pending its decision. Reserve the
       // hit size out of the book and hand it to the engine; no trade yet.
       if (m->lastLook && onLastLook_)
       {
-        const Quantity heldQty = qmin(leaves, m->leaves);
+        const Quantity heldQty = allowed;
         onLastLook_(*m, heldQty, order);
         book.fillBest(restingSide, heldQty);
         leaves -= heldQty;
         continue;
       }
 
-      const Quantity fill = qmin(leaves, m->leaves);
+      const Quantity fill = allowed;
       const OrderId makerId = m->id;
       const uint64_t makerAccount = m->accountId;
       const Price makerPrice = m->price;
@@ -259,6 +302,14 @@ class Matcher
     {
       out.residualCanceled = true;
       out.residualCancelReason = CancelReason::SelfTradePrevention;
+    }
+    else if (takerRiskBlocked)
+    {
+      // The aggressor's own limit stopped the sweep: what it was allowed to
+      // trade traded, and the rest is killed with the reason it earned rather
+      // than resting as an order that may never fill within its limit.
+      out.residualCanceled = true;
+      out.residualCancelReason = takerRiskReason;
     }
     else if (leaves.isZero())
     {
@@ -304,11 +355,89 @@ class Matcher
     return it == stpGroup_.end() ? account : it->second;
   }
 
+  enum class StpOutcome
+  {
+    NotApplicable,  ///< No self-trade interaction with this maker.
+    RePeek,         ///< The book changed; the caller must re-read it.
+    CancelTaker,    ///< The aggressor itself must be canceled.
+  };
+
+  // Self-trade prevention for one prospective aggressor/maker pair.
+  //
+  // Both matching policies route through this: an account must never be on
+  // both sides of a print, and which policy chooses the counterparty has no
+  // bearing on that. Keeping one implementation is the point -- a second copy
+  // is how the two drift apart.
+  //
+  // STP is about to remove (or shrink) the maker, so its open last-look holds
+  // are resolved FIRST, exactly as every engine-side cancel path does.
+  // Skipping that frees collateral an open hold still needs, and the later
+  // accept then settles with no reservation behind it (value created). The
+  // hook can restore quantity to the book, hence RePeek; it resolves at most
+  // once per maker, so this cannot spin. The aggressor can never be a leg of
+  // those holds: STP is tested before the last-look branch on every iteration,
+  // so a same-scope maker is removed before it can hold a slice of this order.
+  StpOutcome applySelfTradePrevention(const NewOrder& order, const RestingOrder& m, Book& book,
+                                      Quantity& leaves, const EventSink& sink) const
+  {
+    using namespace detail;
+    if (order.stp == STPMode::None || stpScope(m.accountId) != stpScope(order.accountId))
+    {
+      return StpOutcome::NotApplicable;
+    }
+    if (onRestingHolds_ && onRestingHolds_(m.id))
+    {
+      return StpOutcome::RePeek;
+    }
+    switch (order.stp)
+    {
+      case STPMode::CancelOldest:
+        sink(OrderCanceled{m.id, order.symbol, CancelReason::SelfTradePrevention, m.accountId});
+        book.cancel(m.id);
+        return StpOutcome::RePeek;
+      case STPMode::CancelNewest:
+        return StpOutcome::CancelTaker;
+      case STPMode::CancelBoth:
+        sink(OrderCanceled{m.id, order.symbol, CancelReason::SelfTradePrevention, m.accountId});
+        book.cancel(m.id);
+        return StpOutcome::CancelTaker;
+      case STPMode::Decrement:
+      {
+        // Cancel the smaller leg fully; reduce the larger by the smaller qty.
+        // No trade occurs. (Iceberg reserve is ignored for STP.)
+        const Quantity restTotal = m.leaves;
+        const Quantity dec = qmin(leaves, restTotal);
+        if (!(dec < restTotal))  // resting <= incoming: resting fully removed
+        {
+          sink(OrderCanceled{m.id, order.symbol, CancelReason::SelfTradePrevention, m.accountId});
+          book.cancel(m.id);
+        }
+        else  // incoming smaller: reduce resting, incoming fully decremented
+        {
+          const int64_t trimmedTo = restTotal.raw() - dec.raw();
+          book.reduce(m.id, Quantity::fromRaw(trimmedTo));
+          if (onRestingReduced_)
+          {
+            onRestingReduced_(m.id, restTotal.raw(), trimmedTo);
+          }
+        }
+        leaves = Quantity::fromRaw(leaves.raw() - dec.raw());
+        return leaves.isZero() ? StpOutcome::CancelTaker : StpOutcome::RePeek;
+      }
+      case STPMode::None:
+        break;
+    }
+    return StpOutcome::NotApplicable;
+  }
+
   // Pro-rata matching: at each crossing level distribute the aggressor across all
   // resting orders proportionally to size (deterministic floor + FIFO remainder),
   // for instruments with thick display levels. Icebergs ARE refilled here (via
-  // consumeById). Scope limitations: STP is treated as None, and last-look is
-  // NOT honoured. The engine refuses lastLook orders on pro-rata instruments
+  // consumeById). Self-trade prevention binds here exactly as it does under
+  // price-time, through the shared applySelfTradePrevention, and is applied to
+  // the whole level before the split so the allocation only ever runs over
+  // participants that may actually trade with this aggressor. Scope limitation:
+  // last-look is NOT honoured. The engine refuses lastLook orders on pro-rata instruments
   // at admission (RejectReason::LastLookUnsupported), so a lastLook maker can
   // only appear here if the caller bypassed validate(). DEFENSIVE PATH: such
   // a maker is NOT filled as firm (pro-rata cannot hold a slice, so filling
@@ -351,6 +480,10 @@ class Matcher
     // keeps the FIFO path's zero-alloc guarantee for pro-rata too.
     static thread_local std::vector<RestingOrder> level;
     static thread_local std::vector<int64_t> alloc;
+    // Per-participant allocable size: the resting quantity, cut to what the
+    // fill-time risk limit allows that maker right now (0 = excluded).
+    static thread_local std::vector<int64_t> allocable;
+    bool takerCanceledBySTP = false;
     while (!leaves.isZero())
     {
       RestingOrder* top = book.peekBest(restingSide);
@@ -364,44 +497,100 @@ class Matcher
       {
         break;
       }
+
+      // Self-trade prevention runs BEFORE the allocation, not inside it. The
+      // pro-rata split has to be computed over the participants that may
+      // actually trade with this aggressor, so every same-scope maker is
+      // resolved (canceled, trimmed) and the level re-read first. Any book
+      // mutation invalidates the snapshot, hence the restart.
+      if (order.stp != STPMode::None)
+      {
+        bool bookChanged = false;
+        for (const RestingOrder& participant : level)
+        {
+          const StpOutcome so = applySelfTradePrevention(order, participant, book, leaves, sink);
+          if (so == StpOutcome::CancelTaker)
+          {
+            takerCanceledBySTP = true;
+            break;
+          }
+          if (so == StpOutcome::RePeek)
+          {
+            bookChanged = true;
+            break;
+          }
+        }
+        if (takerCanceledBySTP)
+        {
+          break;
+        }
+        if (bookChanged)
+        {
+          continue;  // re-read the level: the snapshot is stale
+        }
+      }
+
       // Defensive: a resting lastLook maker here means validate() was bypassed
       // (admission rejects the combination). It is non-firm liquidity and is
       // excluded from the allocation entirely -- see the method comment.
+      //
+      // Fill-time risk (perp reduce-only / position cap) cuts each participant
+      // to what it may still trade; a participant left with nothing is excluded
+      // and counted (pro-rata cannot cancel a maker mid-allocation, and leaving
+      // it out is what keeps the allocation from opening a position the maker's
+      // reduce-only flag forbids). The aggressor's own limit bounds the LEVEL
+      // total below -- one bound over the whole level is exactly right, since
+      // every fill in it moves the taker's position the same way.
       int64_t tot = 0;
-      for (const auto& o : level)
+      int64_t takerRoom = leaves.raw();
+      allocable.assign(level.size(), 0);
+      for (size_t i = 0; i < level.size(); ++i)
       {
-        if (o.lastLook)
+        if (level[i].lastLook)
         {
           ++skippedLastLookProRata_;
           continue;
         }
-        tot += o.leaves.raw();
+        int64_t sz = level[i].leaves.raw();
+        if (onFillLimit_)
+        {
+          const FillLimit lim = onFillLimit_(level[i], order, Quantity::fromRaw(sz));
+          sz = std::min(sz, lim.makerQty.raw());
+          takerRoom = std::min(takerRoom, lim.takerQty.raw());
+          if (sz <= 0)
+          {
+            ++skippedRiskProRata_;
+            continue;
+          }
+        }
+        allocable[i] = sz;
+        tot += sz;
       }
-      if (tot == 0)
+      if (tot == 0 || takerRoom <= 0)
       {
-        break;  // the whole level is non-firm: nothing to allocate against
+        break;  // nothing firm and allocable here, or the aggressor may take no more
       }
-      const int64_t want = std::min<int64_t>(leaves.raw(), tot);
+      const int64_t want = std::min<int64_t>(takerRoom, tot);
 
       alloc.assign(level.size(), 0);  // reuses capacity across levels/aggressors
       int64_t assigned = 0;
       for (size_t i = 0; i < level.size(); ++i)
       {
-        if (level[i].lastLook)
+        if (allocable[i] <= 0)
         {
           continue;  // excluded participant keeps alloc 0
         }
-        alloc[i] = static_cast<int64_t>(static_cast<__int128>(want) * level[i].leaves.raw() / tot);
+        alloc[i] = static_cast<int64_t>(static_cast<__int128>(want) * allocable[i] / tot);
         assigned += alloc[i];
       }
       int64_t leftover = want - assigned;  // deterministic FIFO remainder
       for (size_t i = 0; i < level.size() && leftover > 0; ++i)
       {
-        if (level[i].lastLook)
+        if (allocable[i] <= 0)
         {
           continue;
         }
-        const int64_t room = level[i].leaves.raw() - alloc[i];
+        const int64_t room = allocable[i] - alloc[i];
         if (room > 0)
         {
           const int64_t add = std::min(room, leftover);
@@ -442,7 +631,12 @@ class Matcher
     }
 
     out.leaves = leaves;
-    if (leaves.isZero())
+    if (takerCanceledBySTP)
+    {
+      out.residualCanceled = true;
+      out.residualCancelReason = CancelReason::SelfTradePrevention;
+    }
+    else if (leaves.isZero())
     {
       out.takerComplete = true;
     }
@@ -465,9 +659,13 @@ class Matcher
 
   MatchPolicy policy_;
   LastLookHook onLastLook_;
+  RestingHoldHook onRestingHolds_;
+  RestingReducedHook onRestingReduced_;
+  FillLimitHook onFillLimit_;
   std::unordered_map<uint64_t, uint64_t> stpGroup_;  // account -> firm group (empty = account-level STP)
-  // mutable: cross() is const; this is a diagnostic counter, not matching state.
+  // mutable: cross() is const; these are diagnostic counters, not matching state.
   mutable uint64_t skippedLastLookProRata_{0};
+  mutable uint64_t skippedRiskProRata_{0};
 };
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/matching_engine.h
+++ b/venue/include/flox-venue/matching_engine.h
@@ -59,9 +59,13 @@ struct SymbolConfig
   bool linearPerp{false};               // derivatives: linear perpetual (margin, no asset delivery)
   int32_t initialMarginBps{0};          // IM as bps of notional (1000 = 10% = 10x leverage)
   int32_t maintenanceMarginBps{0};      // MM; position liquidated when equity < MM (0 = off)
-  bool autoDeleverage{false};           // ADL: recover a bankruptcy deficit from winners before insurance
-  Quantity maxPositionQty{};            // 0 = unchecked (max |position| per account, perp risk cap)
-  uint32_t maxOpenOrders{0};            // 0 = unchecked (max live resting orders per account)
+  // Liquidation decided elsewhere (portfolio margin above the per-symbol
+  // engines). The engine still posts isolated IM and settles, but never
+  // liquidates on its own -- it closes only on ForceClosePosition.
+  bool externalLiquidation{false};
+  bool autoDeleverage{false};  // ADL: recover a bankruptcy deficit from winners before insurance
+  Quantity maxPositionQty{};   // 0 = unchecked (max |position| per account, perp risk cap)
+  uint32_t maxOpenOrders{0};   // 0 = unchecked (max live resting orders per account)
 
   // Per-symbol fixed-point scale, same semantics as core SymbolInfo. Default
   // 1e8 = the compile-time Price/Quantity scale. Money always settles at
@@ -120,8 +124,25 @@ class MatchingEngine
       }
       else if (const auto* c = std::get_if<OrderCanceled>(&e))
       {
-        releaseReservation(c->id);
-        forgetOrder(c->id);
+        // Only the matcher's own removals (self-trade prevention, a fill-time
+        // risk block) reach this branch -- every engine-side cancel path emits
+        // through sink_ and does its own cleanup. Those removals resolve the
+        // order's holds first (Matcher's resting-hold hook), so the common case
+        // has no hold left here. The guard is the belt to that brace: stripping
+        // the reservation while a hold is still open would leave the eventual
+        // accept nothing to settle from, and settlement without a reservation
+        // is exactly the path that used to mint value. Hold-aware, like the
+        // executed branch above: release only what no hold needs, and defer
+        // dropping the order until resolveHeld cleans it up.
+        if (!hasHoldsFor(c->id))
+        {
+          releaseReservation(c->id);
+          forgetOrder(c->id);
+        }
+        else
+        {
+          releaseReservationExceptHeld(c->id);
+        }
       }
       sink_(e);
       if (const auto* t = std::get_if<Trade>(&e))
@@ -138,6 +159,37 @@ class MatchingEngine
       matcher_.setLastLookHook(
           [this](const RestingOrder& maker, Quantity fill, const NewOrder& taker)
           { createHeld(maker, fill, taker); });
+      // The matcher removes resting orders on two of its own paths (STP and a
+      // fill-time risk block). Both must resolve that order's open holds first,
+      // like every engine-side cancel path does -- otherwise the removal frees
+      // collateral an open hold still needs. Only wired when last look is on:
+      // with the window at 0 no hold can exist.
+      matcher_.setRestingHoldHook(
+          [this](OrderId resting)
+          {
+            if (!hasHoldsFor(resting))
+            {
+              return false;
+            }
+            rejectHoldsFor(resting);
+            return true;  // liquidity may have been restored: the caller re-peeks
+          });
+    }
+
+    // An STP decrement trims a resting order in place. Freeing the reservation
+    // for the part that no longer rests has nothing to do with last look, so
+    // this is wired unconditionally -- inside the block above it would only
+    // work on instruments that happen to enable holds.
+    matcher_.setRestingReducedHook([this](OrderId id, int64_t fromQtyRaw, int64_t toQtyRaw)
+                                   { releaseReservationPro(id, fromQtyRaw, toQtyRaw); });
+
+    // Fill-time perp risk re-check. Spot has no positions to re-check, so the
+    // hook stays unwired there and the matching hot path is untouched.
+    if (cfg_.linearPerp)
+    {
+      matcher_.setFillLimitHook([this](const RestingOrder& maker, const NewOrder& taker,
+                                       Quantity want)
+                                { return fillLimit(maker, taker, want); });
     }
   }
 
@@ -226,6 +278,14 @@ class MatchingEngine
         setTriggerRef(st->ref);  // sequenced -> journaled -> replayed
       }
     }
+    else if (const auto* rl = std::get_if<SetRiskLimits>(&cmd))
+    {
+      applyRiskLimits(*rl);  // sequenced -> journaled -> replayed
+    }
+    else if (const auto* ap = std::get_if<SetAdmissionProfile>(&cmd))
+    {
+      setAdmissionProfile(ap->account, ap->profile);  // sequenced -> journaled -> replayed
+    }
     else if (const auto* sg = std::get_if<SetStpGroup>(&cmd))
     {
       if (sg->symbol == cfg_.id)
@@ -238,6 +298,13 @@ class MatchingEngine
       if (fs->symbol == cfg_.id)
       {
         setFundingSchedule(fs->intervalNs, fs->nextFundingNs);  // sequenced -> journaled -> replayed
+      }
+    }
+    else if (const auto* fc = std::get_if<ForceClosePosition>(&cmd))
+    {
+      if (fc->symbol == cfg_.id)
+      {
+        onForceClose(*fc);
       }
     }
     else if (std::get_if<TimeTick>(&cmd) != nullptr)
@@ -286,7 +353,28 @@ class MatchingEngine
 
   // Pre-trade credit / buying-power gate. Returns true if the account may place
   // the order. A real deployment binds this to the account/balance service.
-  using CreditCheck = std::function<bool(uint64_t account, Side, Price, Quantity)>;
+  // What an external risk owner is told about an order it must approve. The
+  // old shape (account, side, price, quantity) could not answer a portfolio
+  // question: it did not say WHICH instrument -- the engine knows its own, the
+  // risk layer serves many -- nor whether the order reduces exposure, and a
+  // bare false gave the client no reason for the refusal.
+  struct CreditRequest
+  {
+    OrderId order{};
+    uint64_t account{};
+    SymbolId symbol{};
+    Side side{};
+    OrderType type{};
+    Price price{};
+    Quantity quantity{};
+    bool reduceOnly{false};
+  };
+  struct CreditDecision
+  {
+    bool allowed{true};
+    RejectReason reason{RejectReason::InsufficientFunds};  // used when allowed == false
+  };
+  using CreditCheck = std::function<CreditDecision(const CreditRequest&)>;
   void setCreditCheck(CreditCheck c) { credit_ = std::move(c); }
 
   // Bind a settlement ledger. When set, order entry reserves buying power
@@ -399,6 +487,10 @@ class MatchingEngine
   // so reopening returns to exactly the state the close interrupted.
   TradingStatus tradingStatus() const noexcept
   {
+    if (delisted_)
+    {
+      return TradingStatus::Delisted;
+    }
     if (closed_)
     {
       return TradingStatus::Closed;
@@ -416,6 +508,9 @@ class MatchingEngine
 
   // Session state (see AdminAction::CloseSession / OpenSession).
   bool sessionClosed() const noexcept { return closed_; }
+
+  // Withdrawn from trading (see AdminAction::Delist / Relist).
+  bool delisted() const noexcept { return delisted_; }
 
   struct OrderView
   {
@@ -566,6 +661,55 @@ class MatchingEngine
   // volatility without a restart. Only the risk knobs are mutable -- structural
   // fields (symbol id, tick size, assets, linearPerp) stay fixed. Applies to
   // subsequent orders; existing resting orders are unaffected.
+  // Apply only the limits the record claims. The direct setters below still
+  // exist for pre-start wiring; on a running engine this is the route that
+  // survives a restart and reproduces on a replica.
+  void applyRiskLimits(const SetRiskLimits& r) noexcept
+  {
+    if ((r.fields & RiskLimitField::RiskLuld) != 0)
+    {
+      cfg_.luldBps = r.luldBps;
+      cfg_.luldHaltNs = r.luldHaltNs;
+    }
+    if ((r.fields & RiskLimitField::RiskFatFinger) != 0)
+    {
+      cfg_.maxOrderQty = r.maxOrderQty;
+      cfg_.maxOrderNotional = r.maxOrderNotional;
+    }
+    if ((r.fields & RiskLimitField::RiskMaxOpenOrders) != 0)
+    {
+      cfg_.maxOpenOrders = r.maxOpenOrders;
+    }
+    if ((r.fields & RiskLimitField::RiskMaxPosition) != 0)
+    {
+      cfg_.maxPositionQty = r.maxPositionQty;
+    }
+    if ((r.fields & RiskLimitField::RiskMargin) != 0)
+    {
+      cfg_.initialMarginBps = r.initialMarginBps;
+      cfg_.maintenanceMarginBps = r.maintenanceMarginBps;
+    }
+  }
+
+  // The live limits, as a record that would reproduce them.
+  SetRiskLimits riskLimits() const noexcept
+  {
+    SetRiskLimits r;
+    r.symbol = cfg_.id;
+    r.fields = RiskLimitField::RiskLuld | RiskLimitField::RiskFatFinger |
+               RiskLimitField::RiskMaxOpenOrders | RiskLimitField::RiskMaxPosition |
+               RiskLimitField::RiskMargin;
+    r.luldBps = cfg_.luldBps;
+    r.luldHaltNs = cfg_.luldHaltNs;
+    r.maxOrderQty = cfg_.maxOrderQty;
+    r.maxOrderNotional = cfg_.maxOrderNotional;
+    r.maxOpenOrders = cfg_.maxOpenOrders;
+    r.maxPositionQty = cfg_.maxPositionQty;
+    r.initialMarginBps = cfg_.initialMarginBps;
+    r.maintenanceMarginBps = cfg_.maintenanceMarginBps;
+    return r;
+  }
+
   void setLuldBps(int32_t bps) noexcept { cfg_.luldBps = bps; }
   void setTriggerRef(TriggerRef ref) noexcept { cfg_.triggerRef = ref; }
   void setPriceBand(Price minPrice, Price maxPrice) noexcept
@@ -593,6 +737,29 @@ class MatchingEngine
   // this direct setter is for pre-start() wiring and the recovery path.
   void setStpGroup(uint64_t account, uint64_t group) { matcher_.setStpGroup(account, group); }
 
+  // Admission profile of one account. A default-constructed profile clears the
+  // entry (back to "everything permitted"), which keeps the table canonical
+  // for the checkpoint state hash.
+  void setAdmissionProfile(uint64_t account, const AdmissionProfile& p)
+  {
+    if (p.allowedTypes == 0 && p.allowedTif == 0 && p.deny == 0)
+    {
+      admission_.erase(account);
+      return;
+    }
+    admission_[account] = p;
+  }
+
+  const std::unordered_map<uint64_t, AdmissionProfile>& admissionProfiles() const noexcept
+  {
+    return admission_;
+  }
+
+  // Orders refused because the sender was not entitled to send them. Non-zero
+  // means a counterparty is sending what it may not -- visible immediately
+  // rather than a week later as a position nobody can explain.
+  uint64_t admissionRejects() const noexcept { return admissionRejects_; }
+
   // Pro-rata defensive-path counter (see Matcher::crossProRata): a resting
   // lastLook maker met by a pro-rata allocation was skipped, not filled firm.
   uint64_t skippedLastLookProRata() const noexcept { return matcher_.skippedLastLookProRata(); }
@@ -608,8 +775,16 @@ class MatchingEngine
     // subscriber reads them as consequences of a halt rather than as an
     // unexplained mass cancel.
     publishStatus(TradingStatusReason::Administrative);
+    cancelEntireBook(CancelReason::VenueHalt);
+  }
+
+  // Pull every resting and pending order. Shared by the emergency halt and by
+  // delisting, because "nothing survives" has exactly one correct
+  // implementation and a second copy is how the two drift apart.
+  void cancelEntireBook(CancelReason reason)
+  {
     // Resolve every open hold first: restored quantity lands back on the book
-    // and is then swept by the cancel loop below, so nothing survives the halt.
+    // and is then swept by the loop below, so nothing survives.
     rejectAllHolds();
     std::vector<OrderId> resting;
     for (const auto& [acct, ids] : byAccount_)
@@ -625,7 +800,7 @@ class MatchingEngine
         const uint64_t acct = ownerOf(id);
         releaseReservation(id);
         forgetOrder(id);
-        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt, acct});
+        sink_(OrderCanceled{id, cfg_.id, reason, acct});
       }
     }
     for (OrderId id : stops_.ids())
@@ -634,7 +809,7 @@ class MatchingEngine
       if (stops_.cancel(id))
       {
         releaseReservation(id);
-        sink_(OrderCanceled{id, cfg_.id, CancelReason::VenueHalt, acct});
+        sink_(OrderCanceled{id, cfg_.id, reason, acct});
       }
     }
   }
@@ -660,6 +835,29 @@ class MatchingEngine
   {
     closed_ = false;
     publishStatus(TradingStatusReason::Session);
+  }
+
+  // Withdraw the instrument from trading. Unlike a halt or a closed session,
+  // this carries no promise of a return, so leaving orders resting would leave
+  // them waiting for an open that is not coming -- the book is pulled on the
+  // way out, through the same path an emergency halt uses.
+  void delist()
+  {
+    if (delisted_)
+    {
+      return;
+    }
+    delisted_ = true;
+    // The status reaches the feed before the cancels it causes, so a subscriber
+    // reads them as a consequence rather than as an unexplained mass cancel.
+    publishStatus(TradingStatusReason::Administrative);
+    cancelEntireBook(CancelReason::VenueHalt);
+  }
+
+  void relist()
+  {
+    delisted_ = false;
+    publishStatus(TradingStatusReason::Administrative);
   }
 
   // ---- session / auctions ----
@@ -701,6 +899,12 @@ class MatchingEngine
         break;
       case AdminAction::OpenSession:
         openSession();
+        break;
+      case AdminAction::Delist:
+        delist();
+        break;
+      case AdminAction::Relist:
+        relist();
         break;
     }
   }
@@ -813,11 +1017,82 @@ class MatchingEngine
       {
         break;
       }
-      const Quantity fill = (bid->leaves < ask->leaves) ? bid->leaves : ask->leaves;
+      Quantity fill = (bid->leaves < ask->leaves) ? bid->leaves : ask->leaves;
       const OrderId bidId = bid->id;
       const OrderId askId = ask->id;
       const uint64_t bAcct = bid->accountId;
       const uint64_t aAcct = ask->accountId;
+      // Self-trade prevention. An auction has no aggressor -- both legs are
+      // resting -- so the mode is read off each order and applied from the
+      // requester's point of view: its counterparty is the "oldest" leg (it is
+      // resting) and its own order is the "newest". When both legs ask, the
+      // cancellations union, which needs no precedence rule between modes and
+      // lands the same way whichever order the book hands them to us in.
+      if (stpScope(bAcct) == stpScope(aAcct))
+      {
+        const STPMode bidStp = stpOf(bidId);
+        const STPMode askStp = stpOf(askId);
+        if (bidStp != STPMode::None || askStp != STPMode::None)
+        {
+          if (bidStp == STPMode::Decrement || askStp == STPMode::Decrement)
+          {
+            // Trim both legs by the overlap; no print, and whatever is left of
+            // the larger leg stays in the auction.
+            decrementForStp(bidId, fill);
+            decrementForStp(askId, fill);
+            continue;
+          }
+          bool killBid = false, killAsk = false;
+          if (bidStp == STPMode::CancelOldest || bidStp == STPMode::CancelBoth)
+          {
+            killAsk = true;
+          }
+          if (bidStp == STPMode::CancelNewest || bidStp == STPMode::CancelBoth)
+          {
+            killBid = true;
+          }
+          if (askStp == STPMode::CancelOldest || askStp == STPMode::CancelBoth)
+          {
+            killBid = true;
+          }
+          if (askStp == STPMode::CancelNewest || askStp == STPMode::CancelBoth)
+          {
+            killAsk = true;
+          }
+          if (killBid)
+          {
+            cancelForStp(bidId, bAcct);
+          }
+          if (killAsk)
+          {
+            cancelForStp(askId, aAcct);
+          }
+          continue;  // this pair never prints
+        }
+      }
+
+      // The uncross prints its own fills instead of going through the matcher,
+      // so it applies the fill-time perp limits itself: an auction is a fill
+      // moment like any other, and a reduce-only order must not flip a position
+      // (with no margin) just because it was filled here.
+      if (cfg_.linearPerp && ledger_ != nullptr)
+      {
+        const FillLimit lim = pairFillLimit(aAcct, Side::SELL, ask->reduceOnly, bAcct, Side::BUY,
+                                            bid->reduceOnly, fill);
+        if (lim.qty.isZero())
+        {
+          // Nothing this pair may trade: pull the blocked leg so the uncross
+          // moves on to the next order at this price (and terminates).
+          const OrderId blocked = lim.makerBlocked ? askId : bidId;
+          const uint64_t blockedAcct = lim.makerBlocked ? aAcct : bAcct;
+          book_.cancel(blocked);
+          releaseReservation(blocked);
+          forgetOrder(blocked);
+          sink_(OrderCanceled{blocked, cfg_.id, lim.reason, blockedAcct});
+          continue;
+        }
+        fill = lim.qty;
+      }
       emit_(Trade{++tradeSeq_, cfg_.id, P, fill, askId, bidId, Side::BUY, aAcct, bAcct});
       book_.consumeById(bidId, fill);
       book_.consumeById(askId, fill);
@@ -851,6 +1126,10 @@ class MatchingEngine
     h = mix(h, static_cast<uint64_t>(cfg_.maxPrice.raw()));
     h = mix(h, static_cast<uint64_t>(cfg_.triggerRef));
     h = mix(h, auctionMode_ ? 1U : 0U);
+    if (delisted_)
+    {
+      h = mix(h, 0xB00EU);  // only when set: an engine that never delisted hashes as before
+    }
     h = mix(h, static_cast<uint64_t>(haltUntil_));
     // Session and funding state fold in only when they are set, the same
     // "zero == absent" rule the balance traversal follows. An engine that has
@@ -915,6 +1194,21 @@ class MatchingEngine
       h = mix(h, static_cast<uint64_t>(trig.raw()));
     }
 
+    for (uint64_t acct : sortedKeys(admission_))
+    {
+      const AdmissionProfile& p = admission_.at(acct);
+      h = mix(h, 0xB00DU);
+      h = mix(h, acct);
+      h = mix(h, p.allowedTypes);
+      h = mix(h, p.allowedTif);
+      h = mix(h, static_cast<uint64_t>(p.deny));
+    }
+    for (OrderId id : sortedKeys(orderStp_))
+    {
+      h = mix(h, 0xB00CU);
+      h = mix(h, static_cast<uint64_t>(id));
+      h = mix(h, static_cast<uint64_t>(orderStp_.at(id)));
+    }
     for (OrderId id : sortedKeys(pegged_))
     {
       const Peg& p = pegged_.at(id);
@@ -1104,6 +1398,10 @@ class MatchingEngine
                                              cfg_.maxPrice}},
                ts);
     out.append(InboundCommand{SetBands{cfg_.id, cfg_.minPrice, cfg_.maxPrice}}, ts);
+    // Risk limits ride the config section for the same reason the bands do:
+    // they decide what is admitted, so a recovered engine that lost them would
+    // admit orders the live one refused.
+    out.append(InboundCommand{riskLimits()}, ts);
     out.append(InboundCommand{SetTriggerRef{cfg_.id, cfg_.triggerRef}}, ts);
     // STP groups are engine state journaled as SetStpGroup commands; the
     // snapshot re-emits the live table as the same records (config section,
@@ -1114,6 +1412,13 @@ class MatchingEngine
       {
         out.append(InboundCommand{SetStpGroup{cfg_.id, acct, groups.at(acct)}}, ts);
       }
+    }
+    // Admission profiles are engine state of the same kind: they decide what
+    // is accepted, so they are re-emitted as the command that set them and
+    // applied through the ordinary submit path on load.
+    for (uint64_t acct : sortedKeys(admission_))
+    {
+      out.append(InboundCommand{SetAdmissionProfile{cfg_.id, acct, admission_.at(acct)}}, ts);
     }
     out.append(InboundCommand{AdminCmd{cfg_.id, cfg_.halted ? AdminAction::Halt
                                                             : AdminAction::Resume}},
@@ -1128,6 +1433,13 @@ class MatchingEngine
     if (closed_)
     {
       out.append(InboundCommand{AdminCmd{cfg_.id, AdminAction::CloseSession}}, ts);
+    }
+    // Delisting is outermost of all, so it is written after the session state.
+    // Only when set, so an engine that never delisted writes the file it always
+    // did and its state hash is unchanged.
+    if (delisted_)
+    {
+      out.append(InboundCommand{AdminCmd{cfg_.id, AdminAction::Delist}}, ts);
     }
     // Funding state: written only when there is any, so an engine with none
     // produces the same file it did before the record existed (and that file
@@ -1244,6 +1556,11 @@ class MatchingEngine
       out.append(InboundCommand{RestorePeg{id, p.side, p.ref, p.offsetRaw}}, ts);
     }
 
+    for (OrderId id : sortedKeys(orderStp_))
+    {
+      out.append(InboundCommand{RestoreOrderStp{id, static_cast<uint8_t>(orderStp_.at(id))}}, ts);
+    }
+
     for (uint64_t acct : sortedKeys(positions_))
     {
       const Position& p = positions_.at(acct);
@@ -1325,6 +1642,15 @@ class MatchingEngine
     if (const auto* r = std::get_if<RestoreStop>(&cmd))
     {
       return applyRestoreStop(*r);
+    }
+    if (const auto* r = std::get_if<RestoreOrderStp>(&cmd))
+    {
+      const auto mode = static_cast<STPMode>(r->mode);
+      if (mode != STPMode::None)
+      {
+        orderStp_[r->id] = mode;
+      }
+      return true;
     }
     if (const auto* r = std::get_if<RestorePeg>(&cmd))
     {
@@ -1414,6 +1740,19 @@ class MatchingEngine
   // Live-traffic snapshot-tag drops (observability; see the guard in submit).
   uint64_t droppedSnapshotRecords() const noexcept { return droppedSnapshotRecords_; }
 
+  // Trades that printed but could not be settled without creating value, so
+  // nothing moved (see reportUnsettled). Must stay at zero: a non-zero value
+  // means a fill reached clearing with neither a reservation nor the balance to
+  // pay for it, and the venue refused to invent the difference.
+  uint64_t unsettledTrades() const noexcept { return unsettledTrades_; }
+
+  // Last-look accepts turned into rejects because the fill would have breached
+  // a perp risk limit by the time the maker answered (see resolveHeld).
+  uint64_t riskRejectedHolds() const noexcept { return riskRejectedHolds_; }
+
+  // Pro-rata participants excluded by the fill-time risk limits.
+  uint64_t skippedRiskProRata() const noexcept { return matcher_.skippedRiskProRata(); }
+
   // ---- asynchronous checkpoint support ----
   // A full engine clone taken under the consumer pause; serialization (fsync,
   // rename, rotation bookkeeping) then runs on a background thread against the
@@ -1460,6 +1799,8 @@ class MatchingEngine
     e.ocoMembers_ = ocoMembers_;
     e.ocoPending_ = ocoPending_;  // empty at a command boundary; copied for completeness
     e.pegged_ = pegged_;
+    e.orderStp_ = orderStp_;
+    e.admission_ = admission_;
     e.fees_ = fees_;
     e.feesEnabled_ = feesEnabled_;
     e.mmpCfg_ = mmpCfg_;
@@ -1500,15 +1841,67 @@ class MatchingEngine
   uint64_t venueAccount() const noexcept { return venueAccount_; }
 
  private:
+  // Instrument conformance for a conditional order: the trigger is a price and
+  // the size is a size, so tick, band and lot apply exactly as they do to a
+  // resting limit. State and duplicate checks already ran before this point.
+  RejectReason validateConditional(const NewOrder& o) const
+  {
+    if (o.quantity.raw() <= 0)
+    {
+      return RejectReason::InvalidQuantity;
+    }
+    if (!cfg_.lotSize.isZero() && (o.quantity.raw() % cfg_.lotSize.raw()) != 0)
+    {
+      return RejectReason::InvalidQuantity;
+    }
+    const int64_t trig = o.triggerPrice.raw();
+    if (trig > 0)
+    {
+      if (!cfg_.tickSize.isZero() && (trig % cfg_.tickSize.raw()) != 0)
+      {
+        return RejectReason::InvalidPrice;
+      }
+      if (!cfg_.minPrice.isZero() && trig < cfg_.minPrice.raw())
+      {
+        return RejectReason::InvalidPrice;
+      }
+      if (!cfg_.maxPrice.isZero() && trig > cfg_.maxPrice.raw())
+      {
+        return RejectReason::InvalidPrice;
+      }
+    }
+    // A stop-LIMIT also carries the limit price it will rest at.
+    if (o.type == OrderType::STOP_LIMIT || o.type == OrderType::TAKE_PROFIT_LIMIT)
+    {
+      if (!cfg_.tickSize.isZero() && (o.price.raw() % cfg_.tickSize.raw()) != 0)
+      {
+        return RejectReason::InvalidPrice;
+      }
+      if (!cfg_.minPrice.isZero() && o.price.raw() < cfg_.minPrice.raw())
+      {
+        return RejectReason::InvalidPrice;
+      }
+      if (!cfg_.maxPrice.isZero() && o.price.raw() > cfg_.maxPrice.raw())
+      {
+        return RejectReason::InvalidPrice;
+      }
+    }
+    return RejectReason::None;
+  }
+
   RejectReason validate(const NewOrder& o) const
   {
     if (o.symbol != cfg_.id)
     {
       return RejectReason::UnknownSymbol;
     }
-    // Ahead of the halt check: a client whose order is refused deserves the
-    // outer reason. "The market is closed" tells it to come back next session;
-    // "halted" would tell it something is wrong with the instrument.
+    // Outermost first: a client whose order is refused deserves the reason that
+    // tells it what to do next. Delisted means do not come back; closed means
+    // next session; halted means something is wrong with the instrument now.
+    if (delisted_)
+    {
+      return RejectReason::InstrumentDelisted;
+    }
     if (closed_)
     {
       return RejectReason::MarketClosed;
@@ -1591,6 +1984,50 @@ class MatchingEngine
   // plain stop bypasses the position cap). Caps a reduce-only order to the
   // opposing position (0 reducible -> reject: nothing to reduce) and rejects a
   // fill that would breach maxPositionQty. Mutates o.quantity for the cap.
+  // Entitlement gate. Every admission path consults this before anything else
+  // decides the order's fate, so a counterparty cannot reach the book through
+  // a path that forgot to ask. Declared in scripts/check_gate_reachability.py,
+  // which fails the build if a path stops calling it.
+  RejectReason admissionGate(const NewOrder& o) const
+  {
+    auto it = admission_.find(o.accountId);
+    if (it == admission_.end())
+    {
+      return RejectReason::None;  // no profile: everything permitted
+    }
+    const AdmissionProfile& p = it->second;
+    if (p.allowedTypes != 0 && (p.allowedTypes & (1u << static_cast<uint32_t>(o.type))) == 0)
+    {
+      return RejectReason::OrderTypeNotPermitted;
+    }
+    // Tested before the TIF list so the answer names the policy rather than the
+    // field: "you may not leave an order resting" tells the counterparty what
+    // to change, "this time in force is not allowed" leaves it guessing which
+    // of the allowed ones is safe.
+    //
+    // Refused on admission, not killed on the way out: an order that could rest
+    // must never be accepted from a counterparty that does not track resting
+    // orders. POST_ONLY exists only to rest; GTC and GTD outlive the message
+    // that carried them.
+    if ((p.deny & AdmissionDeny::DenyResting) != 0 &&
+        (o.tif == TimeInForce::GTC || o.tif == TimeInForce::GTD ||
+         o.tif == TimeInForce::POST_ONLY || o.postOnly))
+    {
+      return RejectReason::RestingNotPermitted;
+    }
+    if (p.allowedTif != 0 && (p.allowedTif & (1u << static_cast<uint32_t>(o.tif))) == 0)
+    {
+      return RejectReason::TimeInForceNotPermitted;
+    }
+    return RejectReason::None;
+  }
+
+  bool admissionDenies(uint64_t account, uint8_t bit) const
+  {
+    auto it = admission_.find(account);
+    return it != admission_.end() && (it->second.deny & bit) != 0;
+  }
+
   RejectReason perpRiskGate(NewOrder& o)
   {
     if (!cfg_.linearPerp)
@@ -1626,8 +2063,109 @@ class MatchingEngine
     return RejectReason::None;
   }
 
+  // How much of one leg's prospective fill the perp risk limits still allow,
+  // measured against the position the account holds RIGHT NOW. `reason` names
+  // the limit that cut it (meaningful only when the result is below `want`).
+  int64_t legFillLimit(uint64_t account, Side side, bool reduceOnly, int64_t want,
+                       CancelReason& reason) const
+  {
+    const auto pit = positions_.find(account);
+    const int64_t posQ = (pit == positions_.end()) ? 0 : pit->second.qtyRaw;
+    int64_t allowed = want;
+    if (reduceOnly)
+    {
+      // A reduce-only order may only close what is open on the other side. Its
+      // reserved IM is 0 by construction, so any part of it that opened a
+      // position would open it with NO margin at all.
+      const int64_t reducible = (side == Side::BUY && posQ < 0)    ? -posQ
+                                : (side == Side::SELL && posQ > 0) ? posQ
+                                                                   : 0;
+      if (reducible < allowed)
+      {
+        allowed = reducible;
+        reason = CancelReason::ReduceOnlyNotReducing;
+      }
+    }
+    if (!cfg_.maxPositionQty.isZero())
+    {
+      // Room left before the RESULTING position breaches the cap. Checking the
+      // incoming order alone (the admission gate) lets several orders, each
+      // under the cap, settle into a position past it.
+      const int64_t room =
+          (side == Side::BUY) ? cfg_.maxPositionQty.raw() - posQ : cfg_.maxPositionQty.raw() + posQ;
+      if (room < allowed)
+      {
+        allowed = room;
+        reason = CancelReason::PositionLimitExceeded;
+      }
+    }
+    return allowed < 0 ? 0 : allowed;
+  }
+
+  // Fill-time risk re-check for one prospective bite (see the FillLimit hook).
+  // reduceOnly and maxPositionQty are gated at submit / stop-trigger / modify,
+  // but a RESTING order fills later, against a position that has since moved:
+  // a reduce-only order whose position shrank would open or flip it (with zero
+  // margin -- reduce-only reserves none), and orders that each passed the cap
+  // individually would settle past it together. Both legs are therefore
+  // re-measured here, on live engine state, so a replay reproduces it.
+  FillLimit fillLimit(const RestingOrder& maker, const NewOrder& taker, Quantity want) const
+  {
+    if (ledger_ == nullptr)
+    {
+      // No ledger: the engine keeps no positions to measure against.
+      return FillLimit{want, want, want, false, false, CancelReason::ReduceOnlyNotReducing};
+    }
+    return pairFillLimit(maker.accountId, maker.side, maker.reduceOnly, taker.accountId, taker.side,
+                         taker.reduceOnly, want);
+  }
+
+  // fillLimit over two legs described directly -- used by the auction uncross,
+  // where BOTH legs are resting orders and neither is an incoming NewOrder.
+  FillLimit pairFillLimit(uint64_t makerAcct, Side makerSide, bool makerReduceOnly,
+                          uint64_t takerAcct, Side takerSide, bool takerReduceOnly,
+                          Quantity want) const
+  {
+    FillLimit out;
+    out.qty = want;
+    out.makerQty = want;
+    out.takerQty = want;
+    CancelReason makerReason = CancelReason::ReduceOnlyNotReducing;
+    CancelReason takerReason = CancelReason::ReduceOnlyNotReducing;
+    const int64_t makerAllowed =
+        legFillLimit(makerAcct, makerSide, makerReduceOnly, want.raw(), makerReason);
+    const int64_t takerAllowed =
+        legFillLimit(takerAcct, takerSide, takerReduceOnly, want.raw(), takerReason);
+    out.makerQty = Quantity::fromRaw(makerAllowed);
+    out.takerQty = Quantity::fromRaw(takerAllowed);
+    // The maker is the leg reported as blocked when both are: it is the one the
+    // matcher can act on (pull it from the book) without killing an aggressor
+    // that may still trade elsewhere.
+    if (makerAllowed <= takerAllowed)
+    {
+      out.qty = out.makerQty;
+      out.makerBlocked = makerAllowed <= 0;
+      out.reason = makerReason;
+    }
+    else
+    {
+      out.qty = out.takerQty;
+      out.takerBlocked = takerAllowed <= 0;
+      out.reason = takerReason;
+    }
+    return out;
+  }
+
   void onNew(NewOrder o)
   {
+    // Entitlement first: an order the counterparty may not send should not
+    // consume a clientOrderId, link an OCO group or reach any later gate.
+    if (const RejectReason r = admissionGate(o); r != RejectReason::None)
+    {
+      ++admissionRejects_;
+      sink_(OrderRejected{o.id, o.symbol, r, o.accountId});
+      return;
+    }
     // clientOrderId dedup (per account, window = engine session/uptime; see
     // docs/venue/matching.md). Registered on receipt, BEFORE any other gate:
     // a resend of an already-seen clOrdId must reject deterministically even
@@ -1675,6 +2213,16 @@ class MatchingEngine
     }
     if (isConditional(o.type))
     {
+      // Conditional orders branch off before validate(), which is written for
+      // an order carrying a live limit price. They still have a price (the
+      // trigger) and a quantity, and both must obey the instrument -- an
+      // off-tick or out-of-band trigger, or a sub-lot size, used to be parked
+      // happily and only surfaced when the stop fired.
+      if (const RejectReason r = validateConditional(o); r != RejectReason::None)
+      {
+        sink_(OrderRejected{o.id, o.symbol, r, o.accountId});
+        return;
+      }
       committed = onStop(o);  // parked in the stop book -> committed (keep OCO link)
       return;
     }
@@ -1706,8 +2254,9 @@ class MatchingEngine
     }
     if (!reserveFunds(o))
     {
-      sink_(OrderRejected{o.id, o.symbol, RejectReason::InsufficientFunds, o.accountId});
-      return;  // pre-trade buying-power (ledger reservation or credit hook)
+      sink_(OrderRejected{o.id, o.symbol, creditReason_, o.accountId});
+      creditReason_ = RejectReason::InsufficientFunds;  // reset for the next order
+      return;                                           // pre-trade buying-power (ledger reservation or credit hook)
     }
     committed = true;  // past all reject gates: the order will match/rest, and any
                        // OCO resolution is now owned by processOco / forgetOrder.
@@ -1725,7 +2274,7 @@ class MatchingEngine
       RestingOrder ro{o.id, o.accountId, restPx, o.quantity, o.side};
       ro.reduceOnly = o.reduceOnly;
       book_.addResting(o.side, ro);
-      trackResting(o.id, o.accountId);
+      trackResting(o.id, o.accountId, o.stp);
       sink_(OrderAccepted{o.id, o.symbol, o.side, restPx, o.quantity, true, Quantity{}, o.accountId});
       return;
     }
@@ -1772,7 +2321,7 @@ class MatchingEngine
         ro.hidden = out.leaves - o.visibleQuantity;
       }
       book_.addResting(o.side, ro);
-      trackResting(o.id, o.accountId);
+      trackResting(o.id, o.accountId, o.stp);
       if (o.tif == TimeInForce::GTD && o.expiryNs > 0)
       {
         expiry_[o.id] = o.expiryNs;
@@ -1903,6 +2452,11 @@ class MatchingEngine
       sink_(OrderRejected{o.id, o.symbol, RejectReason::UnknownSymbol, o.accountId});
       return false;
     }
+    if (delisted_)
+    {
+      sink_(OrderRejected{o.id, o.symbol, RejectReason::InstrumentDelisted, o.accountId});
+      return false;
+    }
     if (closed_)
     {
       sink_(OrderRejected{o.id, o.symbol, RejectReason::MarketClosed, o.accountId});
@@ -1955,6 +2509,13 @@ class MatchingEngine
       initTrig = o.triggerPrice;
     }
     stops_.add(o, initTrig, trailing);
+    // GTD binds a conditional order as much as a resting one: a stop whose
+    // deadline passes before it ever triggers has to expire, not wait forever
+    // for a price that may never come.
+    if (o.tif == TimeInForce::GTD && o.expiryNs > 0)
+    {
+      expiry_[o.id] = o.expiryNs;
+    }
     sink_(OrderAccepted{o.id, o.symbol, o.side, o.triggerPrice, o.quantity, false, Quantity{},
                         o.accountId});  // pending, not on book
     processTriggers();                  // may already be in-the-money
@@ -1974,6 +2535,15 @@ class MatchingEngine
 
   void processTriggers()
   {
+    // A stop re-enters matching here rather than through onNew, so the
+    // instrument-state check that guards new orders has to be repeated -- it
+    // is not inherited. Without this a mark update fires stops straight
+    // through a halt, a LULD pause, a closed session or a pre-open auction:
+    // the trigger reference keeps moving even when trading does not.
+    if (tradingStatus() != TradingStatus::Trading)
+    {
+      return;
+    }
     auto ref = triggerReference();
     if (!ref)
     {
@@ -2026,7 +2596,7 @@ class MatchingEngine
         RestingOrder rro{agg->id, agg->accountId, agg->price, out.leaves, agg->side};
         rro.reduceOnly = agg->reduceOnly;
         book_.addResting(agg->side, rro);
-        trackResting(agg->id, agg->accountId);
+        trackResting(agg->id, agg->accountId, agg->stp);
         sink_(OrderAccepted{agg->id, cfg_.id, agg->side, agg->price, out.leaves, true, Quantity{},
                             agg->accountId});
       }
@@ -2048,7 +2618,13 @@ class MatchingEngine
   {
     if (m.symbol != cfg_.id)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownSymbol, m.accountId});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::UnknownSymbol, m.accountId, true});
+      return;
+    }
+    if (admissionDenies(m.accountId, AdmissionDeny::DenyAmend))
+    {
+      ++admissionRejects_;
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::AmendNotPermitted, m.accountId, true});
       return;
     }
     // Resolve (reject) any last-look holds referencing this order FIRST: both
@@ -2058,12 +2634,12 @@ class MatchingEngine
     const RestingOrder* cur = book_.find(m.id);
     if (cur == nullptr)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::UnknownOrder, m.accountId});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::UnknownOrder, m.accountId, true});
       return;
     }
     if (m.newQty.raw() <= 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidQuantity, m.accountId});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::InvalidQuantity, m.accountId, true});
       return;
     }
 
@@ -2079,27 +2655,27 @@ class MatchingEngine
     // original order untouched.
     if (newPrice.raw() <= 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct, true});
       return;
     }
     if (!cfg_.tickSize.isZero() && (newPrice.raw() % cfg_.tickSize.raw()) != 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::TickSizeViolation, acct});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::TickSizeViolation, acct, true});
       return;
     }
     if (!cfg_.minPrice.isZero() && newPrice < cfg_.minPrice)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct, true});
       return;
     }
     if (!cfg_.maxPrice.isZero() && cfg_.maxPrice < newPrice)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::InvalidPrice, acct, true});
       return;
     }
     if (!cfg_.lotSize.isZero() && (m.newQty.raw() % cfg_.lotSize.raw()) != 0)
     {
-      sink_(OrderRejected{m.id, m.symbol, RejectReason::LotSizeViolation, acct});
+      sink_(CancelRejected{m.id, m.symbol, RejectReason::LotSizeViolation, acct, true});
       return;
     }
 
@@ -2115,16 +2691,7 @@ class MatchingEngine
     if (newPrice == curPrice && m.newQty <= curLeaves && curHidden.isZero())
     {
       book_.reduce(m.id, m.newQty);
-      if (ledger_ != nullptr && m.newQty < curLeaves)
-      {
-        if (auto it = reserve_.find(m.id); it != reserve_.end() && curLeaves.raw() > 0)
-        {
-          const Amount freed = static_cast<Amount>(static_cast<__int128>(it->second.reservedRaw) *
-                                                   (curLeaves.raw() - m.newQty.raw()) / curLeaves.raw());
-          ledger_->release(it->second.account, it->second.asset, freed);
-          it->second.reservedRaw -= freed;
-        }
-      }
+      releaseReservationPro(m.id, curLeaves.raw(), m.newQty.raw());
       sink_(OrderModified{m.id, m.symbol, newPrice, m.newQty, true, acct});
       return;
     }
@@ -2144,6 +2711,10 @@ class MatchingEngine
     re.tif = TimeInForce::GTC;
     re.accountId = acct;
     re.reduceOnly = curReduceOnly;  // preserve reduce-only across the modify
+    // A modify re-enters matching as a fresh aggressor, so it must carry the
+    // self-trade prevention the original order was admitted with. Rebuilding
+    // the order from the resting record alone would silently drop it.
+    re.stp = stpOf(m.id);
 
     // Perp risk gate: a modified perp order re-enters matching HERE, not through
     // onNew, so it must run the same reduce-only cap + position-cap checks (spot:
@@ -2170,7 +2741,7 @@ class MatchingEngine
       RestingOrder mro{m.id, acct, newPrice, out.leaves, side};
       mro.reduceOnly = re.reduceOnly;
       book_.addResting(side, mro);
-      trackResting(m.id, acct);
+      trackResting(m.id, acct, re.stp);
     }
     sink_(OrderModified{m.id, m.symbol, newPrice, out.leaves, false, acct});
     processTriggers();  // a reprice-into-cross may have moved the last price
@@ -2180,7 +2751,13 @@ class MatchingEngine
   {
     if (c.symbol != cfg_.id)
     {
-      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownSymbol, c.accountId});
+      sink_(CancelRejected{c.id, c.symbol, RejectReason::UnknownSymbol, c.accountId, false});
+      return;
+    }
+    if (admissionDenies(c.accountId, AdmissionDeny::DenyCancel))
+    {
+      ++admissionRejects_;
+      sink_(CancelRejected{c.id, c.symbol, RejectReason::CancelNotPermitted, c.accountId, false});
       return;
     }
     // Cancel-while-held: deterministically resolve (reject) the order's holds
@@ -2200,11 +2777,16 @@ class MatchingEngine
     }
     else if (stops_.cancel(c.id))
     {
+      // A pending stop holds no reservation, but it does hold an OCO
+      // membership: leaving it behind means a later trigger of the sibling
+      // looks for an order that no longer exists.
+      unlinkOco(c.id);
+      forgetOrder(c.id);
       sink_(OrderCanceled{c.id, c.symbol, CancelReason::UserRequested, stopAcct});
     }
     else
     {
-      sink_(OrderRejected{c.id, c.symbol, RejectReason::UnknownOrder, c.accountId});
+      sink_(CancelRejected{c.id, c.symbol, RejectReason::UnknownOrder, c.accountId, false});
     }
   }
 
@@ -2216,10 +2798,77 @@ class MatchingEngine
     auto it = orderAccount_.find(id);
     return it == orderAccount_.end() ? 0 : it->second;
   }
-  void trackResting(OrderId id, uint64_t account)
+  // Self-trade-prevention mode recorded for an order, or None if it asked for
+  // none. Reading it back is how a re-entering order keeps the control it was
+  // admitted with.
+  STPMode stpOf(OrderId id) const
+  {
+    auto it = orderStp_.find(id);
+    return it == orderStp_.end() ? STPMode::None : it->second;
+  }
+
+  // Self-trade-prevention scope: the firm group if the account is in one, else
+  // the account itself. Read off the matcher's table so the two can never
+  // disagree about who counts as the same trader.
+  uint64_t stpScope(uint64_t account) const
+  {
+    const auto& groups = matcher_.stpGroups();
+    if (groups.empty())
+    {
+      return account;
+    }
+    auto it = groups.find(account);
+    return it == groups.end() ? account : it->second;
+  }
+
+  // Cancel one leg of a self-matching auction pair, with the same discipline
+  // every other engine-side cancel follows: free the reservation, drop the
+  // tracking, tell the owner.
+  void cancelForStp(OrderId id, uint64_t account)
+  {
+    book_.cancel(id);
+    releaseReservation(id);
+    forgetOrder(id);
+    sink_(OrderCanceled{id, cfg_.id, CancelReason::SelfTradePrevention, account});
+  }
+
+  // Trim one leg by the overlapping quantity without printing. A leg trimmed
+  // to nothing is canceled outright, which is also what keeps the uncross loop
+  // making progress.
+  void decrementForStp(OrderId id, Quantity by)
+  {
+    const RestingOrder* r = book_.find(id);
+    if (r == nullptr)
+    {
+      return;
+    }
+    const uint64_t acct = r->accountId;
+    const int64_t fromRaw = r->leaves.raw();
+    const int64_t toRaw = fromRaw - by.raw();
+    if (toRaw <= 0)
+    {
+      cancelForStp(id, acct);
+      return;
+    }
+    book_.reduce(id, Quantity::fromRaw(toRaw));
+    releaseReservationPro(id, fromRaw, toRaw);
+  }
+
+  // Every path that puts an order on the book comes through here, and the STP
+  // mode is a required argument on purpose: a new rest path cannot compile
+  // without saying what self-trade prevention the order carries.
+  void trackResting(OrderId id, uint64_t account, STPMode stp)
   {
     orderAccount_[id] = account;
     byAccount_[account].insert(id);
+    if (stp != STPMode::None)
+    {
+      orderStp_[id] = stp;
+    }
+    else
+    {
+      orderStp_.erase(id);  // an id can be reused after the previous order left
+    }
   }
   void forgetOrder(OrderId id)
   {
@@ -2237,6 +2886,7 @@ class MatchingEngine
     expiry_.erase(id);
     unlinkOco(id);
     pegged_.erase(id);
+    orderStp_.erase(id);
   }
 
   // Remove an order from its OCO group, keeping orderOco_ and ocoMembers_ in
@@ -2244,6 +2894,30 @@ class MatchingEngine
   // (cancel / expiry / MMP / halt / liquidation / reject) must route through
   // here, or a departed leg lingers in ocoMembers_ and later cancels a reused
   // OrderId when the surviving sibling resolves (and the group vector leaks).
+  // Free the reservation covering the quantity an order just lost. Any path
+  // that shrinks a resting order owes this: buying power held against size
+  // that no longer rests is the account's money, frozen for nothing.
+  void releaseReservationPro(OrderId id, int64_t fromQtyRaw, int64_t toQtyRaw)
+  {
+    if (ledger_ == nullptr || fromQtyRaw <= 0 || toQtyRaw >= fromQtyRaw)
+    {
+      return;
+    }
+    auto it = reserve_.find(id);
+    if (it == reserve_.end())
+    {
+      return;
+    }
+    const Amount freed = static_cast<Amount>(static_cast<__int128>(it->second.reservedRaw) *
+                                             (fromQtyRaw - toQtyRaw) / fromQtyRaw);
+    if (freed <= 0)
+    {
+      return;
+    }
+    ledger_->release(it->second.account, it->second.asset, freed);
+    it->second.reservedRaw -= freed;
+  }
+
   void unlinkOco(OrderId id)
   {
     auto it = orderOco_.find(id);
@@ -2301,6 +2975,12 @@ class MatchingEngine
   {
     if (q.symbol != cfg_.id)
     {
+      return;
+    }
+    if (admissionDenies(q.accountId, AdmissionDeny::DenyQuote))
+    {
+      ++admissionRejects_;
+      sink_(OrderRejected{q.bidId, q.symbol, RejectReason::QuoteNotPermitted, q.accountId});
       return;
     }
     rejectHoldsFor(q.bidId);  // a replaced quote may carry open holds
@@ -2445,13 +3125,36 @@ class MatchingEngine
 
   bool reserveFunds(const NewOrder& o)
   {
+    // Permission first, funding second. An external risk owner answers a
+    // question the engine cannot ("is this account good for it across every
+    // instrument it holds?"), so it has to be asked whether or not this engine
+    // also posts collateral -- both money branches below used to return before
+    // the hook was ever reached, so binding a ledger silently disabled it.
+    if (credit_)
+    {
+      const CreditDecision d = credit_(CreditRequest{o.id, o.accountId, cfg_.id, o.side, o.type,
+                                                     o.price, o.quantity, o.reduceOnly});
+      if (!d.allowed)
+      {
+        creditReason_ = d.reason;  // surfaced by the caller's reject
+        return false;
+      }
+    }
     if (ledger_ != nullptr && cfg_.linearPerp)
     {
       // Derivatives: reserve initial margin in quote collateral (reduce-only
       // reserves nothing -- it frees position margin instead).
-      const int64_t limitRaw =
-          (o.type == OrderType::LIMIT) ? o.price.raw()
-                                       : (o.side == Side::BUY ? cfg_.maxPrice.raw() : cfg_.minPrice.raw());
+      //
+      // An unpriced (market / triggered-stop) order is bounded by the price
+      // band, and for a linear perp that bound is the band's TOP on BOTH sides.
+      // Nothing is delivered here: the exposure is notional, and notional --
+      // hence initial margin -- grows with price whether the account is long or
+      // short. Bounding a perp SELL at minPrice (which is the correct worst case
+      // for a SPOT seller, who delivers base and whose quote proceeds only grow
+      // with price -- see the spot branch below) under-reserves it by the whole
+      // maxPrice/minPrice ratio, and consumeOrderIM then caps the position's
+      // margin at that under-reserved number.
+      const int64_t limitRaw = (o.type == OrderType::LIMIT) ? o.price.raw() : cfg_.maxPrice.raw();
       // A market/stop order with no price band (limitRaw == 0) cannot be bounded
       // for margin: reserving 0 IM would let it open a position with no
       // collateral. Reject rather than admit an uncollateralized fill.
@@ -2500,10 +3203,6 @@ class MatchingEngine
       reserve_[o.id] = Reservation{o.accountId, asset, amt, limitRaw, o.side};
       return true;
     }
-    if (credit_)
-    {
-      return credit_(o.accountId, o.side, o.price, o.quantity);
-    }
     return true;
   }
 
@@ -2513,7 +3212,15 @@ class MatchingEngine
   // ledger reproduces them. Without a ledger bound they are no-ops.
   void onDeposit(const Deposit& d)
   {
-    if (ledger_ == nullptr || d.amountRaw <= 0)
+    // A money command against an engine that holds no ledger is answered, not
+    // swallowed: silence is indistinguishable from a lost command, and the
+    // sender has no other way to learn the funds went nowhere.
+    if (ledger_ == nullptr)
+    {
+      sink_(OrderRejected{0, cfg_.id, RejectReason::NoLedgerBound, d.accountId});
+      return;
+    }
+    if (d.amountRaw <= 0)
     {
       return;
     }
@@ -2527,7 +3234,12 @@ class MatchingEngine
 
   void onWithdraw(const Withdraw& w)
   {
-    if (ledger_ == nullptr || w.amountRaw <= 0)
+    if (ledger_ == nullptr)
+    {
+      sink_(OrderRejected{0, cfg_.id, RejectReason::NoLedgerBound, w.accountId});
+      return;
+    }
+    if (w.amountRaw <= 0)
     {
       return;
     }
@@ -2648,10 +3360,41 @@ class MatchingEngine
     forgetOrder(id);
   }
 
+  // A printed trade could not be settled without creating value, so nothing was
+  // moved. Counted and logged rather than event-carried: the counter is a
+  // diagnostic (like droppedSnapshotRecords), and adding an event here would
+  // change the outbound stream on a path that must stay unreachable.
+  void reportUnsettled(const Trade& t, uint64_t account, const char* why)
+  {
+    ++unsettledTrades_;
+    std::fprintf(stderr,
+                 "flox-venue: trade %llu on symbol %u NOT settled (%s, account %llu) -- "
+                 "no value moved\n",
+                 static_cast<unsigned long long>(t.tradeId), static_cast<unsigned>(cfg_.id), why,
+                 static_cast<unsigned long long>(account));
+  }
+
   void settleTrade(const Trade& t)
   {
     if (ledger_ == nullptr)
     {
+      // A position is EXPOSURE, not cash: it is what reduce-only, the position
+      // cap and open interest are computed from, and none of those are money
+      // questions. So a ledgerless perp still tracks positions -- only the
+      // settlement (PnL, margin, fees) is skipped. Leaving positions_ empty
+      // here is what used to make reduce-only reject unconditionally, degrade
+      // the position cap to a per-order cap, and publish open interest as a
+      // flat zero.
+      if (cfg_.linearPerp)
+      {
+        const bool takerBuys = (t.takerSide == Side::BUY);
+        updatePerpPosition(takerBuys ? t.takerAccount : t.makerAccount,
+                           takerBuys ? t.takerId : t.makerId, true, t.quantity.raw(),
+                           t.price.raw());
+        updatePerpPosition(takerBuys ? t.makerAccount : t.takerAccount,
+                           takerBuys ? t.makerId : t.takerId, false, t.quantity.raw(),
+                           t.price.raw());
+      }
       emitFees(t);  // no settlement: fee events only
       return;
     }
@@ -2669,8 +3412,40 @@ class MatchingEngine
     const OrderId sellerId = takerBuys ? t.makerId : t.takerId;
     const uint64_t sellerAcct = takerBuys ? t.makerAccount : t.takerAccount;
 
+    auto rb = reserve_.find(buyerId);
+    auto rs = reserve_.find(sellerId);
+    const bool buyerUnreserved = (rb == reserve_.end());
+    const bool sellerUnreserved = (rs == reserve_.end());
+
+    // VALUE INTEGRITY. A leg with no reservation has to settle straight out of
+    // `available`, and Ledger::debit is all-or-nothing: it can refuse. Crediting
+    // the counterparty regardless -- which is what discarding the debit's result
+    // amounts to -- CREATES the credited amount out of nothing. So both
+    // unreserved legs are funded first, each checked, before anything is
+    // credited: if either refuses, the settlement is abandoned as a unit (the
+    // first debit, if it happened, is credited back by exactly the same amount),
+    // the trade is counted as unsettled and nothing moves. Every path that
+    // reaches here is supposed to hold a reservation; this is the floor under
+    // any path that ever stops doing so.
+    if (buyerUnreserved && !ledger_->debit(buyerAcct, cfg_.quoteAsset, notional))
+    {
+      reportUnsettled(t, buyerAcct, "buyer cannot fund quote");
+      return;
+    }
+    if (sellerUnreserved && !ledger_->debit(sellerAcct, cfg_.baseAsset, qtyRaw))
+    {
+      if (buyerUnreserved)
+      {
+        ledger_->credit(buyerAcct, cfg_.quoteAsset, notional);  // exact undo of the debit above
+      }
+      reportUnsettled(t, sellerAcct, "seller cannot deliver base");
+      return;
+    }
+
+    // Past this point the settlement cannot fail: what is left is reserved
+    // spending (already ring-fenced) and credits.
     // Buyer: pay quote from reserved (refund over-reservation), receive base.
-    if (auto rb = reserve_.find(buyerId); rb != reserve_.end())
+    if (!buyerUnreserved)
     {
       const Amount limitNotional = notionalRaw(rb->second.limitPriceRaw, t.quantity.raw(),
                                                cfg_.priceScale, cfg_.qtyScale);
@@ -2681,21 +3456,13 @@ class MatchingEngine
       }
       rb->second.reservedRaw -= limitNotional;
     }
-    else
-    {
-      ledger_->debit(buyerAcct, cfg_.quoteAsset, notional);
-    }
     ledger_->credit(buyerAcct, cfg_.baseAsset, qtyRaw);
 
     // Seller: deliver base from reserved, receive quote.
-    if (auto rs = reserve_.find(sellerId); rs != reserve_.end())
+    if (!sellerUnreserved)
     {
       ledger_->spendReserved(sellerAcct, cfg_.baseAsset, qtyRaw);
       rs->second.reservedRaw -= qtyRaw;
-    }
-    else
-    {
-      ledger_->debit(sellerAcct, cfg_.baseAsset, qtyRaw);
     }
     ledger_->credit(sellerAcct, cfg_.quoteAsset, notional);
 
@@ -2778,16 +3545,19 @@ class MatchingEngine
     {
       const int64_t reduceQty = std::min<int64_t>(remaining, iabs64(p.qtyRaw));
       // realized PnL vs entry (long: (price-entry)*qty; short: (entry-price)*qty)
-      const Amount pnl =
-          notionalRaw(priceRaw - p.entryRaw, reduceQty, cfg_.priceScale, cfg_.qtyScale) * posSign;
-      ledger_->credit(acct, cfg_.quoteAsset, pnl);
-      ledger_->credit(venueAccount_, cfg_.quoteAsset, -pnl);
-      // release position margin for the reduced portion
-      const Amount relMargin =
-          static_cast<Amount>(static_cast<__int128>(p.margin) * reduceQty / iabs64(p.qtyRaw));
-      ledger_->release(acct, cfg_.quoteAsset, relMargin);
-      p.margin -= relMargin;
-      releaseOrderIM(orderId, reduceQty, acct);
+      if (ledger_ != nullptr)
+      {
+        const Amount pnl =
+            notionalRaw(priceRaw - p.entryRaw, reduceQty, cfg_.priceScale, cfg_.qtyScale) * posSign;
+        ledger_->credit(acct, cfg_.quoteAsset, pnl);
+        ledger_->credit(venueAccount_, cfg_.quoteAsset, -pnl);
+        // release position margin for the reduced portion
+        const Amount relMargin =
+            static_cast<Amount>(static_cast<__int128>(p.margin) * reduceQty / iabs64(p.qtyRaw));
+        ledger_->release(acct, cfg_.quoteAsset, relMargin);
+        p.margin -= relMargin;
+        releaseOrderIM(orderId, reduceQty, acct);
+      }
       p.qtyRaw += fillSign * reduceQty;  // toward zero
       remaining -= reduceQty;
       if (p.qtyRaw == 0)
@@ -2798,7 +3568,7 @@ class MatchingEngine
 
     if (remaining > 0)
     {
-      const Amount im = consumeOrderIM(orderId, remaining);
+      const Amount im = (ledger_ != nullptr) ? consumeOrderIM(orderId, remaining) : 0;
       const int64_t absOld = iabs64(p.qtyRaw);
       const __int128 num = static_cast<__int128>(absOld) * p.entryRaw +
                            static_cast<__int128>(remaining) * priceRaw;
@@ -2809,11 +3579,11 @@ class MatchingEngine
 
     if (p.qtyRaw == 0)
     {
-      if (p.margin > 0)
+      if (p.margin > 0 && ledger_ != nullptr)
       {
         ledger_->release(acct, cfg_.quoteAsset, p.margin);
-        p.margin = 0;
       }
+      p.margin = 0;
       positions_.erase(acct);
     }
   }
@@ -2838,10 +3608,41 @@ class MatchingEngine
     }
   }
 
+  // Close a position on someone else's decision. The engine sees one symbol;
+  // a portfolio-margin model sees the whole basket and is the only party that
+  // can judge an account solvent or not across instruments. Same settlement
+  // path as the engine's own sweep, so both produce identical events and the
+  // replay cannot tell them apart.
+  void onForceClose(const ForceClosePosition& fc)
+  {
+    if (ledger_ == nullptr)
+    {
+      sink_(OrderRejected{0, cfg_.id, RejectReason::NoLedgerBound, fc.accountId});
+      return;
+    }
+    if (!cfg_.linearPerp || !hasMark_)
+    {
+      sink_(OrderRejected{0, cfg_.id, RejectReason::UnknownOrder, fc.accountId});
+      return;
+    }
+    if (positions_.find(fc.accountId) == positions_.end())
+    {
+      return;  // nothing open: a no-op, not an error
+    }
+    forceClose(fc.accountId, markPrice_);
+  }
+
   // Maintenance-margin sweep: liquidate every position whose equity (posted
   // margin + unrealized PnL) has fallen below the maintenance requirement.
+  // Skipped entirely when an external risk owner drives liquidation: two
+  // systems closing the same position from different numbers is worse than
+  // either doing it alone.
   void checkLiquidations(Price mark)
   {
+    if (cfg_.externalLiquidation)
+    {
+      return;
+    }
     if (ledger_ == nullptr || !cfg_.linearPerp || cfg_.maintenanceMarginBps == 0)
     {
       return;
@@ -3093,7 +3894,7 @@ class MatchingEngine
     // order (levels best-first, FIFO within) makes tail-appends reproduce the
     // exact live book layout.
     book_.addResting(r.side, ro);
-    trackResting(r.id, r.accountId);
+    trackResting(r.id, r.accountId, STPMode::None);  // set by the RestoreOrderStp that follows
     if (r.expiryNs > 0)
     {
       expiry_[r.id] = r.expiryNs;
@@ -3141,15 +3942,16 @@ class MatchingEngine
     h.takerReduceOnly = r.takerReduceOnly;
     held_[r.heldId] = h;
     heldOpen_.store(held_.size(), std::memory_order_relaxed);
-    // Tracking follows the recorded live truth: a held maker normally stays
-    // tracked even fully off the book (see createHeld), but an STP-cancel can
-    // have removed it while the hold stayed open. Idempotent when the maker
-    // also rests (RestoreOrder tracked it). The taker is tracked only while
-    // resting. Reservations backing the legs arrive as RestoreReservation
-    // records -- nothing is re-derived here.
+    // Tracking follows the recorded live truth rather than being re-derived: a
+    // held maker stays tracked even fully off the book (see createHeld), and
+    // the flag also carries snapshots written before the matcher's own removals
+    // learned to resolve holds first. Idempotent when the maker also rests
+    // (RestoreOrder tracked it). The taker is tracked only while resting.
+    // Reservations backing the legs arrive as RestoreReservation records --
+    // nothing is re-derived here.
     if (r.makerTracked)
     {
-      trackResting(h.maker, h.makerAccount);
+      trackResting(h.maker, h.makerAccount, stpOf(h.maker));
     }
     return true;
   }
@@ -3168,7 +3970,19 @@ class MatchingEngine
     }
     if (ledger_ == nullptr)
     {
-      return true;  // no ledger bound: reservations do not exist
+      // The snapshot describes a venue that held money; this engine does not.
+      // Accepting it would leave reserve_ empty while stateHash folds it in,
+      // and the generation would later be discarded as "corrupt" -- a wrong
+      // diagnosis of a sound file. Refuse here, where the reason is knowable.
+      if (r.reservedRaw > 0)
+      {
+        std::fprintf(stderr,
+                     "venue: snapshot carries reservations but no ledger is bound "
+                     "(order %llu) -- restore refused\n",
+                     static_cast<unsigned long long>(r.id));
+        return false;
+      }
+      return true;  // nothing reserved: nothing to honour
     }
     if (!exactBalanceRestore_ && r.reservedRaw > 0 &&
         !ledger_->reserve(r.account, r.asset, r.reservedRaw))
@@ -3245,6 +4059,13 @@ class MatchingEngine
     const uint64_t id = ++heldSeq_;
     Held h{id, taker.id, taker.accountId, taker.side, maker.id,
            maker.accountId, maker.price, fill, now_ + cfg_.lastLookWindowNs};
+    // The taker is an aggressor now, but its residual may rest once the hold
+    // resolves -- and a resting order's STP mode is what an auction reads.
+    // Capture it here, where the mode is still in hand.
+    if (taker.stp != STPMode::None)
+    {
+      orderStp_[taker.id] = taker.stp;
+    }
     h.takerTif = taker.tif;
     h.takerType = taker.type;
     h.takerPrice = taker.price;
@@ -3316,6 +4137,18 @@ class MatchingEngine
     const Held h = it->second;
     held_.erase(it);
     heldOpen_.store(held_.size(), std::memory_order_relaxed);
+    // An accept settles a fill that was risk-checked when the hold was created,
+    // possibly a whole window ago. Re-measure it against the position as it is
+    // now: a perp fill that would open or flip a reduce-only leg (with no margin
+    // behind it) or carry an account past the position cap must not print just
+    // because the maker said yes late. The hold is rejected instead -- the
+    // honest outcome, since the venue cannot part-accept a hold: liquidity is
+    // restored to both legs exactly as a maker reject would.
+    if (accept && !holdStillAllowed(h))
+    {
+      ++riskRejectedHolds_;
+      accept = false;
+    }
     if (accept)
     {
       emit_(Trade{++tradeSeq_, cfg_.id, h.price, h.qty, h.maker, h.taker, h.takerSide,
@@ -3348,6 +4181,26 @@ class MatchingEngine
     // (deferred from the emit_ wrapper while holds were open).
     cleanupOrderIfDone(h.taker);
     cleanupOrderIfDone(h.maker);
+  }
+
+  // Would settling this hold in full still pass the perp risk limits? Both legs
+  // are measured on the live position (see fillLimit); spot and ledgerless
+  // engines have no positions, so nothing constrains them.
+  bool holdStillAllowed(const Held& h) const
+  {
+    if (!cfg_.linearPerp || ledger_ == nullptr)
+    {
+      return true;
+    }
+    const Side makerSide = (h.takerSide == Side::BUY) ? Side::SELL : Side::BUY;
+    CancelReason ignored = CancelReason::ReduceOnlyNotReducing;
+    if (legFillLimit(h.makerAccount, makerSide, h.makerReduceOnly, h.qty.raw(), ignored) <
+        h.qty.raw())
+    {
+      return false;
+    }
+    return legFillLimit(h.takerAccount, h.takerSide, h.takerReduceOnly, h.qty.raw(), ignored) >=
+           h.qty.raw();
   }
 
   // Return a rejected hold's qty to the maker: back onto its price level at the
@@ -3392,7 +4245,7 @@ class MatchingEngine
       {
         RestingOrder rebuilt{h.taker, h.takerAccount, h.takerPrice, h.qty, h.takerSide};
         book_.addResting(h.takerSide, rebuilt);
-        trackResting(h.taker, h.takerAccount);
+        trackResting(h.taker, h.takerAccount, stpOf(h.taker));
         if (h.takerTif == TimeInForce::GTD && h.takerExpiryNs > 0)
         {
           expiry_[h.taker] = h.takerExpiryNs;
@@ -3533,6 +4386,13 @@ class MatchingEngine
         forgetOrder(id);
         sink_(OrderCanceled{id, cfg_.id, CancelReason::Expired, acct});
       }
+      else if (stops_.cancel(id))  // never triggered -> expire the conditional
+      {
+        const uint64_t acct = ownerOf(id);
+        unlinkOco(id);
+        forgetOrder(id);
+        sink_(OrderCanceled{id, cfg_.id, CancelReason::Expired, acct});
+      }
     }
   }
 
@@ -3634,9 +4494,12 @@ class MatchingEngine
         book_.addResting(ro->side, *ro);  // unchanged -> put it back
         continue;
       }
-      if (ledger_ != nullptr)
+      // The reprice is re-funded whether or not a ledger is bound: with no
+      // ledger reserveFunds still consults the setCreditCheck hook, and
+      // skipping the whole block here was the one path where a repriced peg
+      // escaped a check that submit and stop-trigger both apply.
       {
-        releaseReservation(id);
+        releaseReservation(id);  // no-op without a ledger
         NewOrder synth;
         synth.id = id;
         synth.symbol = cfg_.id;
@@ -3763,6 +4626,16 @@ class MatchingEngine
     int64_t offsetRaw;
   };
   std::unordered_map<OrderId, Peg> pegged_;  // orderId -> peg spec (re-priced each submit)
+  // orderId -> self-trade-prevention mode, for orders that asked for one. Only
+  // the auction uncross and a modify re-entry read it: continuous matching
+  // takes the mode off the aggressor. Sparse -- STPMode::None is absent.
+  std::unordered_map<OrderId, STPMode> orderStp_;
+  // account -> admission profile. Empty table and absent entries both mean
+  // "everything permitted", so an engine that was never given profiles behaves
+  // exactly as before.
+  std::unordered_map<uint64_t, AdmissionProfile> admission_;
+  bool delisted_{false};          // withdrawn from trading; outranks halt / session / auction
+  uint64_t admissionRejects_{0};  // observability: a counterparty sending what it may not
 
   flox::FeeSchedule fees_;
   bool feesEnabled_{false};
@@ -3784,6 +4657,9 @@ class MatchingEngine
   std::unordered_map<uint64_t, MmpWindow> mmpFills_;
   std::vector<uint64_t> mmpBreached_;
   CreditCheck credit_;
+  // Reason from the last refused credit check, so the reject the client sees
+  // says why ("portfolio margin", say) instead of a flat InsufficientFunds.
+  mutable RejectReason creditReason_{RejectReason::InsufficientFunds};
 
   std::unordered_map<uint64_t, Held> held_;
   uint64_t heldSeq_{0};
@@ -3798,6 +4674,12 @@ class MatchingEngine
 
   // Snapshot-only records seen (and dropped) on the live submit path.
   uint64_t droppedSnapshotRecords_{0};
+
+  // Clearing-integrity counters (diagnostics, not hashed state): trades left
+  // unsettled rather than settled by creating value, and last-look accepts
+  // refused at decision time by a perp risk limit.
+  uint64_t unsettledTrades_{0};
+  uint64_t riskRejectedHolds_{0};
 
   // Recovery mode flag: this snapshot carried exact RestoreBalance splits, so
   // RestoreReservation / RestorePosition must not move ledger money (v1

--- a/venue/include/flox-venue/messages.h
+++ b/venue/include/flox-venue/messages.h
@@ -148,6 +148,14 @@ enum class AdminAction : uint8_t
   // entry and no snapshot-format change.
   CloseSession,  // close the session: new orders rejected (MarketClosed), the book stands
   OpenSession,   // reopen the session; the halt/auction state underneath is untouched
+  // Withdrawal from trading, as distinct from a halt or a closed session. A
+  // halt promises the instrument comes back and a closed session promises the
+  // next one; delisting promises neither, so it pulls the resting book on the
+  // way out rather than leaving orders waiting for an open that is not coming.
+  // Reversible by Relist on purpose: an irreversible operator action is one
+  // mistake away from needing a restart to undo.
+  Delist,
+  Relist,
 };
 
 struct AdminCmd
@@ -209,6 +217,78 @@ struct SetTriggerRef  // switch the conditional-order reference (last trade vs m
 // decisions), so replay and recovery reproduce the same STP outcomes; a
 // checkpoint re-emits the live table as SetStpGroup records in its config
 // section. group 0 removes the membership (back to account-level STP).
+// What a counterparty is entitled to send.
+//
+// Not every session plays the same role. One routes flow it manages itself and
+// must never leave an order resting here -- an order the framework holds and
+// the counterparty does not know it owns is a position nobody reconciles.
+// Another exists to post and pull quotes, and cancel/replace is its hot path.
+// Those are opposite rights, so they are stated per account and refused on
+// admission rather than assumed.
+//
+// A zero-valued profile permits everything, which is the behaviour of an
+// engine that was never given one.
+struct AdmissionProfile
+{
+  uint32_t allowedTypes{0};  // bit i = OrderType(i) allowed; 0 = all
+  uint32_t allowedTif{0};    // bit i = TimeInForce(i) allowed; 0 = all
+  uint8_t deny{0};           // bitmask of AdmissionDeny
+};
+
+// Rights withheld from a profile. A bitmask rather than four bools so the
+// record stays blittable and appending a right does not change its size.
+enum AdmissionDeny : uint8_t
+{
+  DenyResting = 1u << 0,  // a residual may not join the book
+  DenyAmend = 1u << 1,    // ModifyOrder refused
+  DenyCancel = 1u << 2,   // CancelOrder refused
+  DenyQuote = 1u << 3,    // Quote refused
+};
+
+struct SetAdmissionProfile
+{
+  SymbolId symbol{};  // routing key
+  uint64_t account{};
+  AdmissionProfile profile{};
+};
+
+// Which risk limits a SetRiskLimits record carries.
+//
+// A mask rather than replace-all semantics: an operator raising a position cap
+// must not silently zero the fat-finger cap by omitting it, and a record that
+// says exactly what it changes replays the same way whatever else moved in
+// between. Related knobs travel together because they are only meaningful as
+// a pair.
+enum RiskLimitField : uint16_t
+{
+  RiskLuld = 1u << 0,       // luldBps + luldHaltNs
+  RiskFatFinger = 1u << 1,  // maxOrderQty + maxOrderNotional
+  RiskMaxOpenOrders = 1u << 2,
+  RiskMaxPosition = 1u << 3,
+  RiskMargin = 1u << 4,  // initialMarginBps + maintenanceMarginBps
+};
+
+// Live risk limits.
+//
+// These used to be reachable only through direct setters on the engine, which
+// applied immediately and rode nothing: a restart reverted them and a replica
+// replaying the journal never saw the change. As a sequenced command they
+// behave like the rest of engine state -- journaled, re-emitted by a
+// checkpoint, replayed.
+struct SetRiskLimits
+{
+  SymbolId symbol{};
+  uint16_t fields{};  // bitmask of RiskLimitField; 0 = no-op
+  int32_t luldBps{};
+  int64_t luldHaltNs{};
+  Quantity maxOrderQty{};
+  Volume maxOrderNotional{};
+  uint32_t maxOpenOrders{};
+  Quantity maxPositionQty{};
+  int32_t initialMarginBps{};
+  int32_t maintenanceMarginBps{};
+};
+
 struct SetStpGroup
 {
   SymbolId symbol{};  // routing key
@@ -313,6 +393,19 @@ struct RestorePeg  // peg spec of a resting order (pegged_ entry)
   Side side{};
   PegRef ref{PegRef::None};
   int64_t offsetRaw{0};
+};
+
+// Self-trade-prevention mode of one resting order.
+//
+// In continuous trading only the aggressor's mode counts, so the book never
+// needed to carry it. An auction has no aggressor: both legs of an uncross
+// print are resting, and the mode each of them asked for is the only thing
+// that says whether they may trade with each other. Kept sparse -- orders
+// with STPMode::None have no entry.
+struct RestoreOrderStp
+{
+  OrderId id{};
+  uint8_t mode{};  // STPMode
 };
 
 struct RestoreHeld  // one open last-look hold (mirrors MatchingEngine::Held)
@@ -452,12 +545,26 @@ struct SnapshotEnd
 // and the live SetStpGroup command postdate the original snapshot block, so
 // live and snapshot-only tags interleave past tag 24. SetFundingSchedule (live)
 // and RestoreFunding (snapshot-only) are the newest pair, tags 28 and 29.)
+// Force-close a perp position from OUTSIDE the engine. Isolated margin lets the
+// engine decide for itself (it sees one symbol and the collateral behind it),
+// but a portfolio-margin model decides on the whole basket and lives above the
+// per-symbol engines -- it can already stop an account trading (MassCancel) and
+// until now had no way to close what it holds. Journaled like any command, so
+// replay reproduces an externally-driven liquidation exactly.
+struct ForceClosePosition
+{
+  uint64_t accountId{};
+  SymbolId symbol{};
+  int64_t qtyRaw{};  // 0 = the whole position
+};
+
 using InboundCommand =
     std::variant<NewOrder, CancelOrder, ModifyOrder, MassCancel, Quote, LastLookDecision, SetMark,
                  ApplyFunding, AdminCmd, Deposit, Withdraw, ListInstrument, SetBands, TimeTick,
                  SetTriggerRef, SnapshotBegin, RestoreOrder, RestoreStop, RestorePeg, RestoreHeld,
                  RestorePosition, RestoreMmpCfg, RestoreClOrdIds, SnapshotEnd, RestoreReservation,
-                 RestoreBalance, RestoreMmpFills, SetStpGroup, SetFundingSchedule, RestoreFunding>;
+                 RestoreBalance, RestoreMmpFills, SetStpGroup, SetFundingSchedule, RestoreFunding,
+                 ForceClosePosition, RestoreOrderStp, SetAdmissionProfile, SetRiskLimits>;
 
 inline constexpr size_t kFirstSnapshotTag = 15;
 inline constexpr size_t kLastContiguousSnapshotTag = 24;
@@ -677,6 +784,10 @@ enum class TradingStatus : uint8_t
   // schema keeps reading every field of the message and sees only an unknown
   // status code (which it must treat as "not tradeable", never as Trading).
   Closed = 5,  // session closed: new orders rejected, the book stands
+  // Appended: withdrawn from trading with no scheduled return. Ranked outside
+  // every other status -- a delisted instrument is not halted, not closed and
+  // not in an auction, and nothing underneath it can make it tradeable.
+  Delisted = 6,
 };
 
 enum class TradingStatusReason : uint8_t
@@ -726,9 +837,27 @@ struct DerivativesUpdated
 
 // Appended alternatives go at the END (wire codecs and the event hash key off
 // the alternative order).
+// A cancel or a cancel/replace that was refused.
+//
+// Distinct from OrderRejected because it answers a different request and, on
+// the wire, a different message: FIX 4.4 answers a refused 35=F/35=G with
+// OrderCancelReject (35=9), not with an execution report. Carrying which
+// request it was ON THE EVENT is what makes that encodable -- a resend
+// re-encodes from the event log long after the session forgot the context, and
+// a replayed message that changes type is a protocol violation exactly when
+// the counterparty is recovering.
+struct CancelRejected
+{
+  OrderId id{};
+  SymbolId symbol{};
+  RejectReason reason{};
+  uint64_t account{0};
+  bool wasReplace{false};  // false = cancel request, true = cancel/replace
+};
+
 using OutboundEvent =
     std::variant<OrderAccepted, OrderRejected, Trade, OrderExecuted, OrderCanceled, OrderModified,
                  OrderTriggered, FillHeld, FillRejected, MmpTriggered, FeeCharged, Liquidation,
-                 BalanceUpdate, TradingStatusChanged, DerivativesUpdated>;
+                 BalanceUpdate, TradingStatusChanged, DerivativesUpdated, CancelRejected>;
 
 }  // namespace flox::venue

--- a/venue/include/flox-venue/metrics.h
+++ b/venue/include/flox-venue/metrics.h
@@ -169,6 +169,15 @@ inline void Metrics::observe(const OutboundEvent& e) noexcept
       ++rejectsByReason[idx];
     }
   }
+  else if (const auto* r = std::get_if<CancelRejected>(&e))
+  {
+    ++rejects;
+    const size_t idx = static_cast<size_t>(r->reason);
+    if (idx < kReasons)
+    {
+      ++rejectsByReason[idx];
+    }
+  }
   else if (std::get_if<OrderModified>(&e))
   {
     ++modifies;

--- a/venue/include/flox-venue/reject_reason.h
+++ b/venue/include/flox-venue/reject_reason.h
@@ -34,6 +34,7 @@ enum class RejectReason : uint8_t
   NotOrderOwner,           // last-look decision from an account that does not own the held maker order
   DuplicateClientOrderId,  // clientOrderId already used by this account this session (resend dedup)
   LastLookUnsupported,     // lastLook order on a pro-rata instrument (allocation would not honour the hold)
+  NoLedgerBound,           // a money command reached an engine that holds no ledger (funds live elsewhere)
   // Session-level admission rejects, surfaced to the client as an exec-report
   // reject instead of silence (appended values -- wire enum is append-only).
   RateLimited,       // per-session rate limit tripped; the command was not admitted
@@ -44,6 +45,20 @@ enum class RejectReason : uint8_t
   // operator exception. A client retries after the next session opens; a halt
   // has no such promise. Appended value (the wire enum is append-only).
   MarketClosed,
+  // Admission profile: what a counterparty is entitled to send. A broker
+  // routing flow it manages itself must not be able to leave an order resting
+  // in a book it does not know it owns, so the entitlement is refused on
+  // admission rather than assumed by agreement (appended -- wire enum is
+  // append-only).
+  OrderTypeNotPermitted,    // the profile does not allow this order type
+  TimeInForceNotPermitted,  // the profile does not allow this time in force
+  RestingNotPermitted,      // the profile forbids leaving a residual on the book
+  AmendNotPermitted,        // the profile forbids modify
+  CancelNotPermitted,       // the profile forbids cancel
+  QuoteNotPermitted,        // the profile forbids mass quoting
+  // Withdrawn from trading with no scheduled return, unlike Halted (comes back)
+  // or MarketClosed (next session). Appended -- wire enum is append-only.
+  InstrumentDelisted,
 };
 
 enum class CancelReason : uint8_t
@@ -57,6 +72,10 @@ enum class CancelReason : uint8_t
   VenueHalt,           // canceled by an operator emergency halt-and-cancel
   Liquidation,         // canceled because the account was liquidated (free its collateral)
   FillOrKillResidual,  // a FOK that did not fully fill -- killed, never rests
+  // Fill-time perp risk re-check (the position an order was sized against can
+  // move while it rests). Appended values -- the wire enum is append-only.
+  ReduceOnlyNotReducing,  // the order would no longer reduce: it would open or flip the position
+  PositionLimitExceeded,  // the fill would carry the account past maxPositionQty
 };
 
 const char* toString(RejectReason r) noexcept;

--- a/venue/include/flox-venue/rest_json.h
+++ b/venue/include/flox-venue/rest_json.h
@@ -148,6 +148,12 @@ class RestJson
       w.u64("id", j->id);
       w.str("reason", toString(j->reason));
     }
+    else if (const auto* j = std::get_if<CancelRejected>(&ev))
+    {
+      w.str("type", j->wasReplace ? "replace_rejected" : "cancel_rejected");
+      w.u64("id", j->id);
+      w.str("reason", toString(j->reason));
+    }
     else if (const auto* m = std::get_if<OrderModified>(&ev))
     {
       w.str("type", "modified");

--- a/venue/include/flox-venue/sequenced_shard.h
+++ b/venue/include/flox-venue/sequenced_shard.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include <future>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -489,6 +490,22 @@ class SequencedShard
     }
     else
     {
+      // Falling back a generation is unbounded, but what pruning keeps is not.
+      // Once no snapshot validates, the only thing covering history before the
+      // first checkpoint is the pre-checkpoint journal -- and pruning deletes
+      // it as soon as `retainGenerations` snapshots exist. Replaying what is
+      // left would rebuild a state that looks plausible, is missing everything
+      // before the oldest surviving segment, and would then be served. Refuse
+      // instead: a venue that will not start is an incident, a venue that
+      // starts on a truncated ledger is a disaster.
+      const bool haveLegacy = std::filesystem::exists(journalPath_);
+      if (!haveLegacy && (!g.snapshots.empty() || !g.segments.empty()))
+      {
+        throw std::runtime_error(
+            "flox-venue: no snapshot validates and the pre-checkpoint journal " + journalPath_ +
+            " is gone, so history cannot be replayed in full. Refusing to start on a "
+            "truncated state -- restore a good snapshot generation from backup.");
+      }
       if (!g.snapshots.empty())
       {
         std::fprintf(stderr, "flox-venue: WARN no valid snapshot for %s, full-history replay\n",

--- a/venue/include/flox-venue/session_registry.h
+++ b/venue/include/flox-venue/session_registry.h
@@ -645,6 +645,10 @@ class SessionRegistry
     {
       out[n++] = r->account;
     }
+    else if (const auto* r = std::get_if<CancelRejected>(&e))
+    {
+      out[n++] = r->account;
+    }
     else if (const auto* t = std::get_if<Trade>(&e))
     {
       out[n++] = t->makerAccount;

--- a/venue/include/flox-venue/symbol_router.h
+++ b/venue/include/flox-venue/symbol_router.h
@@ -91,6 +91,10 @@ inline SymbolId symbolOf(const InboundCommand& c) noexcept
   {
     return fs->symbol;
   }
+  if (const auto* fc = std::get_if<ForceClosePosition>(&c))
+  {
+    return fc->symbol;
+  }
   return 0;  // snapshot-only records never route by symbol (recovery-path only)
 }
 

--- a/venue/schema/order-entry-sbe.xml
+++ b/venue/schema/order-entry-sbe.xml
@@ -51,7 +51,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="flox.venue.oe"
                    id="92"
-                   version="2"
+                   version="3"
                    semanticVersion="1.0"
                    description="Flox venue order entry + execution reports"
                    byteOrder="littleEndian">
@@ -262,5 +262,17 @@
     <field name="reservedRaw"  id="4" type="QtyRaw" sinceVersion="2"/>
     <field name="reason"       id="5" type="EnumU8" sinceVersion="2"/>
     <field name="seq"          id="6" type="SeqNum" sinceVersion="2"/>
+  </sbe:message>
+
+  <!-- A cancel or cancel/replace that was refused. Distinct from Rejected
+       because it answers a different request: FIX 4.4 maps it to 35=9, not to
+       an execution report, and wasReplace is what says which of the two the
+       counterparty sent. -->
+  <sbe:message name="CancelRejected" id="22" sinceVersion="3">
+    <field name="orderId"    id="1" type="OrderId"/>
+    <field name="symbol"     id="2" type="Symbol"/>
+    <field name="reason"     id="3" type="EnumU8"/>
+    <field name="wasReplace" id="4" type="Flag"/>
+    <field name="seq"        id="5" type="SeqNum"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/venue/src/reject_reason.cpp
+++ b/venue/src/reject_reason.cpp
@@ -54,6 +54,8 @@ const char* toString(RejectReason r) noexcept
       return "DuplicateClientOrderId";
     case RejectReason::LastLookUnsupported:
       return "LastLookUnsupported";
+    case RejectReason::NoLedgerBound:
+      return "NoLedgerBound";
     case RejectReason::RateLimited:
       return "RateLimited";
     case RejectReason::MalformedMessage:
@@ -64,6 +66,20 @@ const char* toString(RejectReason r) noexcept
       return "SessionSeqGap";
     case RejectReason::MarketClosed:
       return "MarketClosed";
+    case RejectReason::OrderTypeNotPermitted:
+      return "OrderTypeNotPermitted";
+    case RejectReason::TimeInForceNotPermitted:
+      return "TimeInForceNotPermitted";
+    case RejectReason::RestingNotPermitted:
+      return "RestingNotPermitted";
+    case RejectReason::AmendNotPermitted:
+      return "AmendNotPermitted";
+    case RejectReason::CancelNotPermitted:
+      return "CancelNotPermitted";
+    case RejectReason::QuoteNotPermitted:
+      return "QuoteNotPermitted";
+    case RejectReason::InstrumentDelisted:
+      return "InstrumentDelisted";
   }
   return "?";
 }
@@ -90,6 +106,10 @@ const char* toString(CancelReason r) noexcept
       return "Liquidation";
     case CancelReason::FillOrKillResidual:
       return "FillOrKillResidual";
+    case CancelReason::ReduceOnlyNotReducing:
+      return "ReduceOnlyNotReducing";
+    case CancelReason::PositionLimitExceeded:
+      return "PositionLimitExceeded";
   }
   return "?";
 }

--- a/venue/tests/support/counterexample.h
+++ b/venue/tests/support/counterexample.h
@@ -1,0 +1,174 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+#pragma once
+
+// Counterexample minimisation for the venue fuzzes.
+//
+// A fuzz that reports "diverged at command 47,213" has found a real defect and
+// handed over a report nobody can act on: the 47,213 commands before it are
+// almost all irrelevant, and finding out which few matter is manual work. The
+// command stream is deterministic and replayable, so the harness can answer
+// "does this shorter stream still fail?" itself, and keep asking until no
+// single remaining command can be dropped.
+//
+// This is delta debugging, run only after a failure -- the green path pays for
+// recording the stream and nothing else. Two phases:
+//
+//   1. Shortest failing prefix, by binary search. A stream that fails at
+//      command N usually fails on some prefix of it, and the search costs
+//      log2(N) replays rather than N.
+//   2. Chunk removal, halving the chunk size each round. Removing a command
+//      can only make later commands referentially stale (a cancel for an id
+//      that was never created), which the engine rejects deterministically --
+//      so a shorter stream is always a legal stream.
+//
+// The predicate must be a pure replay: build fresh engines, run the commands,
+// return whether the failure reproduced. Anything it carries over between
+// calls makes the result meaningless.
+
+#include "flox-venue/messages.h"
+
+#include <cstddef>
+#include <cstdio>
+#include <vector>
+
+namespace flox::venue::fuzz
+{
+
+struct ShrinkLimits
+{
+  // Replays are the expensive unit; a deep fuzz stream makes each one cost
+  // real time. The cap keeps a failing CI run from turning into a timeout,
+  // and a partly-shrunk counterexample is still far better than the full one.
+  int maxReplays{400};
+};
+
+struct ShrinkReport
+{
+  std::vector<InboundCommand> commands;
+  int replays{0};
+  bool hitLimit{false};
+};
+
+// `stillFails(first, count)` replays commands [first, first+count) of the
+// candidate vector and returns true when the failure reproduces.
+template <class Fails>
+ShrinkReport shrinkCounterexample(const std::vector<InboundCommand>& full, Fails stillFails,
+                                  ShrinkLimits limits = {})
+{
+  ShrinkReport out;
+  out.commands = full;
+
+  auto fails = [&](const std::vector<InboundCommand>& candidate)
+  {
+    ++out.replays;
+    return stillFails(candidate);
+  };
+
+  if (full.empty())
+  {
+    return out;
+  }
+
+  // Phase 1: shortest failing prefix.
+  {
+    size_t lo = 1, hi = out.commands.size();
+    while (lo < hi && out.replays < limits.maxReplays)
+    {
+      const size_t mid = lo + (hi - lo) / 2;
+      std::vector<InboundCommand> prefix(out.commands.begin(),
+                                         out.commands.begin() + static_cast<long>(mid));
+      if (fails(prefix))
+      {
+        hi = mid;
+      }
+      else
+      {
+        lo = mid + 1;
+      }
+    }
+    if (hi < out.commands.size())
+    {
+      out.commands.resize(hi);
+    }
+  }
+
+  // Phase 2: drop chunks, halving until single commands.
+  size_t chunk = out.commands.size() / 2;
+  while (chunk >= 1 && out.replays < limits.maxReplays)
+  {
+    bool droppedAny = false;
+    size_t at = 0;
+    while (at < out.commands.size() && out.replays < limits.maxReplays)
+    {
+      const size_t take = (chunk < out.commands.size() - at) ? chunk : (out.commands.size() - at);
+      std::vector<InboundCommand> candidate;
+      candidate.reserve(out.commands.size() - take);
+      candidate.insert(candidate.end(), out.commands.begin(),
+                       out.commands.begin() + static_cast<long>(at));
+      candidate.insert(candidate.end(), out.commands.begin() + static_cast<long>(at + take),
+                       out.commands.end());
+      if (!candidate.empty() && fails(candidate))
+      {
+        out.commands = std::move(candidate);
+        droppedAny = true;
+        // `at` stays: the next chunk slid into this position.
+      }
+      else
+      {
+        at += take;
+      }
+    }
+    if (!droppedAny)
+    {
+      chunk /= 2;
+    }
+  }
+
+  out.hitLimit = out.replays >= limits.maxReplays;
+  return out;
+}
+
+// One line per command, enough to paste into a regression test.
+inline void printCounterexample(const ShrinkReport& r)
+{
+  std::printf("\n--- minimal counterexample: %zu command(s), %d replay(s)%s ---\n",
+              r.commands.size(), r.replays, r.hitLimit ? " (replay cap reached)" : "");
+  for (size_t i = 0; i < r.commands.size(); ++i)
+  {
+    const InboundCommand& c = r.commands[i];
+    if (const auto* o = std::get_if<NewOrder>(&c))
+    {
+      std::printf("  [%zu] NewOrder id=%llu acct=%llu %s type=%d px=%lld qty=%lld tif=%d stp=%d\n", i,
+                  static_cast<unsigned long long>(o->id),
+                  static_cast<unsigned long long>(o->accountId),
+                  o->side == Side::BUY ? "BUY" : "SELL", static_cast<int>(o->type),
+                  static_cast<long long>(o->price.raw()), static_cast<long long>(o->quantity.raw()),
+                  static_cast<int>(o->tif), static_cast<int>(o->stp));
+    }
+    else if (const auto* x = std::get_if<CancelOrder>(&c))
+    {
+      std::printf("  [%zu] CancelOrder id=%llu\n", i, static_cast<unsigned long long>(x->id));
+    }
+    else if (const auto* m = std::get_if<ModifyOrder>(&c))
+    {
+      std::printf("  [%zu] ModifyOrder id=%llu px=%lld qty=%lld\n", i,
+                  static_cast<unsigned long long>(m->id),
+                  static_cast<long long>(m->newPrice.raw()),
+                  static_cast<long long>(m->newQty.raw()));
+    }
+    else
+    {
+      std::printf("  [%zu] command variant %zu\n", i, c.index());
+    }
+  }
+  std::printf("--- end counterexample ---\n\n");
+}
+
+}  // namespace flox::venue::fuzz

--- a/venue/tests/test_venue_admission.cpp
+++ b/venue/tests/test_venue_admission.cpp
@@ -1,0 +1,351 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+// Admission profiles: what a counterparty is entitled to send.
+//
+// Two roles share one venue and have opposite rights. A counterparty routing
+// flow it manages itself must never leave an order resting here -- an order the
+// engine holds and the sender does not know it owns is a position nobody
+// reconciles, and nothing about it looks wrong until it fills. A quoting
+// counterparty needs exactly the opposite: rest, amend, cancel, repeat.
+//
+// The rights are refused on admission rather than trusted, because an
+// entitlement that is documented and unenforced is the same thing as no
+// entitlement at all.
+
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+#include "flox/book/ladder_book.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <functional>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+const char* g_label = "";
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL [%s] line %d: %s\n", g_label, line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg()
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  return c;
+}
+LadderBook::Config lc() { return LadderBook::Config{0, px(0.01).raw(), 200000, 1 << 16}; }
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+constexpr uint32_t typeBit(OrderType t) { return 1u << static_cast<uint32_t>(t); }
+constexpr uint32_t tifBit(TimeInForce t) { return 1u << static_cast<uint32_t>(t); }
+
+// The profile a counterparty gets when it manages its own order book and only
+// sends what is meant to execute now.
+AdmissionProfile takerOnly()
+{
+  AdmissionProfile p;
+  p.allowedTypes = typeBit(OrderType::LIMIT) | typeBit(OrderType::MARKET);
+  p.allowedTif = tifBit(TimeInForce::IOC) | tifBit(TimeInForce::FOK);
+  p.deny = AdmissionDeny::DenyResting | AdmissionDeny::DenyAmend | AdmissionDeny::DenyCancel |
+           AdmissionDeny::DenyQuote;
+  return p;
+}
+
+struct Cap
+{
+  std::vector<OutboundEvent> ev;
+  EventSink sink()
+  {
+    return [this](const OutboundEvent& e)
+    { ev.push_back(e); };
+  }
+  int rejects(RejectReason r) const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<OrderRejected>(&e); x && x->reason == r)
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  // A refused cancel or replace is its own event, so the assertion names it
+  // and says which request it answered. Counting it as a plain reject would
+  // pass even if the discriminator were wrong.
+  int cancelRejects(RejectReason r, bool wasReplace) const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<CancelRejected>(&e);
+          x && x->reason == r && x->wasReplace == wasReplace)
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+  int trades() const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<Trade>(&e))
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
+};
+
+template <class Book>
+void run(const std::function<Book()>& mk, const char* label)
+{
+  g_label = label;
+  std::printf("== admission book: %s ==\n", label);
+
+  {  // The order that must never happen: a GTC limit from a taker-only
+     // counterparty. Refused on admission, not killed after partially filling,
+     // so no residual can ever reach the book.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setAdmissionProfile(7, takerOnly());
+    eng.submit(InboundCommand{limit(1, Side::BUY, 100, 5, 7)});  // GTC by default
+    CHECK(cap.rejects(RejectReason::RestingNotPermitted) == 1);
+    CHECK(eng.book().empty());
+    CHECK(eng.admissionRejects() == 1);
+  }
+  {  // The same counterparty sending what it is entitled to: IOC executes
+     // against resting liquidity and leaves nothing behind.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setAdmissionProfile(7, takerOnly());
+    eng.submit(InboundCommand{limit(1, Side::SELL, 100, 2, 99)});  // a maker, unprofiled
+    NewOrder take = limit(2, Side::BUY, 100, 5, 7);
+    take.tif = TimeInForce::IOC;
+    eng.submit(InboundCommand{take});
+    CHECK(cap.trades() == 1);
+    CHECK(eng.book().empty());  // the unfilled 3 did not rest
+    CHECK(eng.admissionRejects() == 0);
+  }
+  {  // A conditional order is not in the profile's type set, so it is refused
+     // rather than parked. A stop living in two places at once is the failure
+     // this exists to prevent.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setAdmissionProfile(7, takerOnly());
+    NewOrder stop = limit(1, Side::BUY, 100, 5, 7);
+    stop.type = OrderType::STOP_MARKET;
+    stop.triggerPrice = px(101);
+    stop.tif = TimeInForce::IOC;
+    eng.submit(InboundCommand{stop});
+    CHECK(cap.rejects(RejectReason::OrderTypeNotPermitted) == 1);
+    CHECK(eng.admissionRejects() == 1);
+  }
+  {  // post-only is a request to rest and nothing else.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setAdmissionProfile(7, takerOnly());
+    NewOrder po = limit(1, Side::BUY, 99, 5, 7);
+    po.tif = TimeInForce::IOC;
+    po.postOnly = true;
+    eng.submit(InboundCommand{po});
+    CHECK(cap.rejects(RejectReason::RestingNotPermitted) == 1);
+    CHECK(eng.book().empty());
+  }
+  {  // Amend, cancel and quote are refused for a counterparty that owns none
+     // of those, and each says which right was missing.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setAdmissionProfile(7, takerOnly());
+    eng.submit(InboundCommand{ModifyOrder{1, SYM, px(100), qty(1), 7}});
+    eng.submit(InboundCommand{CancelOrder{1, SYM, 7}});
+    eng.submit(InboundCommand{Quote{10, 11, SYM, px(99), qty(1), px(101), qty(1), 7}});
+    CHECK(cap.cancelRejects(RejectReason::AmendNotPermitted, /*wasReplace*/ true) == 1);
+    CHECK(cap.cancelRejects(RejectReason::CancelNotPermitted, /*wasReplace*/ false) == 1);
+    CHECK(cap.rejects(RejectReason::QuoteNotPermitted) == 1);
+    CHECK(eng.admissionRejects() == 3);
+  }
+  {  // A quoting counterparty is the opposite role and is untouched: it rests,
+     // amends and cancels as before.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    AdmissionProfile mm;
+    mm.allowedTypes = typeBit(OrderType::LIMIT);
+    mm.allowedTif = tifBit(TimeInForce::GTC) | tifBit(TimeInForce::POST_ONLY);
+    eng.setAdmissionProfile(8, mm);
+    eng.submit(InboundCommand{limit(1, Side::BUY, 99, 5, 8)});
+    CHECK(eng.book().find(1) != nullptr);
+    eng.submit(InboundCommand{ModifyOrder{1, SYM, px(98), qty(4), 8}});
+    eng.submit(InboundCommand{CancelOrder{1, SYM, 8}});
+    CHECK(eng.book().empty());
+    CHECK(eng.admissionRejects() == 0);
+  }
+  {  // No profile means no restriction: an engine that was never given one
+     // behaves exactly as it always did.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(InboundCommand{limit(1, Side::BUY, 99, 5, 7)});
+    CHECK(eng.book().find(1) != nullptr);
+    CHECK(eng.admissionRejects() == 0);
+  }
+  {  // A refused order consumes nothing: the clientOrderId it carried is still
+     // free, so the counterparty can correct the message and resend it.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setAdmissionProfile(7, takerOnly());
+    NewOrder bad = limit(1, Side::BUY, 100, 5, 7);
+    bad.clientOrderId = 555;
+    eng.submit(InboundCommand{bad});
+    CHECK(cap.rejects(RejectReason::RestingNotPermitted) == 1);
+    NewOrder good = limit(2, Side::BUY, 100, 5, 7);
+    good.clientOrderId = 555;  // same id, corrected message
+    good.tif = TimeInForce::IOC;
+    eng.submit(InboundCommand{good});
+    CHECK(cap.rejects(RejectReason::DuplicateClientOrderId) == 0);
+  }
+  {  // The profile is engine state and rides the state hash, so two replicas
+     // holding different profiles cannot agree.
+     //
+     // Both engines are fed the same NUMBER of commands at the same
+     // timestamps throughout: the sequencer counter is itself part of the
+     // hash, so a test that let the command counts drift would pass on that
+     // difference alone and prove nothing about the profile.
+    Cap ca, cb;
+    MatchingEngine<Book> a(cfg(), ca.sink(), mk());
+    MatchingEngine<Book> b(cfg(), cb.sink(), mk());
+    CHECK(a.stateHash() == b.stateHash());  // baseline: identical before anything
+
+    a.submit(InboundCommand{SetAdmissionProfile{SYM, 7, takerOnly()}}, 1);
+    b.submit(InboundCommand{SetAdmissionProfile{SYM, 8, takerOnly()}}, 1);
+    CHECK(a.stateHash() != b.stateHash());  // same command count, different state
+
+    // Each learns the other's profile. The table is keyed and sorted, so the
+    // order they arrived in must not matter either.
+    a.submit(InboundCommand{SetAdmissionProfile{SYM, 8, takerOnly()}}, 2);
+    b.submit(InboundCommand{SetAdmissionProfile{SYM, 7, takerOnly()}}, 2);
+    CHECK(a.stateHash() == b.stateHash());
+  }
+  {  // Risk limits arrive as a command, so they survive what a direct setter
+     // does not: a replica that replayed the journal agrees, and a checkpoint
+     // carries them. Only the named limits move.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.setMaxOpenOrders(5);
+    eng.setPositionLimit(qty(100));
+
+    SetRiskLimits r;
+    r.symbol = SYM;
+    r.fields = RiskLimitField::RiskMaxOpenOrders;
+    r.maxOpenOrders = 1;
+    eng.submit(InboundCommand{r});
+
+    // Named limit applied; the one not named is untouched.
+    eng.submit(InboundCommand{limit(1, Side::BUY, 99, 1, 7)});
+    eng.submit(InboundCommand{limit(2, Side::BUY, 98, 1, 7)});
+    CHECK(cap.rejects(RejectReason::TooManyOpenOrders) == 1);
+    CHECK(eng.riskLimits().maxPositionQty == qty(100));
+  }
+  {  // A limit set through the command is part of the state two replicas must
+     // agree on, and it reproduces through a snapshot.
+    Cap ca, cb;
+    MatchingEngine<Book> a(cfg(), ca.sink(), mk());
+    MatchingEngine<Book> b(cfg(), cb.sink(), mk());
+    SetRiskLimits r;
+    r.symbol = SYM;
+    r.fields = RiskLimitField::RiskFatFinger;
+    r.maxOrderQty = qty(3);
+    a.submit(InboundCommand{r}, 1);
+    b.submit(InboundCommand{r}, 1);
+    CHECK(a.riskLimits().maxOrderQty == qty(3));
+    CHECK(b.riskLimits().maxOrderQty == qty(3));
+    a.submit(InboundCommand{limit(1, Side::BUY, 99, 10, 7)});
+    CHECK(ca.rejects(RejectReason::OrderTooLarge) == 1);
+  }
+  {  // Delisting is not a halt and not a closed session: it pulls the resting
+     // book, because there is no open to wait for. New orders earn a reason
+     // that says so rather than one that promises a return.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    eng.submit(InboundCommand{limit(1, Side::BUY, 99, 5, 7)});
+    CHECK(eng.book().find(1) != nullptr);
+
+    eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Delist}});
+    CHECK(eng.delisted());
+    CHECK(eng.tradingStatus() == TradingStatus::Delisted);
+    CHECK(eng.book().empty());  // the book went with it
+
+    eng.submit(InboundCommand{limit(2, Side::BUY, 99, 5, 7)});
+    CHECK(cap.rejects(RejectReason::InstrumentDelisted) == 1);
+
+    // Delisting outranks everything under it: reopening the session does not
+    // make a delisted instrument tradeable.
+    eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::OpenSession}});
+    eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Resume}});
+    CHECK(eng.tradingStatus() == TradingStatus::Delisted);
+    eng.submit(InboundCommand{limit(3, Side::BUY, 99, 5, 7)});
+    CHECK(cap.rejects(RejectReason::InstrumentDelisted) == 2);
+
+    // Reversible: an irreversible operator action is one mistake away from
+    // needing a restart to undo.
+    eng.submit(InboundCommand{AdminCmd{SYM, AdminAction::Relist}});
+    CHECK(eng.tradingStatus() == TradingStatus::Trading);
+    eng.submit(InboundCommand{limit(4, Side::BUY, 99, 5, 7)});
+    CHECK(eng.book().find(4) != nullptr);
+  }
+}
+
+}  // namespace
+
+TEST(Admission, EngineSuite)
+{
+  run<MatchingBook>([]
+                    { return MatchingBook{}; }, "map-reference");
+  run<LadderBook>([]
+                  { return LadderBook{lc()}; }, "ladder-o1");
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_auction.cpp
+++ b/venue/tests/test_venue_auction.cpp
@@ -135,6 +135,95 @@ void run(const std::function<Book()>& mk, const char* label)
   CHECK(eng.book().bestBid() == px(100));
   eng.submit(InboundCommand{limit(5, Side::SELL, 100, 1)}, 4);
   CHECK(cap.tradedQty() == qty(8));  // +1
+
+  {  // An uncross must not print an account against itself. There is no
+     // aggressor in an auction, so the mode is read off each resting order and
+     // applied from its owner's point of view: the counterparty is the
+     // "oldest" leg, the requester's own order is the "newest".
+    Cap c2;
+    MatchingEngine<Book> e2(cfg(), c2.sink(), mk());
+    e2.beginPreOpen();
+    NewOrder b = limit(11, Side::BUY, 100, 5);
+    b.accountId = 42;
+    b.stp = STPMode::CancelOldest;  // kill the counterparty, keep mine
+    NewOrder a = limit(12, Side::SELL, 100, 5);
+    a.accountId = 42;
+    e2.submit(InboundCommand{b}, 0);
+    e2.submit(InboundCommand{a}, 1);
+    e2.openContinuous();
+    CHECK(c2.trades() == 0);               // no wash print
+    CHECK(e2.book().find(12) == nullptr);  // counterparty pulled
+    CHECK(e2.book().find(11) != nullptr);  // requester survives
+  }
+  {  // CancelNewest from the requester pulls its own order and leaves the
+     // counterparty resting.
+    Cap c2;
+    MatchingEngine<Book> e2(cfg(), c2.sink(), mk());
+    e2.beginPreOpen();
+    NewOrder b = limit(11, Side::BUY, 100, 5);
+    b.accountId = 42;
+    b.stp = STPMode::CancelNewest;
+    NewOrder a = limit(12, Side::SELL, 100, 5);
+    a.accountId = 42;
+    e2.submit(InboundCommand{b}, 0);
+    e2.submit(InboundCommand{a}, 1);
+    e2.openContinuous();
+    CHECK(c2.trades() == 0);
+    CHECK(e2.book().find(11) == nullptr);
+    CHECK(e2.book().find(12) != nullptr);
+  }
+  {  // Decrement trims both legs by the overlap; the larger leg keeps its
+     // remainder and a stranger can still trade with it.
+    Cap c2;
+    MatchingEngine<Book> e2(cfg(), c2.sink(), mk());
+    e2.beginPreOpen();
+    NewOrder b = limit(11, Side::BUY, 100, 5);
+    b.accountId = 42;
+    b.stp = STPMode::Decrement;
+    NewOrder a = limit(12, Side::SELL, 100, 2);
+    a.accountId = 42;
+    e2.submit(InboundCommand{b}, 0);
+    e2.submit(InboundCommand{a}, 1);
+    e2.openContinuous();
+    CHECK(c2.trades() == 0);
+    CHECK(e2.book().find(12) == nullptr);         // smaller leg gone
+    CHECK(e2.book().find(11)->leaves == qty(3));  // 5 - 2 left resting
+  }
+  {  // Two different accounts of one firm are the same trader for this
+     // purpose, and an order with no mode still prints normally.
+    Cap c2;
+    MatchingEngine<Book> e2(cfg(), c2.sink(), mk());
+    e2.setStpGroup(42, 900);
+    e2.setStpGroup(43, 900);
+    e2.beginPreOpen();
+    NewOrder b = limit(11, Side::BUY, 100, 5);
+    b.accountId = 42;
+    b.stp = STPMode::CancelOldest;
+    NewOrder a = limit(12, Side::SELL, 100, 5);
+    a.accountId = 43;  // same firm
+    NewOrder a2 = limit(13, Side::SELL, 100, 5);
+    a2.accountId = 77;  // a stranger
+    e2.submit(InboundCommand{b}, 0);
+    e2.submit(InboundCommand{a}, 1);
+    e2.submit(InboundCommand{a2}, 2);
+    e2.openContinuous();
+    CHECK(e2.book().find(12) == nullptr);  // same-firm leg pulled
+    CHECK(c2.tradedQty() == qty(5));       // the stranger fills instead
+  }
+  {  // Without a mode nothing changes: an account that never asked for
+     // prevention still crosses itself, exactly as continuous trading does.
+    Cap c2;
+    MatchingEngine<Book> e2(cfg(), c2.sink(), mk());
+    e2.beginPreOpen();
+    NewOrder b = limit(11, Side::BUY, 100, 5);
+    b.accountId = 42;
+    NewOrder a = limit(12, Side::SELL, 100, 5);
+    a.accountId = 42;
+    e2.submit(InboundCommand{b}, 0);
+    e2.submit(InboundCommand{a}, 1);
+    e2.openContinuous();
+    CHECK(c2.tradedQty() == qty(5));
+  }
 }
 
 }  // namespace

--- a/venue/tests/test_venue_checkpoint.cpp
+++ b/venue/tests/test_venue_checkpoint.cpp
@@ -1606,3 +1606,61 @@ TEST(VenueCheckpoint, CrashBeforeSnapshotPublishRecoversViaPreviousGeneration)
   std::error_code ec;
   fs::remove(snapB + ".tmp", ec);
 }
+
+// Falling back a generation is unbounded; what pruning keeps is not. Two
+// checkpoints delete the pre-checkpoint journal, so once neither retained
+// snapshot validates there is nothing left covering history before the first
+// checkpoint. Replaying only the surviving segments would rebuild a state that
+// looks fine and is missing its opening balance, so recovery must refuse.
+//
+// This is the state the recovery model in scripts/check_recovery_model.py
+// reaches in four steps; the guard is what makes that state unreachable at
+// runtime rather than merely unlikely.
+TEST(VenueCheckpoint, RefusesToStartWhenNoGenerationCanCoverHistory)
+{
+  const std::string base = "/tmp/flox_test_venue_checkpoint_exhausted.bin";
+  cleanFiles(base);
+
+  venue::SymbolConfig c = cfg();
+  Ledger led1;
+  auto t1 = clockState(1'000'000);
+  {
+    // The shard carries its ingress/outbound rings inline; it lives on the
+    // heap here for the same reason every other shard in this file does.
+    auto s1 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                                 clockOf(t1));
+    s1->engine().setLedger(&led1, VENUE_ACCT);
+    s1->start();
+    s1->submit(InboundCommand{Deposit{1, BASE, baseRaw(100), SYM}});
+    s1->submit(InboundCommand{Deposit{2, QUOTE, quoteRaw(10000), SYM}});
+    s1->submit(InboundCommand{limit(1, Side::SELL, 100.00, 2.0, 1)});
+    ASSERT_TRUE(s1->checkpointNow());  // generation A
+    s1->submit(InboundCommand{limit(2, Side::BUY, 99.00, 1.0, 2)});
+    ASSERT_TRUE(s1->checkpointNow());  // generation B -- prune drops the legacy file
+    s1->flush();
+    s1->stop();
+  }
+
+  const auto gens = SequencedShard<>::scanGenerations(base);
+  ASSERT_EQ(gens.snapshots.size(), 2u);
+  // The default retention deletes the pre-checkpoint journal at the second
+  // generation. That is the file the no-valid-snapshot path replays.
+  ASSERT_FALSE(std::filesystem::exists(base));
+
+  // Both retained snapshots stop validating -- what a state-hash or format
+  // change does to every generation at once, not a one-off torn write.
+  for (int64_t ts : gens.snapshots)
+  {
+    std::ofstream out(SequencedShard<>::snapshotPath(base, ts),
+                      std::ios::binary | std::ios::trunc);
+    out << "not a snapshot";
+  }
+
+  Ledger led2;
+  auto t2 = clockState(9'000'000);
+  auto s2 = std::make_unique<SequencedShard<>>(c, base, MatchingBook{}, Journal::Sync::Off,
+                                               clockOf(t2));
+  s2->engine().setLedger(&led2, VENUE_ACCT);
+  EXPECT_THROW(s2->start(), std::runtime_error);
+  EXPECT_FALSE(s2->ready());
+}

--- a/venue/tests/test_venue_conservation_fuzz.cpp
+++ b/venue/tests/test_venue_conservation_fuzz.cpp
@@ -225,9 +225,12 @@ void test_spot_conservation()
 // Last-look lifecycle under the conservation invariant: a slice of the flow is
 // lastLook makers, and holds resolve through every path -- explicit accepts,
 // explicit rejects, wrong-owner decision attempts, timeout (acceptOnTimeout
-// exercises the timeout-accept settle), and cancel-while-held during the
-// drain. Money must never be created or destroyed, and after the drain every
-// reservation (including restored held slices) must return to zero.
+// exercises the timeout-accept settle), cancel-while-held during the drain, and
+// SELF-TRADE PREVENTION removing a maker that has a hold open (T028: the one
+// removal path that lives inside the matcher, where a cancel that ignored the
+// hold used to free the collateral the later accept had to settle from). Money
+// must never be created or destroyed, and after the drain every reservation
+// (including restored held slices) must return to zero.
 void test_spot_conservation_lastlook()
 {
   std::printf("test_spot_conservation_lastlook\n");
@@ -252,13 +255,34 @@ void test_spot_conservation_lastlook()
   std::unordered_map<OrderId, uint64_t> acctOf;
   std::vector<std::pair<uint64_t, uint64_t>> pendingHolds;  // (heldId, makerAccount)
   uint64_t totalHolds = 0;
-  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
-                                   {
-                                     if (const auto* h = std::get_if<FillHeld>(&e))
-                                     {
-                                       ++totalHolds;
-                                       pendingHolds.emplace_back(h->heldId, acctOf[h->makerId]);
-                                     } });
+  uint64_t stpCancels = 0;
+  uint64_t stpCancelsOnHeldMaker = 0;  // T028 coverage: STP pulled a maker mid-hold
+  OrderId lastRejectedMaker = 0;
+  MatchingEngine<MatchingBook> eng(
+      c,
+      [&](const OutboundEvent& e)
+      {
+        if (const auto* h = std::get_if<FillHeld>(&e))
+        {
+          ++totalHolds;
+          pendingHolds.emplace_back(h->heldId, acctOf[h->makerId]);
+        }
+        else if (const auto* fr = std::get_if<FillRejected>(&e))
+        {
+          lastRejectedMaker = fr->makerId;  // a hold on this maker just resolved
+        }
+        else if (const auto* oc = std::get_if<OrderCanceled>(&e);
+                 oc != nullptr && oc->reason == CancelReason::SelfTradePrevention)
+        {
+          ++stpCancels;
+          // The STP path resolves the maker's holds immediately before pulling
+          // it, so this pairing is exactly the interaction under test.
+          if (oc->id == lastRejectedMaker)
+          {
+            ++stpCancelsOnHeldMaker;
+          }
+        }
+      });
   flox::FeeSchedule fs;
   fs.addTier(0.0, -1.0, 2.0);
   eng.setFeeSchedule(fs);
@@ -326,6 +350,30 @@ void test_spot_conservation_lastlook()
           o.tif = TimeInForce::FOK;  // FOK never executes into last-look range
         }
       }
+      // Self-trade prevention on a slice of the aggressive flow, ON TOP of the
+      // last-look makers above: with 8 accounts an aggressor regularly crosses
+      // its own quote, so the matcher's own cancel path meets held makers. All
+      // four modes, since each removes or reshapes the maker differently.
+      if (!o.lastLook)
+      {
+        switch (static_cast<uint32_t>((r >> 56) % 8))
+        {
+          case 0:
+            o.stp = STPMode::CancelOldest;
+            break;
+          case 1:
+            o.stp = STPMode::CancelNewest;
+            break;
+          case 2:
+            o.stp = STPMode::CancelBoth;
+            break;
+          case 3:
+            o.stp = STPMode::Decrement;
+            break;
+          default:
+            break;  // the rest trade through their own quotes as before
+        }
+      }
       acctOf[o.id] = o.accountId;
       eng.submit(InboundCommand{o}, i);
     }
@@ -357,11 +405,16 @@ void test_spot_conservation_lastlook()
     }
   }
   CHECK(reservedLeaks == 0);
-  CHECK(totalHolds > 1000);  // coverage guard: the scenario really exercised holds
+  CHECK(eng.unsettledTrades() == 0);  // no fill ever reached clearing unbacked
+  CHECK(totalHolds > 1000);           // coverage guard: the scenario really exercised holds
+  CHECK(stpCancels > 100);            // ... and that STP really fired alongside them
+  CHECK(stpCancelsOnHeldMaker > 0);   // ... including on makers with a live hold (T028)
   std::printf(
       "  100000 ops, %llu holds (accept/reject/wrong-owner/timeout-accept/cancel-while-held), "
-      "base/quote conserved (%d breaches); reserved drained clean (%d leaks)\n",
-      static_cast<unsigned long long>(totalHolds), breaches, reservedLeaks);
+      "%llu STP cancels (%llu on a held maker), base/quote conserved (%d breaches); reserved "
+      "drained clean (%d leaks)\n",
+      static_cast<unsigned long long>(totalHolds), static_cast<unsigned long long>(stpCancels),
+      static_cast<unsigned long long>(stpCancelsOnHeldMaker), breaches, reservedLeaks);
 }
 
 void test_perp_conservation(bool adl)
@@ -392,6 +445,7 @@ void test_perp_conservation(bool adl)
   c.initialMarginBps = 1000;
   c.maintenanceMarginBps = 500;
   c.autoDeleverage = adl;
+  c.maxPositionQty = qty(20);  // the cap must bind the RESULTING position (T030)
   MatchingEngine<MatchingBook> eng(c, [](const OutboundEvent&) {});
   eng.setLedger(&led, VENUE);
 
@@ -410,6 +464,7 @@ void test_perp_conservation(bool adl)
   const int64_t midRaw = px(100).raw();
   const int64_t tickRaw = px(0.01).raw();
   int breaches = 0;
+  int capBreaches = 0;
   OrderId nextId = 1;
   for (int i = 0; i < 100000; ++i)
   {
@@ -435,6 +490,30 @@ void test_perp_conservation(bool adl)
       const int ticks = static_cast<int>((r >> 1) % 61) - 30;
       o.price = Price::fromRaw(midRaw + static_cast<int64_t>(ticks) * tickRaw);
       o.quantity = qty(1.0 + static_cast<double>((r >> 20) % 5));
+      // Unpriced flow: a perp market/stop order is margined against the price
+      // BAND, not its own price, and the band bound must be the same on both
+      // sides (T029) -- a LIMIT-only fuzz never touches that arithmetic.
+      const uint32_t t = static_cast<uint32_t>((r >> 32) % 100);
+      if (t < 15)
+      {
+        o.type = OrderType::MARKET;
+      }
+      else if (t < 25)
+      {
+        o.type = OrderType::STOP_MARKET;
+        const int tt = static_cast<int>((r >> 40) % 61) - 30;
+        o.triggerPrice = Price::fromRaw(midRaw + static_cast<int64_t>(tt) * tickRaw);
+      }
+      else if (t < 32)
+      {
+        o.type = OrderType::STOP_LIMIT;
+        const int tt = static_cast<int>((r >> 40) % 61) - 30;
+        o.triggerPrice = Price::fromRaw(midRaw + static_cast<int64_t>(tt) * tickRaw);
+      }
+      // Reduce-only flow: capped at admission, re-measured at fill time. It
+      // reserves no margin, so a slice of it that opened a position would open
+      // one with none (T030).
+      o.reduceOnly = ((r >> 48) % 100) < 20;
       eng.submit(InboundCommand{o}, i);
     }
     if (sumQuote() != initQuote)
@@ -445,8 +524,25 @@ void test_perp_conservation(bool adl)
         std::printf("  first breach at op %d\n", i);
       }
     }
+    // The position cap binds the RESULT, not just the incoming order: no
+    // account may ever be carried past it by fills.
+    for (int a = 1; a <= NACCT; ++a)
+    {
+      const int64_t q = eng.positionQty(a);
+      if ((q < 0 ? -q : q) > qty(20).raw())
+      {
+        ++capBreaches;
+        if (capBreaches == 1)
+        {
+          std::printf("  first position-cap breach at op %d (acct %d, qty %lld)\n", i, a,
+                      static_cast<long long>(q));
+        }
+      }
+    }
   }
   CHECK(breaches == 0);
+  CHECK(capBreaches == 0);
+  CHECK(eng.unsettledTrades() == 0);
 
   // Perp reserved-invariant: drain resting orders, then every reserved quote
   // unit must be backed by an open position's posted margin -- no IM leak.
@@ -461,9 +557,9 @@ void test_perp_conservation(bool adl)
   }
   CHECK(reservedSum == eng.totalPositionMargin());
   std::printf(
-      "  100000 ops (orders+marks+liquidations), collateral conserved (%d breaches); "
-      "reserved==position-margin (%s)\n",
-      breaches, reservedSum == eng.totalPositionMargin() ? "ok" : "LEAK");
+      "  100000 ops (limit+market+stop+reduce-only orders, marks, liquidations), collateral "
+      "conserved (%d breaches); position cap held (%d breaches); reserved==position-margin (%s)\n",
+      breaches, capBreaches, reservedSum == eng.totalPositionMargin() ? "ok" : "LEAK");
 }
 
 void test_cross_margin_conservation()

--- a/venue/tests/test_venue_control_plane.cpp
+++ b/venue/tests/test_venue_control_plane.cpp
@@ -170,6 +170,28 @@ TEST(ControlPlane, EngineSuite)
   CHECK(has(api2.handle(R"({"method":"setStpGroup","symbol":42,"account":11,"group":77})"),
             "unknown_symbol"));
 
+  // setAdmissionProfile: entitlements ride the same sequenced stream, so a
+  // right granted by an operator survives a restart instead of living only in
+  // the process that granted it.
+  CHECK(has(api2.handle(
+                R"({"method":"setAdmissionProfile","symbol":7,"account":11,"allowedTif":6,"denyResting":true})"),
+            "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"setAdmissionProfile","symbol":42,"account":11})"),
+            "unknown_symbol"));
+
+  // setRiskLimits: only the limits named in the request are carried, so an
+  // operator raising one cannot silently zero another by omission.
+  CHECK(has(api2.handle(R"({"method":"setRiskLimits","symbol":7,"maxOpenOrders":25})"),
+            "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"setRiskLimits","symbol":7})"), "no_limits_named"));
+  CHECK(has(api2.handle(R"({"method":"setRiskLimits","symbol":42,"maxOpenOrders":1})"),
+            "unknown_symbol"));
+
+  // delist: withdrawal from trading, forwarded as an AdminCmd like the halt
+  // and the session boundary.
+  CHECK(has(api2.handle(R"({"method":"delist","symbol":7,"delisted":true})"), "\"ok\":true"));
+  CHECK(has(api2.handle(R"({"method":"delist","symbol":42,"delisted":true})"), "unknown_symbol"));
+
   // session / setFundingSchedule: the operator's schedule surface. The engine
   // owns the state; the CALENDAR lives out here, and both transitions ride the
   // sequenced stream so they journal, snapshot and replay.
@@ -181,7 +203,7 @@ TEST(ControlPlane, EngineSuite)
   CHECK(has(api2.handle(R"({"method":"setFundingSchedule","symbol":42,"intervalNs":1,"nextFundingNs":2})"),
             "unknown_symbol"));
 
-  CHECK(forwarded.size() == 7);  // failed halt / setTriggerRef / snapshotNow forwarded nothing
+  CHECK(forwarded.size() == 10);  // failed halt / setTriggerRef / snapshotNow forwarded nothing
   CHECK(std::get_if<ListInstrument>(&forwarded[0]) != nullptr);
   CHECK(std::get_if<SetBands>(&forwarded[1]) != nullptr);
   const auto* trigCmd = std::get_if<SetTriggerRef>(&forwarded[2]);
@@ -190,10 +212,22 @@ TEST(ControlPlane, EngineSuite)
   CHECK(haltCmd != nullptr && haltCmd->action == AdminAction::Halt && haltCmd->symbol == 7);
   const auto* stpCmd = std::get_if<SetStpGroup>(&forwarded[4]);
   CHECK(stpCmd != nullptr && stpCmd->symbol == 7 && stpCmd->account == 11 && stpCmd->group == 77);
-  const auto* closeCmd = std::get_if<AdminCmd>(&forwarded[5]);
+  const auto* admCmd = std::get_if<SetAdmissionProfile>(&forwarded[5]);
+  CHECK(admCmd != nullptr && admCmd->symbol == 7 && admCmd->account == 11);
+  // allowedTif 6 = bits for IOC(1) and FOK(2); resting denied, the rest open.
+  CHECK(admCmd != nullptr && admCmd->profile.allowedTif == 6 &&
+        admCmd->profile.allowedTypes == 0 &&
+        (admCmd->profile.deny & AdmissionDeny::DenyResting) != 0 &&
+        (admCmd->profile.deny & AdmissionDeny::DenyAmend) == 0);
+  const auto* riskCmd = std::get_if<SetRiskLimits>(&forwarded[6]);
+  CHECK(riskCmd != nullptr && riskCmd->symbol == 7 && riskCmd->maxOpenOrders == 25 &&
+        riskCmd->fields == RiskLimitField::RiskMaxOpenOrders);
+  const auto* delistCmd = std::get_if<AdminCmd>(&forwarded[7]);
+  CHECK(delistCmd != nullptr && delistCmd->action == AdminAction::Delist);
+  const auto* closeCmd = std::get_if<AdminCmd>(&forwarded[8]);
   CHECK(closeCmd != nullptr && closeCmd->action == AdminAction::CloseSession &&
         closeCmd->symbol == 7);
-  const auto* fundCmd = std::get_if<SetFundingSchedule>(&forwarded[6]);
+  const auto* fundCmd = std::get_if<SetFundingSchedule>(&forwarded[9]);
   CHECK(fundCmd != nullptr && fundCmd->symbol == 7 && fundCmd->intervalNs == 28'800'000'000'000LL &&
         fundCmd->nextFundingNs == 100);
 

--- a/venue/tests/test_venue_differential_fuzz.cpp
+++ b/venue/tests/test_venue_differential_fuzz.cpp
@@ -22,6 +22,7 @@
 #include "flox-venue/matching_book.h"
 #include "flox-venue/matching_engine.h"
 #include "flox/book/ladder_book.h"
+#include "support/counterexample.h"
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -150,6 +151,41 @@ InboundCommand genCommand(uint64_t& s, uint64_t seq, OrderId& nextId)
 }
 
 int g_failures = 0;
+
+// Pure replay used by the minimiser: fresh engines every time, same three
+// comparisons as the live loop. Nothing is carried over between calls.
+bool diverges(const std::vector<InboundCommand>& cmds)
+{
+  uint64_t hRef = 1469598103934665603ULL;
+  uint64_t hLad = hRef;
+  std::vector<OutboundEvent> evRef;
+  std::vector<OutboundEvent> evLad;
+  MatchingEngine<MatchingBook> refE(cfg(), [&](const OutboundEvent& e)
+                                    { evRef.push_back(e); });
+  MatchingEngine<LadderBook> ladE(cfg(), [&](const OutboundEvent& e)
+                                  { evLad.push_back(e); }, LadderBook{ladderCfg()});
+  for (const InboundCommand& cmd : cmds)
+  {
+    evRef.clear();
+    evLad.clear();
+    refE.submit(cmd);
+    ladE.submit(cmd);
+    if (evRef.size() != evLad.size())
+    {
+      return true;
+    }
+    for (size_t k = 0; k < evRef.size(); ++k)
+    {
+      hRef = hashEvent(hRef, evRef[k]);
+      hLad = hashEvent(hLad, evLad[k]);
+    }
+    if (hRef != hLad || crossed(refE.book()) || crossed(ladE.book()))
+    {
+      return true;
+    }
+  }
+  return false;
+}
 }  // namespace
 
 TEST(VenueDifferentialFuzz, LadderMatchesReferenceBook)
@@ -169,9 +205,15 @@ TEST(VenueDifferentialFuzz, LadderMatchesReferenceBook)
   uint64_t s = 0xC0FFEE123456789ULL;
   OrderId nextId = 1;
 
+  // The stream is recorded so a failure can be handed over minimised instead
+  // of as an index into 200k commands.
+  std::vector<InboundCommand> stream;
+  stream.reserve(N);
+
   for (uint64_t i = 0; i < N; ++i)
   {
     const InboundCommand cmd = genCommand(s, i, nextId);
+    stream.push_back(cmd);
     evRef.clear();
     evLad.clear();
     refE.submit(cmd);
@@ -209,6 +251,63 @@ TEST(VenueDifferentialFuzz, LadderMatchesReferenceBook)
                 static_cast<unsigned long long>(N));
     std::printf("final event-stream hash: %016llx\n", static_cast<unsigned long long>(hRef));
   }
+  else
+  {
+    const auto report = fuzz::shrinkCounterexample(stream, diverges);
+    fuzz::printCounterexample(report);
+  }
 
   EXPECT_EQ(g_failures, 0);
+}
+
+// The minimiser is only exercised when the fuzz fails, which is exactly when
+// nobody wants to discover it does not work. This drives it against a
+// synthetic predicate with a known-minimal witness: a stream fails when it
+// holds both a SELL and a modify, so the smallest failing stream is those two
+// commands and nothing else.
+TEST(VenueDifferentialFuzz, MinimiserReducesToTheWitness)
+{
+  std::vector<InboundCommand> stream;
+  for (int i = 0; i < 500; ++i)
+  {
+    NewOrder o;
+    o.id = static_cast<OrderId>(i + 1);
+    o.symbol = SYM;
+    o.side = (i == 137) ? Side::SELL : Side::BUY;
+    o.type = OrderType::LIMIT;
+    o.price = Price::fromDouble(99.0);
+    o.quantity = Quantity::fromDouble(1.0);
+    o.accountId = 1;
+    stream.push_back(InboundCommand{o});
+    if (i == 400)
+    {
+      stream.push_back(InboundCommand{ModifyOrder{1, SYM, Price::fromDouble(98.0),
+                                                  Quantity::fromDouble(2.0), 0}});
+    }
+  }
+
+  auto witnessPresent = [](const std::vector<InboundCommand>& cmds)
+  {
+    bool sell = false, modify = false;
+    for (const auto& c : cmds)
+    {
+      if (const auto* o = std::get_if<NewOrder>(&c); o && o->side == Side::SELL)
+      {
+        sell = true;
+      }
+      if (std::get_if<ModifyOrder>(&c) != nullptr)
+      {
+        modify = true;
+      }
+    }
+    return sell && modify;
+  };
+
+  ASSERT_TRUE(witnessPresent(stream));
+  const auto report = fuzz::shrinkCounterexample(stream, witnessPresent);
+
+  EXPECT_TRUE(witnessPresent(report.commands)) << "minimiser lost the failure it was shrinking";
+  EXPECT_EQ(report.commands.size(), 2u) << "did not reach the two-command witness";
+  EXPECT_GT(report.replays, 0) << "minimiser never replayed anything";
+  EXPECT_LT(report.replays, 400) << "hit the replay cap on a 501-command stream";
 }

--- a/venue/tests/test_venue_fix_session.cpp
+++ b/venue/tests/test_venue_fix_session.cpp
@@ -251,6 +251,29 @@ struct FixClient
     send(FixCodec::frame(b));
   }
 
+  // 35=F OrderCancelRequest / 35=G OrderCancelReplaceRequest.
+  void cancelOrReplace(const char* type, uint64_t id, const char* side, const char* price,
+                       const char* quantity)
+  {
+    const uint64_t s = seq++;
+    std::string b;
+    auto add = [&](int t, const std::string& v)
+    { b += std::to_string(t) + "=" + v + std::string(1, FixCodec::SOH); };
+    add(35, type);
+    add(34, std::to_string(s));
+    add(49, "CLIENT");
+    add(56, "VENUE");
+    add(52, FixSession::sendingTime(wallClockNs()));
+    add(41, std::to_string(id));  // OrigClOrdID
+    add(11, std::to_string(id));
+    add(55, "1");
+    add(54, side);
+    add(38, quantity);
+    add(44, price);
+    add(40, "2");
+    send(FixCodec::frame(b));
+  }
+
   bool read(Fields& f)
   {
     std::vector<uint8_t> frame;
@@ -620,9 +643,64 @@ void test_restart_with_sidecar()
   std::remove(sidecar.c_str());
 }
 
-// (8) Unknown MsgType: consumed in sequence and answered with a session
-// Reject (35=3, 45=RefSeqNum, 372=RefMsgType); the session stays alive and
-// application flow continues.
+// (8b) A refused cancel or cancel/replace is answered with OrderCancelReject
+// (35=9), not an execution report. An exec report describes the state of an
+// ORDER, and a refused cancel changed no order state at all -- a counterparty
+// that reconciles on exec reports would record a state transition that never
+// happened, or leave the order hanging in its own book waiting for one.
+//
+// CxlRejResponseTo (434) says which request was refused, and it has to come
+// off the event rather than off session context: a ResendRequest re-encodes
+// from the log long after the context is gone, and a replayed message that
+// changes type is a protocol violation precisely when the counterparty is
+// recovering.
+void test_cancel_reject_is_35_9()
+{
+  std::printf("test_cancel_reject_is_35_9\n");
+  Venue v;
+  auto gw = v.gateway(1);
+  const int port = gw->start(0, v.handler());
+  CHECK(port > 0);
+
+  FixClient c;
+  CHECK(c.connectTo(port));
+  c.admin("A", {{108, "30"}, {141, "Y"}});
+  Fields f;
+  CHECK(c.readType("A", f));
+
+  c.cancelOrReplace("F", 777, "1", "100", "1");  // cancel an order that never existed
+  CHECK(c.readType("9", f));
+  CHECK(u64f(f, 37) == 777);
+  CHECK(f[434] == "1");  // CxlRejResponseTo: Order Cancel Request
+  CHECK(f[102] == "1");  // CxlRejReason: Unknown order
+  CHECK(f[39] == "8");   // OrdStatus: Rejected -- we never had it
+  CHECK(f.count(58) != 0);
+
+  c.cancelOrReplace("G", 778, "1", "100", "1");  // replace one that never existed
+  CHECK(c.readType("9", f));
+  CHECK(u64f(f, 37) == 778);
+  CHECK(f[434] == "2");  // CxlRejResponseTo: Order Cancel/Replace Request
+
+  c.order(40, "2", "100", "1");  // the session is healthy through both
+  CHECK(c.readType("8", f));
+  CHECK(u64f(f, 37) == 40 && f[150] == "0");
+
+  c.close();
+  gw->stop();
+}
+
+// (8) An unhandled MsgType is consumed in sequence and answered, and WHICH
+// answer it gets is itself part of the contract.
+//
+// A well-formed application message this venue does not implement earns a
+// BusinessMessageReject (35=j, BusinessRejectReason=3): the session is
+// healthy, the capability is declined. A session-level Reject would blame the
+// session for our own missing feature, and counterparties count those against
+// session health.
+//
+// Something that is not a FIX message type at all is a different failure and
+// still earns 35=3 with SessionRejectReason=11 -- it is a parsing problem, not
+// a declined capability, and dressing it up as one would hide a framing bug.
 void test_session_reject_unknown_type()
 {
   std::printf("test_session_reject_unknown_type\n");
@@ -637,13 +715,19 @@ void test_session_reject_unknown_type()
   Fields f;
   CHECK(c.readType("A", f));
 
-  c.admin("B", {{58, "hello"}});  // News: not in the supported set
-  CHECK(c.readType("3", f));
+  c.admin("B", {{58, "hello"}});  // News: a real application type, unsupported
+  CHECK(c.readType("j", f));
   CHECK(u64f(f, 45) == 2);  // RefSeqNum of the offending message
   CHECK(f[372] == "B");     // RefMsgType
+  CHECK(f[380] == "3");     // BusinessRejectReason: Unsupported Message Type
   CHECK(f.count(58) != 0);
 
-  c.order(40, "2", "100", "1");  // the session survived the reject
+  c.admin("%%", {{58, "garbage"}});  // not a FIX message type at all
+  CHECK(c.readType("3", f));
+  CHECK(u64f(f, 45) == 3);
+  CHECK(f[373] == "11");  // SessionRejectReason: Invalid MsgType
+
+  c.order(40, "2", "100", "1");  // the session survived both rejects
   CHECK(c.readType("8", f));
   CHECK(u64f(f, 37) == 40 && f[150] == "0");
 
@@ -912,6 +996,7 @@ TEST(FixSessionLayer, EngineSuite)
   test_restart_requires_reset();
   test_restart_with_sidecar();
   test_session_reject_unknown_type();
+  test_cancel_reject_is_35_9();
   test_cod_negotiation();
   test_ws_fix_logon_trade_heartbeat_resend();
   std::printf("\n%d checks, %d failures\n", g_checks, g_failures);

--- a/venue/tests/test_venue_gate_coverage.cpp
+++ b/venue/tests/test_venue_gate_coverage.cpp
@@ -1,0 +1,440 @@
+/*
+ * Flox Engine
+ * Developed by FLOX Foundation (https://github.com/FLOX-Foundation)
+ *
+ * Copyright (c) 2025 FLOX Foundation
+ * Licensed under the MIT License. See LICENSE file in the project root for full
+ * license information.
+ */
+
+/*
+ * Gate coverage: no order reaches the book, and no trade prints, without the
+ * gates that are supposed to guard it.
+ *
+ * Three defects of one shape were found by hand in this module: the credit hook
+ * was never called on a funded path (both money branches returned first), the
+ * reservation-trim hook only fired on instruments that enable last look, and
+ * reduce-only was checked at submit and never at fill. Each was a mechanism
+ * applied on some paths and skipped on others, and no test noticed because the
+ * tests followed paths, not mechanisms.
+ *
+ * Listing paths would only pin the ones that exist today. These tests assert a
+ * PROPERTY instead -- every admitted order was authorized, every printed trade
+ * was risk-checked -- so a path added tomorrow that forgets a gate fails here
+ * without anyone remembering to extend a list.
+ */
+#include "flox-venue/matching_book.h"
+#include "flox-venue/matching_engine.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <functional>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace flox;
+using namespace flox::venue;
+
+namespace
+{
+int g_failures = 0;
+int g_checks = 0;
+void check(bool ok, const char* e, int line)
+{
+  ++g_checks;
+  if (!ok)
+  {
+    ++g_failures;
+    std::printf("  FAIL line %d: %s\n", line, e);
+  }
+}
+#define CHECK(x) check((x), #x, __LINE__)
+
+constexpr SymbolId SYM = 1;
+constexpr AssetId BASE = 0;
+constexpr AssetId QUOTE = 1;
+constexpr uint64_t VENUE = 999;
+using Eng = MatchingEngine<MatchingBook>;
+
+Price px(double v) { return Price::fromDouble(v); }
+Quantity qty(double v) { return Quantity::fromDouble(v); }
+
+SymbolConfig cfg(bool perp = false)
+{
+  SymbolConfig c;
+  c.id = SYM;
+  c.tickSize = px(0.01);
+  c.minPrice = px(1.0);
+  c.maxPrice = px(1000.0);
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  if (perp)
+  {
+    c.linearPerp = true;
+    c.initialMarginBps = 1000;
+  }
+  return c;
+}
+
+NewOrder limit(OrderId id, Side s, double p, double q, uint64_t acct)
+{
+  NewOrder o;
+  o.id = id;
+  o.symbol = SYM;
+  o.side = s;
+  o.type = OrderType::LIMIT;
+  o.price = px(p);
+  o.quantity = qty(q);
+  o.accountId = acct;
+  return o;
+}
+
+// Records which orders the risk owner was asked about.
+struct Authorizer
+{
+  std::set<OrderId> asked;
+  Eng::CreditCheck hook()
+  {
+    return [this](const Eng::CreditRequest& r) -> Eng::CreditDecision
+    {
+      asked.insert(r.order);
+      return {true, RejectReason::None};
+    };
+  }
+};
+
+// Every id that ended up resting on the book.
+std::vector<OrderId> restingIds(const Eng& eng)
+{
+  std::vector<OrderId> out;
+  eng.book().forEachOrder([&](const RestingOrder& r)
+                          { out.push_back(r.id); });
+  return out;
+}
+
+// ---- property 1: every admission asks permission, every time ---------------
+//
+// The naive form of this ("every id resting was authorized at some point")
+// does not hold anyone honest: a modify re-enters an id that was authorized on
+// submit, so a modify path that skips the gate still passes. The authorizer is
+// therefore cleared before each step and each step must ask on its own.
+
+struct PathCase
+{
+  const char* name;
+  OrderId expect;  // the id the gate must be asked about
+  std::function<void(Eng&, int64_t)> run;
+};
+
+void test_every_admission_asks_permission()
+{
+  std::printf("test_every_admission_asks_permission\n");
+
+  const std::vector<PathCase> paths = {
+      {"limit", 10, [](Eng& e, int64_t ts)
+       { e.submit(InboundCommand{limit(10, Side::BUY, 100, 5, 1)}, ts); }},
+      {"post-only", 11,
+       [](Eng& e, int64_t ts)
+       {
+         NewOrder o = limit(11, Side::BUY, 99, 5, 1);
+         o.tif = TimeInForce::POST_ONLY;
+         e.submit(InboundCommand{o}, ts);
+       }},
+      {"iceberg", 12,
+       [](Eng& e, int64_t ts)
+       {
+         NewOrder o = limit(12, Side::BUY, 98, 10, 1);
+         o.type = OrderType::ICEBERG;
+         o.visibleQuantity = qty(2);
+         e.submit(InboundCommand{o}, ts);
+       }},
+      {"peg", 13,
+       [](Eng& e, int64_t ts)
+       {
+         NewOrder o = limit(13, Side::BUY, 97, 3, 1);
+         o.peg = PegRef::Bid;
+         e.submit(InboundCommand{o}, ts);
+       }},
+      {"quote bid leg", 14,
+       [](Eng& e, int64_t ts)
+       {
+         Quote q{};
+         q.bidId = 14;
+         q.askId = 15;
+         q.symbol = SYM;
+         q.bidPrice = px(96);
+         q.bidQty = qty(4);
+         q.askPrice = px(120);
+         q.askQty = qty(4);
+         q.accountId = 2;
+         e.submit(InboundCommand{q}, ts);
+       }},
+      {"peg reprice", 13,
+       [](Eng& e, int64_t ts)
+       {
+         // A peg re-enters the book at a new price whenever the reference
+         // moves. That is a fresh admission -- and the one path that used to
+         // skip the gate, so the mutation test needs this case to bite.
+         // repeg() runs at the START of a submit, so the order that moves the
+         // reference only takes effect on the NEXT command: post first, then
+         // drive one more submit to make the peg re-enter at the new price.
+         e.submit(InboundCommand{limit(30, Side::BUY, 100.5, 1, 2)}, ts);
+         e.submit(InboundCommand{limit(31, Side::SELL, 300, 1, 1)}, ts + 1);
+       }},
+      {"modify reprice", 10,
+       [](Eng& e, int64_t ts)
+       {
+         ModifyOrder m{};
+         m.id = 10;
+         m.symbol = SYM;
+         m.newPrice = px(101);
+         m.newQty = qty(5);
+         e.submit(InboundCommand{m}, ts);
+       }},
+      {"stop trigger", 20,
+       [](Eng& e, int64_t ts)
+       {
+         // The stop was admitted when it was placed; triggering makes it a live
+         // aggressor, which is a fresh admission and must be asked about again.
+         e.submit(InboundCommand{limit(21, Side::SELL, 115, 1, 1)}, ts);
+         e.submit(InboundCommand{limit(22, Side::BUY, 115, 1, 2)}, ts + 1);
+       }},
+  };
+
+  Ledger led;
+  for (uint64_t acct : {1ULL, 2ULL})
+  {
+    // Generous on purpose: this suite proves gates are CALLED, so an order
+    // must never be rejected for lack of funds -- an unfunded order simply
+    // never reaches the path under test (which is how the peg case first
+    // "passed" while testing nothing).
+    led.deposit(acct, QUOTE, 100000000000000LL);
+    led.deposit(acct, BASE, 100000000000000LL);
+  }
+  std::vector<OutboundEvent> ev;
+  Authorizer auth;
+  Eng eng(cfg(), [&](const OutboundEvent& e)
+          { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.setCreditCheck(auth.hook());
+
+  int64_t ts = 100;
+  // Park a stop so the "stop trigger" case has something to fire.
+  NewOrder st = limit(20, Side::BUY, 130, 2, 2);
+  st.type = OrderType::STOP_LIMIT;
+  st.triggerPrice = px(110);
+  eng.submit(InboundCommand{st}, ++ts);
+
+  for (const auto& p : paths)
+  {
+    auth.asked.clear();
+    p.run(eng, ts += 10);
+    const bool asked = auth.asked.count(p.expect) != 0;
+    if (!asked)
+    {
+      std::printf("  path '%s' admitted order %llu without asking the gate (asked:", p.name,
+                  static_cast<unsigned long long>(p.expect));
+      for (OrderId a : auth.asked)
+      {
+        std::printf(" %llu", static_cast<unsigned long long>(a));
+      }
+      std::printf(")\n");
+    }
+    CHECK(asked);
+  }
+}
+
+// ---- property 2: every perp fill was risk-checked at fill time -------------
+//
+// Covers the matcher paths and the auction uncross, which prints its own fills
+// outside the matcher and had exactly this hole.
+
+void test_every_perp_fill_was_risk_checked()
+{
+  std::printf("test_every_perp_fill_was_risk_checked\n");
+  for (int mode = 0; mode < 2; ++mode)  // 0 = continuous, 1 = auction uncross
+  {
+    Ledger led;
+    led.deposit(1, QUOTE, 100000000000000LL);
+    led.deposit(2, QUOTE, 100000000000000LL);
+    std::vector<OutboundEvent> ev;
+    Eng eng(cfg(/*perp=*/true), [&](const OutboundEvent& e)
+            { ev.push_back(e); });
+    eng.setLedger(&led, VENUE);
+
+    int64_t ts = 0;
+    if (mode == 1)
+    {
+      eng.beginPreOpen();
+    }
+    eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5, 2)}, ++ts);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 5, 1)}, ++ts);
+    if (mode == 1)
+    {
+      eng.openContinuous();  // uncross prints here
+    }
+
+    int trades = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<Trade>(&e) != nullptr)
+      {
+        ++trades;
+      }
+    }
+    CHECK(trades > 0);
+    // The position the fills produced is the observable proof the fill-time
+    // risk path ran over them: it is maintained by the same code the fill
+    // limit gates. A fill that bypassed it would leave the position empty.
+    CHECK(eng.positionQty(1) == qty(5).raw());
+    CHECK(eng.positionQty(2) == -qty(5).raw());
+  }
+}
+
+// ---- property 3: instrument state is honoured on EVERY path ----------------
+//
+// Halt and session-close are checked in the new-order path. A stop resting from
+// before the halt triggers on a later print, and a peg reprices on book moves:
+// neither goes through that check, so each is asserted directly.
+
+void test_instrument_state_honoured_on_every_path()
+{
+  std::printf("test_instrument_state_honoured_on_every_path\n");
+  // Both trigger references, because they reach processTriggers differently: a
+  // last-price trigger needs a print (which a halt already blocks), while a
+  // mark trigger arrives on setMarkPrice and used to fire straight through a
+  // halt or a closed session -- the state check simply was not on that path.
+  for (int state = 0; state < 4; ++state)
+  {
+    const bool closeSession = (state % 2) == 1;
+    const bool markTrigger = state >= 2;
+    std::vector<OutboundEvent> ev;
+    SymbolConfig c = cfg();
+    if (markTrigger)
+    {
+      c.triggerRef = TriggerRef::Mark;
+    }
+    Eng eng(c, [&](const OutboundEvent& e)
+            { ev.push_back(e); });
+    int64_t ts = 0;
+
+    eng.submit(InboundCommand{limit(1, Side::BUY, 90, 5, 2)}, ++ts);  // resting liquidity
+    NewOrder st = limit(2, Side::SELL, 0, 1, 3);
+    st.type = OrderType::STOP_MARKET;
+    st.triggerPrice = px(95);
+    eng.submit(InboundCommand{st}, ++ts);
+
+    AdminCmd a{};
+    a.symbol = SYM;
+    a.action = closeSession ? AdminAction::CloseSession : AdminAction::Halt;
+    eng.submit(InboundCommand{a}, ++ts);
+
+    const size_t before = ev.size();
+    eng.setMarkPrice(px(94));  // would cross the stop trigger
+    eng.submit(InboundCommand{limit(3, Side::SELL, 94, 1, 4)}, ++ts);
+
+    int trades = 0;
+    for (size_t i = before; i < ev.size(); ++i)
+    {
+      if (std::get_if<Trade>(&ev[i]) != nullptr)
+      {
+        ++trades;
+      }
+    }
+    if (trades != 0)
+    {
+      std::printf("  %d trade(s) printed while %s (%s trigger)\n", trades,
+                  closeSession ? "session-closed" : "halted",
+                  markTrigger ? "mark" : "last");
+    }
+    CHECK(trades == 0);
+  }
+}
+
+// ---- property 4: instrument conformance applies to conditionals too --------
+//
+// A conditional order branches off before validate(), which is written around a
+// live limit price. It still carries a trigger price and a size, and both used
+// to be parked unchecked: an off-tick trigger, one outside the price band, or a
+// sub-lot quantity was accepted and only surfaced when the stop fired.
+
+void test_conditional_orders_obey_the_instrument()
+{
+  std::printf("test_conditional_orders_obey_the_instrument\n");
+  struct Case
+  {
+    const char* name;
+    double trigger;
+    double quantity;
+  };
+  const Case bad[] = {
+      {"off-tick trigger", 50.005, 5},
+      {"trigger below band", 0.5, 5},
+      {"trigger above band", 5000, 5},
+      {"sub-lot quantity", 50, 0.5},
+  };
+
+  for (const auto& c : bad)
+  {
+    std::vector<OutboundEvent> ev;
+    SymbolConfig sc = cfg();
+    sc.minPrice = px(10);
+    sc.lotSize = qty(1);
+    Eng eng(sc, [&](const OutboundEvent& e)
+            { ev.push_back(e); });
+
+    NewOrder st = limit(1, Side::SELL, 0, c.quantity, 1);
+    st.type = OrderType::STOP_MARKET;
+    st.triggerPrice = px(c.trigger);
+    eng.submit(InboundCommand{st}, 1);
+
+    int accepted = 0;
+    for (auto& e : ev)
+    {
+      if (std::get_if<OrderAccepted>(&e) != nullptr)
+      {
+        ++accepted;
+      }
+    }
+    if (accepted != 0)
+    {
+      std::printf("  conditional with %s was parked anyway\n", c.name);
+    }
+    CHECK(accepted == 0);
+  }
+
+  // The conforming case still works -- the guard must not reject everything.
+  std::vector<OutboundEvent> ok;
+  SymbolConfig sc = cfg();
+  sc.minPrice = px(10);
+  sc.lotSize = qty(1);
+  Eng eng(sc, [&](const OutboundEvent& e)
+          { ok.push_back(e); });
+  NewOrder good = limit(2, Side::SELL, 0, 5, 1);
+  good.type = OrderType::STOP_MARKET;
+  good.triggerPrice = px(50);
+  eng.submit(InboundCommand{good}, 1);
+  int accepted = 0;
+  for (auto& e : ok)
+  {
+    if (std::get_if<OrderAccepted>(&e) != nullptr)
+    {
+      ++accepted;
+    }
+  }
+  CHECK(accepted == 1);
+}
+
+}  // namespace
+
+TEST(VenueGateCoverage, EveryPathIsGated)
+{
+  test_every_admission_asks_permission();
+  test_every_perp_fill_was_risk_checked();
+  test_instrument_state_honoured_on_every_path();
+  test_conditional_orders_obey_the_instrument();
+  std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
+  EXPECT_EQ(g_failures, 0);
+}

--- a/venue/tests/test_venue_lastlook.cpp
+++ b/venue/tests/test_venue_lastlook.cpp
@@ -489,6 +489,86 @@ void test_cancel_while_held_conservation()
   CHECK(led.available(2, QUOTE) == usd300 && led.reserved(2, QUOTE) == 0);
 }
 
+// ---- T028: STP-cancel of a held maker ---------------------------------------
+
+// Self-trade prevention removes a resting maker from INSIDE the matcher, which
+// is the one cancel path that never went through the engine's hold discipline.
+// A last-look maker with displayed size reaches that path: STP cancels it, the
+// cancel frees the collateral that its OPEN hold still needs, and the later
+// accept settles with no reservation behind it -- the branch where the debit's
+// result was discarded and the counterparty credited anyway (value minted).
+// The STP path must resolve the maker's holds FIRST, exactly like every other
+// removal.
+void test_stp_cancel_while_held_conservation()
+{
+  std::printf("test_stp_cancel_while_held_conservation\n");
+  constexpr AssetId BASE = 0, QUOTE = 1;
+  constexpr uint64_t VENUE = 999;
+  const Amount base5 = amountOf(qty(5));
+  const Amount usd300 = amountOf(Volume::fromDouble(300));
+  Ledger led;
+  led.deposit(1, BASE, base5);    // maker: exactly the 5 base it quotes
+  led.deposit(2, QUOTE, usd300);  // taker
+  led.deposit(1, QUOTE, usd300);  // maker's STP order needs quote to reserve
+  auto c = cfg();
+  c.baseAsset = BASE;
+  c.quoteAsset = QUOTE;
+  Cap cap;
+  MatchingEngine<MatchingBook> eng(c, cap.sink());
+  eng.setLedger(&led, VENUE);
+  const Amount initBase = led.total(1, BASE) + led.total(2, BASE) + led.total(VENUE, BASE);
+  const Amount initQuote = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+
+  NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+  mk.lastLook = true;
+  eng.submit(InboundCommand{mk}, 0);
+  CHECK(led.reserved(1, BASE) == base5);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);  // holds 3 of the 5
+  const auto* h = cap.lastHeld();
+  CHECK(h != nullptr);
+  const uint64_t heldId = h != nullptr ? h->heldId : 0;
+  CHECK(bookAt(eng.book(), Side::SELL, 100) == qty(2));  // 3 held out of the book
+
+  // The maker's OWN account crosses its own quote with self-trade prevention:
+  // the resting (held) maker is pulled from inside the matcher.
+  NewOrder stp = limit(3, Side::BUY, 100, 2, 1);
+  stp.stp = STPMode::CancelOldest;
+  eng.submit(InboundCommand{stp}, 2);
+  CHECK(cap.sawCancel(CancelReason::SelfTradePrevention));
+  CHECK(cap.count<FillRejected>() == 1);  // the hold was resolved before the cancel
+  CHECK(bookAt(eng.book(), Side::SELL, 100).isZero());
+  // Maker made whole: the full 5 base is back in `available`, nothing stranded.
+  CHECK(led.available(1, BASE) == base5 && led.reserved(1, BASE) == 0);
+
+  // The maker now spends the freed collateral elsewhere. If the STP cancel had
+  // stripped a live hold's backing, the accept below would settle from an empty
+  // account and print base that does not exist.
+  eng.submit(InboundCommand{Withdraw{1, BASE, static_cast<int64_t>(base5), SYM}}, 3);
+  CHECK(led.available(1, BASE) == 0);
+
+  eng.submit(InboundCommand{LastLookDecision{heldId, SYM, true, 1}}, 4);
+  CHECK(cap.trades() == 0);                          // no fill can settle from a resolved hold
+  CHECK(cap.sawReject(RejectReason::UnknownOrder));  // the heldId is gone for good
+  CHECK(eng.unsettledTrades() == 0);                 // and nothing reached the no-reservation path
+
+  // Conservation: base only left through the withdrawal, quote never moved.
+  const Amount endBase = led.total(1, BASE) + led.total(2, BASE) + led.total(VENUE, BASE);
+  const Amount endQuote = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(endBase == initBase - base5);
+  CHECK(endQuote == initQuote);
+
+  // Book and tracking agree: the STP-canceled maker is gone from both, and the
+  // live orders are exactly the taker's restored residual plus the STP
+  // aggressor's own (uncrossed) remainder.
+  CHECK(!eng.book().contains(1));
+  CHECK(eng.restingOrderCount() == 2);
+  eng.submit(InboundCommand{CancelOrder{2, SYM, 2}}, 5);
+  eng.submit(InboundCommand{CancelOrder{3, SYM, 1}}, 6);
+  CHECK(eng.restingOrderCount() == 0);
+  CHECK(led.reserved(2, QUOTE) == 0 && led.available(2, QUOTE) == usd300);
+  CHECK(led.reserved(1, QUOTE) == 0 && led.available(1, QUOTE) == usd300);
+}
+
 // ---- T016: FOK vs last-look -------------------------------------------------
 
 void test_fok_vs_lastlook()
@@ -757,6 +837,7 @@ TEST(VenueLastLook, LifecycleSuite)
   test_idle_expiry_via_tick();
   test_window_zero_disables();
   test_cancel_while_held_conservation();
+  test_stp_cancel_while_held_conservation();
   test_fok_vs_lastlook();
   test_shard_idle_sweeper();
   std::printf("\n%d checks, %d failures\n", g_checks, g_failures);

--- a/venue/tests/test_venue_ledger.cpp
+++ b/venue/tests/test_venue_ledger.cpp
@@ -359,12 +359,108 @@ void test_auction_settlement()
   CHECK(leaks == 0);
 }
 
+// A leg with no reservation settles straight out of `available`, and that debit
+// can refuse. Crediting the counterparty anyway mints exactly the credited
+// amount -- the failure mode behind T028. This is the floor under EVERY such
+// path, not just the one that was found: an order that reached the book before
+// a ledger was bound has no reservation, so its fill takes the unreserved
+// branch with an empty account behind it. Nothing may move, and the venue must
+// count the trade as unsettled rather than pay for it.
+void test_unreserved_leg_cannot_mint()
+{
+  std::printf("test_unreserved_leg_cannot_mint\n");
+  Ledger led;
+  led.deposit(2, QUOTE, quote(1000));  // buyer funded; seller owns no base at all
+  const Amount initBase = led.total(1, BASE) + led.total(2, BASE) + led.total(VENUE, BASE);
+  const Amount initQuote = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+
+  MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+  eng.submit(InboundCommand{limit(1, Side::SELL, 100, 5, 1)}, 0);  // no ledger yet: no reservation
+  eng.setLedger(&led, VENUE);
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 5, 2)}, 1);  // reserved buyer takes it
+
+  CHECK(eng.unsettledTrades() == 1);  // the print could not be settled honestly
+  // Nothing moved: no base conjured for the buyer, no quote paid to the seller.
+  CHECK(led.total(1, BASE) == 0 && led.total(2, BASE) == 0);
+  CHECK(led.total(1, QUOTE) == 0);
+  const Amount endBase = led.total(1, BASE) + led.total(2, BASE) + led.total(VENUE, BASE);
+  const Amount endQuote = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(endBase == initBase);
+  CHECK(endQuote == initQuote);
+  // The buyer's own money is intact and free again (its order left the book).
+  CHECK(led.available(2, QUOTE) == quote(1000) && led.reserved(2, QUOTE) == 0);
+}
+
 }  // namespace
+
+// ---- three defects that used to be "accepted" ------------------------------
+
+// STP Decrement trims a resting order in place. The reservation covering the
+// trimmed quantity used to stay locked until the order was cancelled: the
+// account's own money, frozen against size that no longer rests.
+void test_stp_decrement_frees_trimmed_reservation()
+{
+  std::printf("test_stp_decrement_frees_trimmed_reservation\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(10000));
+  led.deposit(1, BASE, base(10));
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+  eng.setStpGroup(1, 1);  // same firm on both sides
+
+  NewOrder resting = limit(1, Side::SELL, 100, 5, 1);
+  resting.stp = STPMode::Decrement;
+  eng.submit(InboundCommand{resting}, 1);
+  const Amount reservedAfterRest = led.reserved(1, BASE);
+  CHECK(reservedAfterRest == base(5));
+
+  // Same firm crosses with 2: STP decrements the resting side to 3.
+  NewOrder crossing = limit(2, Side::BUY, 100, 2, 1);
+  crossing.stp = STPMode::Decrement;
+  eng.submit(InboundCommand{crossing}, 2);
+  CHECK(led.reserved(1, BASE) == base(3));  // was still 5 -- 2 units frozen for nothing
+  CHECK(led.available(1, BASE) + led.reserved(1, BASE) == base(10));
+}
+
+// A GTD conditional order used to live forever: expiry was registered only for
+// orders resting on the book, so a stop that never triggered never expired.
+void test_gtd_binds_conditional_orders()
+{
+  std::printf("test_gtd_binds_conditional_orders\n");
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+
+  NewOrder stop = limit(1, Side::SELL, 0, 1, 1);
+  stop.type = OrderType::STOP_MARKET;
+  stop.triggerPrice = px(50);  // far from any print: never triggers
+  stop.tif = TimeInForce::GTD;
+  stop.expiryNs = 1000;
+  eng.submit(InboundCommand{stop}, 10);
+
+  // Any later command drives the deterministic sweep past the deadline.
+  eng.submit(InboundCommand{limit(2, Side::BUY, 100, 1, 2)}, 2000);
+  bool expired = false;
+  for (auto& e : ev)
+  {
+    if (auto* c = std::get_if<OrderCanceled>(&e);
+        c != nullptr && c->id == 1 && c->reason == CancelReason::Expired)
+    {
+      expired = true;
+    }
+  }
+  CHECK(expired);
+}
 
 TEST(VenueLedger, EngineSuite)
 {
+  test_unreserved_leg_cannot_mint();
   test_settlement();
   test_taker_fee_policy();
+  test_stp_decrement_frees_trimmed_reservation();
+  test_gtd_binds_conditional_orders();
   test_auction_settlement();
   test_insufficient();
   test_modify_reservation();

--- a/venue/tests/test_venue_matcher.cpp
+++ b/venue/tests/test_venue_matcher.cpp
@@ -90,6 +90,20 @@ struct Capture
     }
     return nullptr;
   }
+  // Cancel and replace refusals are their own event: FIX answers them with
+  // 35=9, not an execution report, so the engine reports them separately too.
+  int cancelRejects(RejectReason r) const
+  {
+    int n = 0;
+    for (auto& e : ev)
+    {
+      if (auto* x = std::get_if<CancelRejected>(&e); x && x->reason == r)
+      {
+        ++n;
+      }
+    }
+    return n;
+  }
   int rejects(RejectReason r) const
   {
     int n = 0;
@@ -336,7 +350,8 @@ void runAll(const std::function<Book()>& mk, const char* label)
     CHECK(cap.cancels(CancelReason::UserRequested) == 1);
     CHECK(eng.book().empty());
     eng.submit(CancelOrder{999, SYM, 1});
-    CHECK(cap.rejects(RejectReason::UnknownOrder) == 1);
+    CHECK(cap.cancelRejects(RejectReason::UnknownOrder) == 1);
+    CHECK(cap.rejects(RejectReason::UnknownOrder) == 0);  // not an exec report
   }
   {  // duplicate order id reject
     Capture cap;
@@ -370,7 +385,8 @@ void runAll(const std::function<Book()>& mk, const char* label)
     Capture cap;
     MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
     eng.submit(ModifyOrder{42, SYM, px(100), qty(1), 1});
-    CHECK(cap.rejects(RejectReason::UnknownOrder) == 1);
+    CHECK(cap.cancelRejects(RejectReason::UnknownOrder) == 1);
+    CHECK(cap.rejects(RejectReason::UnknownOrder) == 0);
   }
   {  // iceberg fully consumed via peak refills
     Capture cap;
@@ -623,6 +639,22 @@ void runAll(const std::function<Book()>& mk, const char* label)
     ok.stp = STPMode::CancelOldest;
     eng.submit(ok);
     CHECK(cap.trades() == 1);  // different firms -> allowed
+  }
+  {  // A modify re-enters matching as a fresh aggressor, and it must carry the
+     // self-trade prevention the order was admitted with. Rebuilding the order
+     // from its resting record alone would drop the mode and let the reprice
+     // trade against its own account.
+    Capture cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk());
+    NewOrder passive = limit(1, Side::BUY, 99, 5, 7);
+    passive.stp = STPMode::CancelOldest;
+    eng.submit(passive);
+    eng.submit(limit(2, Side::SELL, 100, 5, 7));  // same account rests on the other side
+    CHECK(cap.trades() == 0);                     // no cross yet
+    // Reprice the bid up through the account's own offer.
+    eng.submit(InboundCommand{ModifyOrder{1, SYM, px(100), qty(5), 0}});
+    CHECK(cap.trades() == 0);  // still no self-trade
+    CHECK(cap.cancels(CancelReason::SelfTradePrevention) >= 1);
   }
   {  // account snapshot for reconnect reconciliation: open orders + position
     Capture cap;

--- a/venue/tests/test_venue_mm.cpp
+++ b/venue/tests/test_venue_mm.cpp
@@ -271,8 +271,16 @@ void test_credit()
   Cap cap;
   MatchingEngine<MatchingBook> eng(cfg(), cap.sink());
   // Reject any order whose notional exceeds 1000 (toy buying-power gate).
-  eng.setCreditCheck([](uint64_t, Side, Price p, Quantity q)
-                     { return (p * q).toDouble() <= 1000.0; });
+  using Eng = MatchingEngine<MatchingBook>;
+  eng.setCreditCheck(
+      [](const Eng::CreditRequest& r) -> Eng::CreditDecision
+      {
+        if ((r.price * r.quantity).toDouble() > 1000.0)
+        {
+          return {false, RejectReason::InsufficientFunds};
+        }
+        return {true, RejectReason::None};
+      });
   eng.submit(InboundCommand{limit(1, Side::BUY, 100, 20, 1)}, 0);  // notional 2000 -> reject
   CHECK(cap.count<OrderRejected>() == 1);
   cap.ev.clear();

--- a/venue/tests/test_venue_perp.cpp
+++ b/venue/tests/test_venue_perp.cpp
@@ -437,6 +437,239 @@ void test_perp_modify_preserves_reduce_only()
   CHECK(eng.positionQty(1) == 0);  // reduced to flat -- bug flips it to -5 (opened a short)
 }
 
+// T029: an unpriced (market / stop) perp order is bounded by the price band for
+// margin purposes, and on a linear perp that bound is the band's TOP on BOTH
+// sides -- nothing is delivered, so notional and initial margin grow with price
+// whether the account ends long or short. Bounding a SELL at minPrice (correct
+// only for a SPOT seller) under-reserves it by the whole band ratio and
+// consumeOrderIM then posts the position that under-reserved margin.
+void test_perp_unpriced_sell_margin_matches_buy()
+{
+  std::printf("test_perp_unpriced_sell_margin_matches_buy\n");
+  // Band is [1, 1000] and IM is 10%: an unpriced order for 10 contracts must
+  // reserve 10 * 1000 * 10% = 1000 quote regardless of side (bounding a sell at
+  // minPrice would have asked for 1).
+  const Amount imAtBand = quote(1000);
+
+  auto marginAfterMarketFill = [&](Side takerSide)
+  {
+    Ledger led;
+    led.deposit(1, QUOTE, quote(100000));  // resting counterparty
+    led.deposit(2, QUOTE, imAtBand);       // aggressor: exactly the band-bounded IM
+    MatchingEngine<MatchingBook> eng(cfg(), [](const OutboundEvent&) {});
+    eng.setLedger(&led, VENUE);
+    const Side restingSide = (takerSide == Side::BUY) ? Side::SELL : Side::BUY;
+    eng.submit(InboundCommand{ord(1, restingSide, 100, 10, 1)}, 0);
+    NewOrder mkt;
+    mkt.id = 2;
+    mkt.symbol = SYM;
+    mkt.side = takerSide;
+    mkt.type = OrderType::MARKET;
+    mkt.quantity = qty(10);
+    mkt.accountId = 2;
+    eng.submit(InboundCommand{mkt}, 1);
+    CHECK(eng.positionQty(2) == (takerSide == Side::BUY ? qty(10).raw() : -qty(10).raw()));
+    return led.reserved(2, QUOTE);  // == the position's posted margin
+  };
+
+  const Amount buyMargin = marginAfterMarketFill(Side::BUY);
+  const Amount sellMargin = marginAfterMarketFill(Side::SELL);
+  CHECK(buyMargin == imAtBand);
+  CHECK(sellMargin == buyMargin);  // the short was margined at minPrice before the fix
+
+  // And the reservation gate is symmetric: one raw unit short of the
+  // band-bounded IM must reject either side, not just the buy.
+  auto rejectsAtDeposit = [](Side side, Amount deposit)
+  {
+    Ledger led;
+    led.deposit(2, QUOTE, deposit);
+    std::vector<OutboundEvent> ev;
+    MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                     { ev.push_back(e); });
+    eng.setLedger(&led, VENUE);
+    NewOrder mkt;
+    mkt.id = 1;
+    mkt.symbol = SYM;
+    mkt.side = side;
+    mkt.type = OrderType::MARKET;
+    mkt.quantity = qty(10);
+    mkt.accountId = 2;
+    eng.submit(InboundCommand{mkt}, 0);
+    for (auto& e : ev)
+    {
+      if (auto* r = std::get_if<OrderRejected>(&e);
+          r && r->reason == RejectReason::InsufficientFunds)
+      {
+        return true;
+      }
+    }
+    return false;
+  };
+  CHECK(rejectsAtDeposit(Side::SELL, imAtBand - 1));
+  CHECK(rejectsAtDeposit(Side::BUY, imAtBand - 1));
+  CHECK(!rejectsAtDeposit(Side::SELL, imAtBand));
+  CHECK(!rejectsAtDeposit(Side::BUY, imAtBand));
+}
+
+// T030: reduce-only and maxPositionQty are gated when an order is ADMITTED, but
+// a resting order fills later -- against a position that has moved since. A
+// reduce-only order reserves no initial margin, so any part of it that opens or
+// flips the position opens it with ZERO margin; the flags must therefore be
+// re-measured at fill time, on the live position.
+void test_reduce_only_resting_cannot_flip_at_fill()
+{
+  std::printf("test_perp_reduce_only_resting_cannot_flip_at_fill\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100000));
+  led.deposit(2, QUOTE, quote(100000));
+  led.deposit(3, QUOTE, quote(100000));
+  const Amount init = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(3, QUOTE) +
+                      led.total(VENUE, QUOTE);
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);
+  CHECK(eng.positionQty(1) == qty(10).raw());  // acct1 long 10
+
+  // Reduce-only exit for the WHOLE position, resting above the market.
+  eng.submit(InboundCommand{ord(3, Side::SELL, 110, 10, 1, /*reduceOnly*/ true)}, 2);
+  // The position then shrinks by 6 through another exit, leaving +4 behind the
+  // resting order's 10.
+  eng.submit(InboundCommand{ord(4, Side::SELL, 100, 6, 1, /*reduceOnly*/ true)}, 3);
+  eng.submit(InboundCommand{ord(5, Side::BUY, 100, 6, 3)}, 4);
+  CHECK(eng.positionQty(1) == qty(4).raw());
+
+  // Someone lifts the whole resting reduce-only order: only the 4 that still
+  // reduces may print. The rest must not flip acct1 into a short it posted no
+  // margin for.
+  ev.clear();
+  eng.submit(InboundCommand{ord(6, Side::BUY, 110, 10, 2)}, 5);
+  CHECK(eng.positionQty(1) == 0);  // flat, never short
+  CHECK(eng.totalPositionMargin() >= 0);
+  bool canceled = false;
+  for (auto& e : ev)
+  {
+    if (auto* c = std::get_if<OrderCanceled>(&e);
+        c && c->id == 3 && c->reason == CancelReason::ReduceOnlyNotReducing)
+    {
+      canceled = true;
+    }
+  }
+  CHECK(canceled);  // the residual that could not reduce is pulled, with a reason
+  CHECK(!eng.book().contains(3));
+
+  // Margin invariant and conservation both hold afterwards (drained first, so
+  // every reserved unit left must be a position's posted margin).
+  for (OrderId id = 1; id <= 6; ++id)
+  {
+    eng.submit(InboundCommand{CancelOrder{id, SYM, 0}}, 6);
+  }
+  Amount reservedSum = 0;
+  for (uint64_t a = 1; a <= 3; ++a)
+  {
+    reservedSum += led.reserved(a, QUOTE);
+  }
+  CHECK(reservedSum == eng.totalPositionMargin());
+  CHECK(led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(3, QUOTE) + led.total(VENUE, QUOTE) ==
+        init);
+}
+
+// The auction uncross prints its own fills instead of going through the
+// matcher, so it needs the same fill-time re-check: a reduce-only order that
+// rested through a position change must not be flipped by the reopening
+// auction either.
+void test_auction_uncross_respects_reduce_only()
+{
+  std::printf("test_perp_auction_uncross_respects_reduce_only\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100000));
+  led.deposit(2, QUOTE, quote(100000));
+  led.deposit(3, QUOTE, quote(100000));
+  const Amount init = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(3, QUOTE) +
+                      led.total(VENUE, QUOTE);
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 10, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::SELL, 100, 10, 2)}, 1);  // acct1 long 10
+  eng.submit(InboundCommand{ord(3, Side::SELL, 110, 10, 1, /*reduceOnly*/ true)}, 2);
+  eng.submit(InboundCommand{ord(4, Side::SELL, 100, 6, 1, /*reduceOnly*/ true)}, 3);
+  eng.submit(InboundCommand{ord(5, Side::BUY, 100, 6, 3)}, 4);
+  CHECK(eng.positionQty(1) == qty(4).raw());  // order 3 now over-sized for the position
+
+  // Reopening auction: accumulate a bid that lifts the whole resting sell.
+  eng.beginPreOpen();
+  eng.submit(InboundCommand{ord(6, Side::BUY, 110, 10, 2)}, 5);
+  ev.clear();
+  eng.openContinuous();
+
+  CHECK(eng.positionQty(1) == 0);  // reduced to flat, never flipped short
+  bool canceled = false;
+  for (auto& e : ev)
+  {
+    if (auto* c = std::get_if<OrderCanceled>(&e);
+        c && c->id == 3 && c->reason == CancelReason::ReduceOnlyNotReducing)
+    {
+      canceled = true;
+    }
+  }
+  CHECK(canceled);
+  CHECK(led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(3, QUOTE) + led.total(VENUE, QUOTE) ==
+        init);
+}
+
+// T030: maxPositionQty is checked against the INCOMING order at admission, so
+// two orders that each pass individually can settle into a position past the
+// cap. The cap must bind the RESULTING position, at fill time.
+void test_position_cap_not_circumvented_by_several_orders()
+{
+  std::printf("test_perp_position_cap_not_circumvented_by_several_orders\n");
+  Ledger led;
+  led.deposit(1, QUOTE, quote(100000));
+  led.deposit(2, QUOTE, quote(100000));
+  led.deposit(3, QUOTE, quote(100000));
+  auto c = cfg();
+  c.maxPositionQty = qty(10);
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  // Two resting bids of 6 each: each passes the admission cap (the position is
+  // 0 when both are placed), together they would build 12 against a cap of 10.
+  eng.submit(InboundCommand{ord(1, Side::BUY, 100, 6, 1)}, 0);
+  eng.submit(InboundCommand{ord(2, Side::BUY, 100, 6, 1)}, 1);
+  eng.submit(InboundCommand{ord(3, Side::SELL, 100, 6, 2)}, 2);  // fills the first: +6
+  CHECK(eng.positionQty(1) == qty(6).raw());
+  ev.clear();
+  eng.submit(InboundCommand{ord(4, Side::SELL, 100, 6, 3)}, 3);  // would take acct1 to +12
+
+  CHECK(eng.positionQty(1) == qty(10).raw());  // capped exactly, not 12
+  bool capCanceled = false;
+  for (auto& e : ev)
+  {
+    if (auto* cc = std::get_if<OrderCanceled>(&e);
+        cc && cc->id == 2 && cc->reason == CancelReason::PositionLimitExceeded)
+    {
+      capCanceled = true;
+    }
+  }
+  CHECK(capCanceled);  // the maker slice that would breach the cap is pulled
+  CHECK(!eng.book().contains(2));
+
+  for (OrderId id = 1; id <= 4; ++id)
+  {
+    eng.submit(InboundCommand{CancelOrder{id, SYM, 0}}, 4);
+  }
+  Amount reservedSum = led.reserved(1, QUOTE) + led.reserved(2, QUOTE) + led.reserved(3, QUOTE);
+  CHECK(reservedSum == eng.totalPositionMargin());
+}
+
 void test_engine_adl()
 {
   std::printf("test_perp_engine_adl\n");
@@ -526,6 +759,202 @@ void test_position_limit()
 
 }  // namespace
 
+// ---- T031: a ledgerless perp still tracks exposure --------------------------
+//
+// Positions are exposure, not cash. With no ledger bound the engine skips
+// settlement, and it used to skip position tracking with it -- which made every
+// reduce-only order reject ("nothing to reduce"), degraded maxPositionQty to a
+// per-order cap, and published open interest as a flat zero on the public feed.
+
+void test_ledgerless_perp_tracks_exposure()
+{
+  std::printf("test_ledgerless_perp_tracks_exposure\n");
+  SymbolConfig c = cfg();
+  c.maxPositionQty = qty(10);
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  // no setLedger: funds live in another system
+
+  // Open a 5-lot long for account 1 against account 2.
+  eng.submit(InboundCommand{ord(1, Side::SELL, 100, 5, 2)}, 1);
+  eng.submit(InboundCommand{ord(2, Side::BUY, 100, 5, 1)}, 2);
+  CHECK(eng.positionQty(1) == qty(5).raw());
+  CHECK(eng.positionQty(2) == -qty(5).raw());
+  CHECK(eng.openInterest() == qty(5));  // was a flat zero regardless of volume
+
+  // Reduce-only now has something to reduce and is accepted.
+  eng.submit(InboundCommand{ord(3, Side::BUY, 100, 3, 2)}, 3);
+  eng.submit(InboundCommand{ord(4, Side::SELL, 100, 3, 1, /*reduceOnly=*/true)}, 4);
+  bool bogusReject = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e);
+        r != nullptr && r->reason == RejectReason::InvalidQuantity)
+    {
+      bogusReject = true;
+    }
+  }
+  CHECK(!bogusReject);  // used to reject every reduce-only: "nothing to reduce"
+  CHECK(eng.positionQty(1) == qty(2).raw());
+  CHECK(eng.openInterest() == qty(2));
+
+  // The position cap is cumulative again, not per order: 6 + 6 > 10.
+  // Two 6-lot buys against separate makers: each is under the 10 cap on its
+  // own, so only a cumulative check can stop the pair. Makers are distinct
+  // accounts because the cap binds their short side too.
+  std::vector<OutboundEvent> ev2;
+  MatchingEngine<MatchingBook> eng2(c, [&](const OutboundEvent& e)
+                                    { ev2.push_back(e); });
+  eng2.submit(InboundCommand{ord(10, Side::SELL, 100, 6, 2)}, 10);
+  eng2.submit(InboundCommand{ord(11, Side::BUY, 100, 6, 1)}, 11);
+  CHECK(eng2.positionQty(1) == qty(6).raw());
+  eng2.submit(InboundCommand{ord(12, Side::SELL, 100, 6, 3)}, 12);
+  eng2.submit(InboundCommand{ord(13, Side::BUY, 100, 6, 1)}, 13);
+  // 6 + 6 would be 12 against a cap of 10, so the second order is refused
+  // outright rather than trimmed. Without a cumulative check the position
+  // would have reached 12: each order is under the cap on its own.
+  CHECK(eng2.positionQty(1) == qty(6).raw());
+
+  // No money moved anywhere: settlement is the other system's job.
+  CHECK(eng.ledger() == nullptr);
+}
+
+// A money command against a ledgerless engine is answered, not swallowed.
+void test_ledgerless_money_commands_answer()
+{
+  std::printf("test_ledgerless_money_commands_answer\n");
+  std::vector<OutboundEvent> ev;
+  MatchingEngine<MatchingBook> eng(cfg(), [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  Deposit d{};
+  d.accountId = 7;
+  d.asset = QUOTE;
+  d.amountRaw = 1000;
+  eng.submit(InboundCommand{d}, 1);
+  bool depositAnswered = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e);
+        r != nullptr && r->reason == RejectReason::NoLedgerBound)
+    {
+      depositAnswered = true;
+    }
+  }
+  CHECK(depositAnswered);  // used to vanish with no event at all
+
+  std::vector<OutboundEvent> ev2;
+  MatchingEngine<MatchingBook> eng2(cfg(), [&](const OutboundEvent& e)
+                                    { ev2.push_back(e); });
+  Withdraw w{};
+  w.accountId = 7;
+  w.asset = QUOTE;
+  w.amountRaw = 1000;
+  eng2.submit(InboundCommand{w}, 1);
+  bool withdrawAnswered = false;
+  for (auto& e : ev2)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e);
+        r != nullptr && r->reason == RejectReason::NoLedgerBound)
+    {
+      withdrawAnswered = true;
+    }
+  }
+  CHECK(withdrawAnswered);
+}
+
+// ---- external risk owner: the three seams it needs ------------------------
+//
+// A portfolio-margin model lives above the per-symbol engines: it sees the
+// whole basket, so it decides entry and liquidation, and the engine executes.
+// This exercises all three seams together the way such an owner would use
+// them: approve/refuse on entry, watch fills, close on its own decision.
+
+void test_external_risk_owner_seams()
+{
+  std::printf("test_external_risk_owner_seams\n");
+  using Eng = MatchingEngine<MatchingBook>;
+  Ledger led;
+  led.deposit(1, QUOTE, quote(10000));
+  led.deposit(2, QUOTE, quote(10000));
+  std::vector<OutboundEvent> ev;
+  SymbolConfig c = cfg();
+  c.maintenanceMarginBps = 500;
+  c.externalLiquidation = true;  // the engine must not liquidate on its own
+  MatchingEngine<MatchingBook> eng(c, [&](const OutboundEvent& e)
+                                   { ev.push_back(e); });
+  eng.setLedger(&led, VENUE);
+
+  // Seam 1: the risk owner approves entry and can say why it refuses.
+  bool allow = true;
+  eng.setCreditCheck(
+      [&](const Eng::CreditRequest& r) -> Eng::CreditDecision
+      {
+        CHECK(r.symbol == SYM);  // it serves many instruments: it must be told which
+        if (!allow && !r.reduceOnly)
+        {
+          return {false, RejectReason::PositionLimitExceeded};
+        }
+        return {true, RejectReason::None};
+      });
+
+  eng.submit(InboundCommand{ord(1, Side::SELL, 100, 5, 2)}, 1);
+  eng.submit(InboundCommand{ord(2, Side::BUY, 100, 5, 1)}, 2);
+  CHECK(eng.positionQty(1) == qty(5).raw());
+
+  // Refusal carries the owner's reason to the client, not a flat funds error.
+  allow = false;
+  ev.clear();
+  eng.submit(InboundCommand{ord(3, Side::BUY, 100, 1, 1)}, 3);
+  bool refusedWithReason = false;
+  for (auto& e : ev)
+  {
+    if (auto* r = std::get_if<OrderRejected>(&e);
+        r != nullptr && r->reason == RejectReason::PositionLimitExceeded)
+    {
+      refusedWithReason = true;
+    }
+  }
+  CHECK(refusedWithReason);
+  allow = true;
+
+  // Seam 2: the engine does NOT liquidate by itself, however bad the mark.
+  ev.clear();
+  eng.setMarkPrice(px(10));  // far past maintenance for a 5-lot long at 100
+  bool selfLiquidated = false;
+  for (auto& e : ev)
+  {
+    if (std::get_if<Liquidation>(&e) != nullptr)
+    {
+      selfLiquidated = true;
+    }
+  }
+  CHECK(!selfLiquidated);
+  CHECK(eng.positionQty(1) == qty(5).raw());  // still open: not the engine's call
+
+  // Seam 3: the owner closes it, and the engine settles exactly as its own
+  // sweep would have.
+  ev.clear();
+  ForceClosePosition fc{};
+  fc.accountId = 1;
+  fc.symbol = SYM;
+  eng.submit(InboundCommand{fc}, 4);
+  CHECK(eng.positionQty(1) == 0);
+  bool liquidated = false;
+  for (auto& e : ev)
+  {
+    if (std::get_if<Liquidation>(&e) != nullptr)
+    {
+      liquidated = true;
+    }
+  }
+  CHECK(liquidated);
+
+  // Money is still conserved across the externally driven close.
+  const Amount total = led.total(1, QUOTE) + led.total(2, QUOTE) + led.total(VENUE, QUOTE);
+  CHECK(total == quote(20000));
+}
+
 TEST(Perp, EngineSuite)
 {
   test_open_and_close();
@@ -539,8 +968,15 @@ TEST(Perp, EngineSuite)
   test_perp_modify_respects_position_cap();
   test_perp_risk_gate_consistent_across_paths();
   test_perp_modify_preserves_reduce_only();
+  test_perp_unpriced_sell_margin_matches_buy();
+  test_reduce_only_resting_cannot_flip_at_fill();
+  test_auction_uncross_respects_reduce_only();
+  test_position_cap_not_circumvented_by_several_orders();
   test_engine_adl();
   test_position_limit();
+  test_ledgerless_perp_tracks_exposure();
+  test_ledgerless_money_commands_answer();
+  test_external_risk_owner_seams();
   std::printf("\n%d checks, %d failures\n", g_checks, g_failures);
   EXPECT_EQ(g_failures, 0);
 }

--- a/venue/tests/test_venue_prorata.cpp
+++ b/venue/tests/test_venue_prorata.cpp
@@ -205,6 +205,61 @@ void run(const std::function<Book()>& mk, const char* label)
     CHECK(m.skippedLastLookProRata() >= 1);
     CHECK(book.find(1)->leaves == qty(5));
   }
+  {  // Self-trade prevention binds under pro-rata exactly as it does under
+     // price-time. The allocation is a different way of choosing who fills,
+     // not a different set of participants: an account must never be on both
+     // sides of the same print whatever the policy is.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    eng.submit(limit(1, Side::SELL, 100, 4, 7));  // same account as the taker
+    eng.submit(limit(2, Side::SELL, 100, 6, 8));  // a stranger at the same level
+    NewOrder agg = limit(9, Side::BUY, 100, 10, 7);
+    agg.stp = STPMode::CancelOldest;
+    eng.submit(agg);
+    CHECK(cap.forMaker(1).isZero());  // never trades with itself
+    CHECK(cap.forMaker(2) == qty(6));
+    CHECK(eng.book().find(1) == nullptr);  // CancelOldest pulled the resting leg
+  }
+  {  // CancelNewest under pro-rata cancels the aggressor and prints nothing,
+     // even though strangers at the level would otherwise have filled.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    eng.submit(limit(1, Side::SELL, 100, 4, 7));
+    eng.submit(limit(2, Side::SELL, 100, 6, 8));
+    NewOrder agg = limit(9, Side::BUY, 100, 10, 7);
+    agg.stp = STPMode::CancelNewest;
+    eng.submit(agg);
+    CHECK(cap.trades() == 0);
+    CHECK(eng.book().find(1) != nullptr);  // the resting leg survives
+    CHECK(eng.book().find(9) == nullptr);  // the aggressor does not rest
+  }
+  {  // Decrement trims both legs by the overlap without printing, and the
+     // aggressor's remainder still fills against the stranger.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    eng.submit(limit(1, Side::SELL, 100, 4, 7));
+    eng.submit(limit(2, Side::SELL, 100, 6, 8));
+    NewOrder agg = limit(9, Side::BUY, 100, 10, 7);
+    agg.stp = STPMode::Decrement;
+    eng.submit(agg);
+    CHECK(cap.forMaker(1).isZero());
+    CHECK(cap.forMaker(2) == qty(6));  // 10 - 4 decremented = 6 left to trade
+    CHECK(eng.book().find(1) == nullptr);
+  }
+  {  // The firm group is the STP scope under pro-rata too: two different
+     // accounts in one group must not trade with each other.
+    Cap cap;
+    MatchingEngine<Book> eng(cfg(), cap.sink(), mk(), MatchPolicy::ProRata);
+    eng.setStpGroup(7, 99);
+    eng.setStpGroup(11, 99);
+    eng.submit(limit(1, Side::SELL, 100, 4, 11));  // same firm, different account
+    eng.submit(limit(2, Side::SELL, 100, 6, 8));
+    NewOrder agg = limit(9, Side::BUY, 100, 10, 7);
+    agg.stp = STPMode::CancelOldest;
+    eng.submit(agg);
+    CHECK(cap.forMaker(1).isZero());
+    CHECK(cap.forMaker(2) == qty(6));
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Money-path defects in the venue kept sharing one shape: a check applied on one path into matching and missing on another. This closes the ones that were there, and adds tooling that fails the build when a new path skips a check, instead of waiting for a test to notice.

## Defects fixed

**Clearing integrity.** `settleTrade` debits both unreserved legs with a check before crediting anything, and undoes exactly on failure. The credit hook ran after the ledger branch, which made it unreachable on every funded path; it now runs first. A perp SELL with no limit price was bounded on the wrong side and under-margined. Perp exposure is now tracked with no ledger bound, and money commands answer `NoLedgerBound` instead of silently doing nothing.

**Self-trade prevention was missing on three paths.** Pro-rata ignored STP entirely — the limitation was written in a comment and nothing enforced it, so an order carrying a mode was accepted and traded against its own account. A modify rebuilt the order from its resting record, which never carried the mode, so a reprice through the account's own side self-traded under price-time too. An auction uncross had no STP at all; it has no aggressor either, so the mode is now read off each resting order and the book carries it (`orderStp_`, snapshotted, in the state hash).

Both matching policies now call one `applySelfTradePrevention`. `trackResting` takes the mode as a required argument, so a new rest path cannot compile without saying what its order carries — that is what surfaced the modify and last-look paths.

**Instrument state.** Mark-triggered stops fired through halt, close and auction. Conditional orders skipped tick, band and lot entirely, because they branch off before `validate()` — an out-of-band trigger parked happily and only surfaced when it fired.

**Recovery could start on a truncated history.** Falling back a generation when a snapshot fails to validate is unbounded, but pruning is not: the pre-checkpoint journal is deleted once `retainGenerations` snapshots exist. With no valid snapshot, the engine replayed the surviving segments and started, missing everything before the oldest one. A state-hash or format change invalidates every generation at once, so this is reachable, not theoretical. Recovery now refuses to start when it cannot reconstruct back to zero.

## Operator and counterparty state

Three surfaces became sequenced commands, so they journal, survive checkpoints and replay like the rest of engine state.

**Admission profiles** (`SetAdmissionProfile`) state per account what may be sent: order types, times in force, and whether resting, amending, cancelling and quoting are allowed. This is for deployments where a counterparty manages its own order lifecycle and routes only executable flow — an order resting here that the sender does not track will not be reconciled, and nothing looks wrong until it fills. `DenyResting` therefore rejects GTC, GTD and post-only on admission rather than killing the residual afterwards. The rejection happens before the `clientOrderId` is consumed, so a corrected message can be resent under the same id. An absent profile permits everything.

**Risk limits** (`SetRiskLimits`) covers the seven limits that were reachable only through direct setters — LULD, fat finger, per-account order cap, position cap, margin. Those applied immediately and rode nothing: a restart reverted them, and a replica replaying the journal never saw the change, so a live node and its replica could admit different orders with nothing reporting it. A field mask says which limits a record carries, so raising a position cap cannot silently zero the fat-finger cap by omission. The setters stay for pre-start wiring.

**Delisting** (`AdminAction::Delist`) withdraws an instrument and pulls the resting book with it. A halt promises the instrument comes back and a closed session promises the next one; delisting promises neither, so leaving orders resting would leave them waiting for an open that is not coming. New orders earn `InstrumentDelisted` rather than a reason that implies they should retry. It outranks halt, session and auction state, so reopening the session does not make a delisted instrument tradeable. `Relist` reverses it.

## FIX correctness

A refused cancel or cancel/replace is answered with `OrderCancelReject` (35=9) rather than an execution report. The discriminator lives on a new `CancelRejected` event rather than in session state, because a `ResendRequest` re-encodes from the event log long after the session context is gone, and a replayed message that changes type is a protocol violation exactly when the counterparty is recovering. Only refusals before the order leaves the book use it; a modify that fails after `book_.cancel` did change order state, and an execution report is correct there. Every consumer of `OrderRejected` learned the new event in the same change (SBE schema 3 message 22, REST, metrics, session routing), so nobody silently stops seeing refused cancels.

An unsupported application message now gets `BusinessMessageReject` (35=j). A type that is not a FIX message type at all keeps 35=3, now with `SessionRejectReason=11` — that is a parsing failure, not a declined capability.

## Verification

Two checks run against the code rather than against test cases:

- `scripts/check_gate_reachability.py` proves over the clang AST that on every path from a handler to the matcher, each gate it owes has already run and its result was acted on. The set of functions calling into matching is pinned, so a new path fails the check until it declares its gates. Configure-only; runs in CI off `compile_commands.json`.
- `scripts/check_recovery_model.py` enumerates every reachable state of a bounded model of the checkpoint protocol — checkpoint, publish failure, snapshot corruption, pruning, in every interleaving — and checks that recovery either reconstructs history back to zero or refuses to start. It found the recovery defect above in four steps.

Plus `venue/tests/support/counterexample.h`, which minimises a failing fuzz stream to the smallest one that still fails, and `test_venue_gate_coverage.cpp`, which asserts the gate properties per path rather than per scenario.

Every fix has a test, and every test was verified by mutation.

## Compatibility

- `OutboundEvent` gains `CancelRejected`. Consumers using `get_if` chains are unaffected; a consumer that expected `OrderRejected` for a refused cancel now receives `CancelRejected` instead.
- SBE order-entry schema goes to version 3 with message 22 (`CancelRejected`).
- `InboundCommand` gains `RestoreOrderStp` (31), `SetAdmissionProfile` (32) and `SetRiskLimits` (33). Snapshot records are append-only, so a new engine reads an old snapshot; an old engine will not read a new one.
- `AdminAction` gains `Delist` / `Relist`; `TradingStatus` gains `Delisted`; new `RejectReason` values are appended. All wire enums stay append-only.
- The state hash is unchanged for an engine that has no admission profiles, no per-order STP modes and no delisted instrument, so existing snapshots still validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)