### PR TITLE
ci(release): platform gates replace the actor check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Workflow changes gate the release path; they need the owner's eyes.
+/.github/workflows/ @eeiaao

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -85,6 +85,10 @@ jobs:
   publish:
     needs: [build]
     runs-on: ubuntu-latest
+    # Registry publishing runs only inside the gated environment: the
+    # trusted-publisher OIDC subject is pinned to it, so a token cannot be
+    # minted from anywhere else.
+    environment: registry
     if: |
       always() &&
       needs.build.result == 'success' &&

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -101,6 +101,10 @@ jobs:
   publish-testpypi:
     needs: [build-wheels, build-sdist, build-mcp]
     runs-on: ubuntu-latest
+    # Registry publishing runs only inside the gated environment: the
+    # trusted-publisher OIDC subject is pinned to it, so a token cannot be
+    # minted from anywhere else.
+    environment: registry
     if: |
       always() &&
       needs.build-wheels.result == 'success' &&
@@ -121,6 +125,10 @@ jobs:
   publish-pypi:
     needs: [build-wheels, build-sdist, build-mcp]
     runs-on: ubuntu-latest
+    # Registry publishing runs only inside the gated environment: the
+    # trusted-publisher OIDC subject is pinned to it, so a token cannot be
+    # minted from anywhere else.
+    environment: registry
     if: |
       always() &&
       needs.build-wheels.result == 'success' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,16 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # The real gate. A required reviewer on this environment pauses every run
+    # for manual approval in the UI -- a platform control that neither a
+    # compromised token nor an edited workflow file can skip. The app key
+    # lives in this environment's secrets, so no job outside the gate can
+    # read it.
+    environment: release
     permissions:
       contents: write
     steps:
+      # Defense in depth only; the environment above is what actually gates.
       - name: Restrict manual trigger
         if: github.actor != 'eeiaao'
         run: |
@@ -27,11 +34,21 @@ jobs:
             exit 1
           fi
 
+      # Short-lived installation token from the release app: minted per run,
+      # dies in minutes, scoped to this repository. Replaces the fine-grained
+      # PAT that expired twice and was readable by any workflow on any branch.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
The release path was guarded by an `if: github.actor != 'eeiaao'` step. That is advisory code inside the very file an attacker would edit, it does not exist at all on the tag-triggered publish path, and it cannot tell the owner from the owner's leaked token. The unguarded tag path is the exact mechanism of the 2026-05-25 accidental release.

What this PR changes (workflow files):

- The release job runs in the `release` environment; every registry publish job (`publish`, `publish-testpypi`, `publish-pypi`) runs in `registry`. Both environments require manual approval and are pinned by deployment policy to `main` / `v*` tags. A run now pauses in the UI until approved -- a platform control that survives both a compromised token and an edited workflow.
- The expired fine-grained PAT is replaced by a per-run GitHub App installation token (`actions/create-github-app-token`), minted inside the gated job from environment secrets. Minutes of life, one repository of scope, no expiry churn.
- CODEOWNERS puts `/.github/workflows/` under owner review.
- The actor check stays, demoted to defense in depth.

Already configured on the repository (API, effective now):

- Environments `release` and `registry`, required reviewer, deployment policies (`main`; `v*` tags + `main`).
- Ruleset `protected-release-tags`: creation/update/deletion of `v*` tags denied to everyone, **no bypass actors** -- a stray `git push --tags` from any machine, admin included, is rejected server-side. A deliberate manual tag means consciously disabling the ruleset in the UI, which is the right amount of friction.

Remaining owner actions before the next release (the release path is already down -- the PAT expired -- so nothing regresses in the meantime):

1. Create a GitHub App (e.g. `flox-release-bot`), install it on this repo with `contents: write`; put its App ID and private key into the `release` environment secrets as `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`.
2. Add the app to the `protected-release-tags` ruleset bypass list and to the main-branch push allowance.
3. In PyPI and npm trusted-publisher settings, pin the publisher to environment `registry` -- after that a registry token cannot be minted from any other job, gated or not.

Each release now costs two approval clicks (release gate, then registry gate on the tag build). For this repository that is a feature.

## MCP impact

None. No code, binding or doc surface changes; workflow-only. `sync_mcp_data.py --check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)