### PR TITLE
feat(venue): symmetric price tolerance, and last-look conduct made visible

### DIFF
--- a/docs/venue/matching.md
+++ b/docs/venue/matching.md
@@ -75,6 +75,35 @@ A mass quote carries the mode too, and both of its legs inherit it -- so a
 maker that quotes rather than sending individual orders is not left without the
 control.
 
+### Last look, and the option inside it
+
+A held fill is an option the maker holds for the length of the window, and an
+option nobody can see the exercise of is one that gets exercised in one
+direction. Over enough holds, a maker free to answer as it likes fills the ones
+that moved its way and refuses the ones that did not; the taker sees only a
+reject rate and cannot tell that from an honest wide tolerance.
+
+Two controls address that, and they work together.
+
+`lastLookToleranceRaw` is a **symmetric price tolerance applied by the venue**,
+on magnitude alone. Outside the band the fill is rejected whoever it would have
+favoured — including when the move was in the maker's favour, which is the half
+a cherry-picking maker would otherwise keep. Inside the band the maker's answer
+still stands: the tolerance caps the option rather than abolishing last look.
+`0` disables the check.
+
+`MatchingEngine::lastLookStats()` reports per maker how many holds it saw, how
+many it refused, and — the number that matters — the split by which way the
+price had moved. A maker applying a symmetric rule refuses about as often when
+the move favoured it as when it did not. One taking the free option refuses
+almost only when it was losing. That split makes the conduct visible without
+anyone seeing the maker's code, which is what a reject rate on its own can
+never do.
+
+`lastLookAcceptOnTimeout` decides what silence means, and it is the same
+argument: with `false`, a maker that stalls and says nothing pays nothing, so
+stalling is free; with `true`, it costs the maker the trade.
+
 STP also interacts with **last look**: the maker it pulls may have a hold open,
 so the hold is resolved (rejected, liquidity restored) before the order is
 removed -- the same order every engine-side cancel path follows. Removing first

--- a/venue/include/flox-venue/matching_engine.h
+++ b/venue/include/flox-venue/matching_engine.h
@@ -52,13 +52,27 @@ struct SymbolConfig
   TriggerRef triggerRef{TriggerRef::Last};
   int64_t lastLookWindowNs{0};          // 0 = last look disabled venue-wide
   bool lastLookAcceptOnTimeout{false};  // window elapses with no decision -> accept vs reject
-  AssetId baseAsset{0};                 // e.g. BTC in BTC-USD (settled to the seller/buyer)
-  AssetId quoteAsset{1};                // e.g. USD in BTC-USD
-  int32_t luldBps{0};                   // limit-up/limit-down band around the reference (0 = off)
-  int64_t luldHaltNs{0};                // trading pause on a band breach
-  bool linearPerp{false};               // derivatives: linear perpetual (margin, no asset delivery)
-  int32_t initialMarginBps{0};          // IM as bps of notional (1000 = 10% = 10x leverage)
-  int32_t maintenanceMarginBps{0};      // MM; position liquidated when equity < MM (0 = off)
+  // Symmetric price tolerance. When set, the VENUE decides whether the price
+  // moved too far during the hold, and it applies the same threshold in both
+  // directions: outside it, the fill is rejected whoever it would have
+  // favoured.
+  //
+  // This is what removes the free option. A maker allowed to answer a held
+  // fill however it likes will, over enough samples, fill the ones that moved
+  // its way and refuse the ones that did not -- and that asymmetry is
+  // invisible to the taker, who sees only a reject rate. Enforcing magnitude
+  // at the venue leaves nothing to be asymmetric about outside the band, and
+  // lastLookStats makes what happens inside it visible.
+  //
+  // 0 = no venue-side check: the maker's answer stands whatever the price did.
+  int64_t lastLookToleranceRaw{0};
+  AssetId baseAsset{0};             // e.g. BTC in BTC-USD (settled to the seller/buyer)
+  AssetId quoteAsset{1};            // e.g. USD in BTC-USD
+  int32_t luldBps{0};               // limit-up/limit-down band around the reference (0 = off)
+  int64_t luldHaltNs{0};            // trading pause on a band breach
+  bool linearPerp{false};           // derivatives: linear perpetual (margin, no asset delivery)
+  int32_t initialMarginBps{0};      // IM as bps of notional (1000 = 10% = 10x leverage)
+  int32_t maintenanceMarginBps{0};  // MM; position liquidated when equity < MM (0 = off)
   // Liquidation decided elsewhere (portfolio margin above the per-symbol
   // engines). The engine still posts isolated IM and settles, but never
   // liquidates on its own -- it closes only on ForceClosePosition.
@@ -1749,6 +1763,34 @@ class MatchingEngine
   // Last-look accepts turned into rejects because the fill would have breached
   // a perp risk limit by the time the maker answered (see resolveHeld).
   uint64_t riskRejectedHolds() const noexcept { return riskRejectedHolds_; }
+
+  // Per-maker last-look conduct.
+  //
+  // The reject RATE on its own says nothing: a maker with a wide tolerance and
+  // a maker cherry-picking its fills can post the same number. What separates
+  // them is which way the price had moved when they refused. A maker applying a
+  // symmetric rule refuses roughly as often when the move favoured it as when
+  // it did not; one taking the free option refuses almost only when it was
+  // losing. That single split is what makes the behaviour visible without
+  // anyone having to see the maker's code.
+  struct LastLookStats
+  {
+    uint64_t held{0};
+    uint64_t accepted{0};
+    uint64_t rejected{0};
+    uint64_t adverse{0};          // holds where the move went against the maker
+    uint64_t rejectedAdverse{0};  // ... of which it refused
+    uint64_t favourable{0};       // holds where the move went its way
+    uint64_t rejectedFavourable{0};
+  };
+
+  const std::unordered_map<uint64_t, LastLookStats>& lastLookStats() const noexcept
+  {
+    return lastLookStats_;
+  }
+
+  // Holds refused by the venue's own tolerance rather than by the maker.
+  uint64_t toleranceRejectedHolds() const noexcept { return toleranceRejectedHolds_; }
 
   // Pro-rata participants excluded by the fill-time risk limits.
   uint64_t skippedRiskProRata() const noexcept { return matcher_.skippedRiskProRata(); }
@@ -4161,6 +4203,18 @@ class MatchingEngine
       ++riskRejectedHolds_;
       accept = false;
     }
+    // Symmetric price tolerance, applied by the venue on magnitude alone.
+    const int64_t moveRaw = referenceMoveSinceHold(h);
+    if (cfg_.lastLookToleranceRaw > 0)
+    {
+      const int64_t mag = moveRaw < 0 ? -moveRaw : moveRaw;
+      if (mag > cfg_.lastLookToleranceRaw)
+      {
+        ++toleranceRejectedHolds_;
+        accept = false;
+      }
+    }
+    recordHoldOutcome(h, moveRaw, accept);
     if (accept)
     {
       emit_(Trade{++tradeSeq_, cfg_.id, h.price, h.qty, h.maker, h.taker, h.takerSide,
@@ -4193,6 +4247,52 @@ class MatchingEngine
     // (deferred from the emit_ wrapper while holds were open).
     cleanupOrderIfDone(h.taker);
     cleanupOrderIfDone(h.maker);
+  }
+
+  // How far the reference has moved since the hold was taken, signed so that a
+  // positive value means it moved AGAINST the maker: it sold and the price rose,
+  // or it bought and the price fell. Zero when there is no reference to compare
+  // against, which is the only honest answer before the first trade.
+  int64_t referenceMoveSinceHold(const Held& h) const
+  {
+    if (!hasLast_)
+    {
+      return 0;
+    }
+    const int64_t delta = lastPrice_.raw() - h.price.raw();
+    // takerSide is the aggressor's. A taker buying leaves the maker short, so a
+    // rising price hurts the maker.
+    return h.takerSide == Side::BUY ? delta : -delta;
+  }
+
+  void recordHoldOutcome(const Held& h, int64_t moveRaw, bool accepted)
+  {
+    LastLookStats& st = lastLookStats_[h.makerAccount];
+    ++st.held;
+    if (accepted)
+    {
+      ++st.accepted;
+    }
+    else
+    {
+      ++st.rejected;
+    }
+    if (moveRaw > 0)
+    {
+      ++st.adverse;
+      if (!accepted)
+      {
+        ++st.rejectedAdverse;
+      }
+    }
+    else if (moveRaw < 0)
+    {
+      ++st.favourable;
+      if (!accepted)
+      {
+        ++st.rejectedFavourable;
+      }
+    }
   }
 
   // Would settling this hold in full still pass the perp risk limits? Both legs
@@ -4672,6 +4772,10 @@ class MatchingEngine
   // Reason from the last refused credit check, so the reject the client sees
   // says why ("portfolio margin", say) instead of a flat InsufficientFunds.
   mutable RejectReason creditReason_{RejectReason::InsufficientFunds};
+  // Diagnostic only, like the pro-rata skip counters: conduct measurement, not
+  // matching state, so it stays out of the state hash and the snapshot.
+  std::unordered_map<uint64_t, LastLookStats> lastLookStats_;
+  uint64_t toleranceRejectedHolds_{0};
 
   std::unordered_map<uint64_t, Held> held_;
   uint64_t heldSeq_{0};

--- a/venue/include/flox-venue/matching_engine.h
+++ b/venue/include/flox-venue/matching_engine.h
@@ -1589,6 +1589,7 @@ class MatchingEngine
                     x.takerType, x.takerPrice, x.takerExpiryNs, x.makerReduceOnly,
                     x.takerReduceOnly};
       r.makerTracked = orderAccount_.count(x.maker) != 0;
+      r.refAtHoldRaw = x.refAtHoldRaw;
       out.append(InboundCommand{r}, ts);
     }
 
@@ -3994,6 +3995,7 @@ class MatchingEngine
     h.takerExpiryNs = r.takerExpiryNs;
     h.makerReduceOnly = r.makerReduceOnly;
     h.takerReduceOnly = r.takerReduceOnly;
+    h.refAtHoldRaw = r.refAtHoldRaw;
     held_[r.heldId] = h;
     heldOpen_.store(held_.size(), std::memory_order_relaxed);
     // Tracking follows the recorded live truth rather than being re-derived: a
@@ -4097,6 +4099,11 @@ class MatchingEngine
     Price price{};
     Quantity qty{};
     int64_t deadline{};
+    // The reference when the hold was taken. Last look is about the move
+    // DURING the window, so the move has to be measured from here -- measuring
+    // from the quoted price instead reports the distance between a quote and
+    // the last print, which is a stale quote, not a move.
+    int64_t refAtHoldRaw{0};
     // Captured at hold time so a reject can route the taker residual by its
     // TIF and rebuild either leg if it was fully held out of the book.
     TimeInForce takerTif{TimeInForce::GTC};
@@ -4111,8 +4118,19 @@ class MatchingEngine
   void createHeld(const RestingOrder& maker, Quantity fill, const NewOrder& taker)
   {
     const uint64_t id = ++heldSeq_;
-    Held h{id, taker.id, taker.accountId, taker.side, maker.id,
-           maker.accountId, maker.price, fill, now_ + cfg_.lastLookWindowNs};
+    Held h{id,
+           taker.id,
+           taker.accountId,
+           taker.side,
+           maker.id,
+           maker.accountId,
+           maker.price,
+           fill,
+           now_ + cfg_.lastLookWindowNs,
+           // Where the market was when the hold started. Before the first
+           // trade there is no reference, and 0 means the move is unmeasurable
+           // rather than enormous.
+           hasLast_ ? lastPrice_.raw() : 0};
     // The taker is an aggressor now, but its residual may rest once the hold
     // resolves -- and a resting order's STP mode is what an auction reads.
     // Capture it here, where the mode is still in hand.
@@ -4255,11 +4273,11 @@ class MatchingEngine
   // against, which is the only honest answer before the first trade.
   int64_t referenceMoveSinceHold(const Held& h) const
   {
-    if (!hasLast_)
+    if (!hasLast_ || h.refAtHoldRaw == 0)
     {
       return 0;
     }
-    const int64_t delta = lastPrice_.raw() - h.price.raw();
+    const int64_t delta = lastPrice_.raw() - h.refAtHoldRaw;
     // takerSide is the aggressor's. A taker buying leaves the maker short, so a
     // rising price hurts the maker.
     return h.takerSide == Side::BUY ? delta : -delta;

--- a/venue/include/flox-venue/messages.h
+++ b/venue/include/flox-venue/messages.h
@@ -440,6 +440,10 @@ struct RestoreHeld  // one open last-look hold (mirrors MatchingEngine::Held)
   // STP-cancel can legally remove a maker while its hold stays open -- the
   // write side records the live truth instead of re-deriving it.
   bool makerTracked{true};
+  // Reference when the hold was taken; the move that last look is about is
+  // measured from here. Appended -- the record grows, and this module has not
+  // shipped.
+  int64_t refAtHoldRaw{0};
 };
 
 struct RestorePosition  // one perp position (qty, average entry, posted margin)

--- a/venue/tests/test_venue_lastlook.cpp
+++ b/venue/tests/test_venue_lastlook.cpp
@@ -274,6 +274,139 @@ void test_quote_carries_lastlook()
   CHECK(h2 != nullptr && h2->makerId == 1);
 }
 
+// The venue applies the price tolerance itself, on magnitude alone.
+//
+// A maker allowed to answer however it likes will, over enough holds, fill the
+// ones that moved its way and refuse the ones that did not. The taker sees only
+// a reject rate and cannot tell that from an honest wide tolerance. Enforcing
+// the threshold at the venue leaves nothing to be asymmetric about outside the
+// band -- a move too far is refused whoever it would have favoured.
+void test_symmetric_price_tolerance()
+{
+  std::printf("test_symmetric_price_tolerance\n");
+
+  // A move AGAINST the maker, beyond tolerance: refused even though the maker
+  // said yes.
+  {
+    Cap cap;
+    venue::SymbolConfig c = cfg();
+    c.lastLookToleranceRaw = px(0.50).raw();
+    MatchingEngine<MatchingBook> eng(c, cap.sink());
+    // The whole quote is held, so nothing of the maker's is left on the book to
+    // intercept the trades that move the price.
+    NewOrder mk = limit(1, Side::SELL, 100, 3, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+    CHECK(cap.lastHeld() != nullptr);
+    // Copied out now: lastHeld points into the capture vector, and the submits
+    // below reallocate it.
+    const uint64_t heldId = cap.lastHeld() ? cap.lastHeld()->heldId : 0;
+    // The maker sold at 100; the market trades up to 102, so it is losing.
+    eng.submit(InboundCommand{limit(3, Side::SELL, 102, 1, 3)}, 2);
+    eng.submit(InboundCommand{limit(4, Side::BUY, 102, 1, 4)}, 3);
+    eng.submit(InboundCommand{LastLookDecision{heldId, SYM, true, 1}}, 4);
+    CHECK(eng.toleranceRejectedHolds() == 1);
+  }
+
+  // The SAME magnitude in the maker's favour is refused too. That is what
+  // symmetric means, and it is the half a cherry-picking maker would keep.
+  {
+    Cap cap;
+    venue::SymbolConfig c = cfg();
+    c.lastLookToleranceRaw = px(0.50).raw();
+    MatchingEngine<MatchingBook> eng(c, cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 3, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+    CHECK(cap.lastHeld() != nullptr);
+    const uint64_t heldId = cap.lastHeld() ? cap.lastHeld()->heldId : 0;
+    // Down to 98: the maker sold at 100 and is now winning.
+    eng.submit(InboundCommand{limit(3, Side::SELL, 98, 1, 3)}, 2);
+    eng.submit(InboundCommand{limit(4, Side::BUY, 98, 1, 4)}, 3);
+    eng.submit(InboundCommand{LastLookDecision{heldId, SYM, true, 1}}, 4);
+    CHECK(eng.toleranceRejectedHolds() == 1);
+  }
+
+  // Inside the band the maker's answer still stands: the tolerance caps the
+  // option, it does not abolish last look.
+  {
+    Cap cap;
+    venue::SymbolConfig c = cfg();
+    c.lastLookToleranceRaw = px(5.0).raw();
+    MatchingEngine<MatchingBook> eng(c, cap.sink());
+    NewOrder mk = limit(1, Side::SELL, 100, 5, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, 0);
+    eng.submit(InboundCommand{limit(2, Side::BUY, 100, 3, 2)}, 1);
+    const uint64_t heldId = cap.lastHeld() ? cap.lastHeld()->heldId : 0;
+    eng.submit(InboundCommand{LastLookDecision{heldId, SYM, true, 1}}, 2);
+    CHECK(cap.trades() == 1);
+    CHECK(eng.toleranceRejectedHolds() == 0);
+  }
+}
+
+// Conduct is measured by WHICH holds a maker refused, not how many.
+//
+// A maker with an honest wide tolerance and one taking the free option post the
+// same reject rate. What separates them is the direction the price had moved
+// when they said no.
+void test_last_look_conduct_is_visible()
+{
+  std::printf("test_last_look_conduct_is_visible\n");
+  Cap cap;
+  venue::SymbolConfig c = cfg();
+  MatchingEngine<MatchingBook> eng(c, cap.sink());
+
+  int64_t ts = 0;
+  // Run the same episode twice: once with the price moving against the maker,
+  // once in its favour. The maker refuses only when it is losing.
+  for (int round = 0; round < 2; ++round)
+  {
+    const bool adverse = (round == 0);
+    NewOrder mk = limit(100 + round * 10, Side::SELL, 100, 1, 1);
+    mk.lastLook = true;
+    eng.submit(InboundCommand{mk}, ++ts);
+    eng.submit(InboundCommand{limit(101 + round * 10, Side::BUY, 100, 1, 2)}, ++ts);
+    CHECK(cap.lastHeld() != nullptr);
+    const uint64_t heldId = cap.lastHeld() ? cap.lastHeld()->heldId : 0;
+    const double to = adverse ? 102 : 98;
+    eng.submit(InboundCommand{limit(102 + round * 10, Side::SELL, to, 1, 3)}, ++ts);
+    eng.submit(InboundCommand{limit(103 + round * 10, Side::BUY, to, 1, 4)}, ++ts);
+    eng.submit(InboundCommand{LastLookDecision{heldId, SYM, !adverse, 1}}, ++ts);
+  }
+
+  // The same on the other side of the book. A maker that BOUGHT is hurt by a
+  // falling price, not a rising one -- so which move counts as adverse depends
+  // on the side the maker took. Testing only one side leaves the sign
+  // unverified, and a sign error there mislabels every maker on the bid.
+  {
+    NewOrder mkBid = limit(200, Side::BUY, 100, 1, 1);
+    mkBid.lastLook = true;
+    eng.submit(InboundCommand{mkBid}, ++ts);
+    eng.submit(InboundCommand{limit(201, Side::SELL, 100, 1, 2)}, ++ts);
+    CHECK(cap.lastHeld() != nullptr);
+    const uint64_t heldId = cap.lastHeld() ? cap.lastHeld()->heldId : 0;
+    // Down to 98: the maker bought at 100, so this is adverse for it.
+    eng.submit(InboundCommand{limit(202, Side::SELL, 98, 1, 3)}, ++ts);
+    eng.submit(InboundCommand{limit(203, Side::BUY, 98, 1, 4)}, ++ts);
+    eng.submit(InboundCommand{LastLookDecision{heldId, SYM, false, 1}}, ++ts);
+  }
+
+  const auto& stats = eng.lastLookStats();
+  auto it = stats.find(1);
+  CHECK(it != stats.end());
+  if (it != stats.end())
+  {
+    CHECK(it->second.held == 3);
+    // Two adverse holds -- one where the maker sold into a rising market, one
+    // where it bought into a falling one -- and it refused both.
+    CHECK(it->second.adverse == 2 && it->second.rejectedAdverse == 2);
+    CHECK(it->second.favourable == 1 && it->second.rejectedFavourable == 0);
+  }
+}
+
 void test_partial_hold_reject()
 {
   std::printf("test_partial_hold_reject\n");
@@ -878,6 +1011,8 @@ TEST(VenueLastLook, LifecycleSuite)
   test_prorata_lastlook_rejected();
   test_reject_restores_book();
   test_quote_carries_lastlook();
+  test_symmetric_price_tolerance();
+  test_last_look_conduct_is_visible();
   test_partial_hold_reject();
   test_taker_residual_tifs();
   test_md_equals_book();

--- a/venue/tests/test_venue_lastlook.cpp
+++ b/venue/tests/test_venue_lastlook.cpp
@@ -292,6 +292,10 @@ void test_symmetric_price_tolerance()
     venue::SymbolConfig c = cfg();
     c.lastLookToleranceRaw = px(0.50).raw();
     MatchingEngine<MatchingBook> eng(c, cap.sink());
+    // Establish a reference first: before the first trade there is nothing to
+    // measure a move from, and the venue says so by not measuring one.
+    eng.submit(InboundCommand{limit(90, Side::SELL, 100, 1, 8)}, 0);
+    eng.submit(InboundCommand{limit(91, Side::BUY, 100, 1, 9)}, 0);
     // The whole quote is held, so nothing of the maker's is left on the book to
     // intercept the trades that move the price.
     NewOrder mk = limit(1, Side::SELL, 100, 3, 1);
@@ -316,6 +320,8 @@ void test_symmetric_price_tolerance()
     venue::SymbolConfig c = cfg();
     c.lastLookToleranceRaw = px(0.50).raw();
     MatchingEngine<MatchingBook> eng(c, cap.sink());
+    eng.submit(InboundCommand{limit(90, Side::SELL, 100, 1, 8)}, 0);
+    eng.submit(InboundCommand{limit(91, Side::BUY, 100, 1, 9)}, 0);
     NewOrder mk = limit(1, Side::SELL, 100, 3, 1);
     mk.lastLook = true;
     eng.submit(InboundCommand{mk}, 0);
@@ -358,6 +364,8 @@ void test_last_look_conduct_is_visible()
   Cap cap;
   venue::SymbolConfig c = cfg();
   MatchingEngine<MatchingBook> eng(c, cap.sink());
+  eng.submit(InboundCommand{limit(90, Side::SELL, 100, 1, 8)}, 0);
+  eng.submit(InboundCommand{limit(91, Side::BUY, 100, 1, 9)}, 0);
 
   int64_t ts = 0;
   // Run the same episode twice: once with the price moving against the maker,


### PR DESCRIPTION
A held fill is an option the maker holds for the length of the window, and an option nobody can see the exercise of is one that gets exercised in one direction. Over enough holds, a maker free to answer as it likes fills the ones that moved its way and refuses the ones that did not. The taker sees only a reject rate and cannot separate that from an honest wide tolerance — which is why the industry's answer to asymmetric last look took a decade and a code of conduct rather than a measurement.

Two controls, which work together.

**`SymbolConfig::lastLookToleranceRaw`** — a symmetric price tolerance applied by the venue, on magnitude alone. Outside the band the fill is rejected whoever it would have favoured, *including* when the move was in the maker's favour: that is the half a cherry-picking maker would otherwise keep, and leaving it out is what makes a "tolerance" asymmetric. Inside the band the maker's answer still stands, so this caps the option rather than abolishing last look. `0` keeps the previous behaviour.

**`MatchingEngine::lastLookStats()`** — per maker: holds seen, refusals, and the split by which way the price had moved when it refused. A maker applying a symmetric rule refuses about as often when the move favoured it as when it did not; one taking the free option refuses almost only when it was losing. That split makes the conduct visible without anyone seeing the maker's code.

Both are diagnostics: they stay out of the state hash and the snapshot, like the pro-rata skip counters, because they measure conduct and do not decide matching.

## On the tests

Four mutations, all caught: removing the tolerance, making it asymmetric (magnitude replaced by signed move), dropping the adverse-reject counter, and — the one the first version of the test missed — ignoring which side the maker took when deciding what counts as adverse. A maker that bought is hurt by a falling price, so testing only sell-side makers leaves that sign unverified and a fault there mislabels every maker on the bid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)